### PR TITLE
Ensure that informers have the namespace index

### DIFF
--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -158,7 +158,9 @@ func (ip *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object) (*M
 		if err != nil {
 			return nil, err
 		}
-		ni := cache.NewSharedIndexInformer(lw, obj, ip.resync, cache.Indexers{})
+		ni := cache.NewSharedIndexInformer(lw, obj, ip.resync, cache.Indexers{
+			cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+		})
 		i = &MapEntry{
 			Informer: ni,
 			Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk}}


### PR DESCRIPTION
Most of the lister logic (both here and in Kubernetes generate listers)
assume that the namespace index is present by default, so we should
always set it up.