### PR TITLE
Make sure cache Reader still works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# editor and IDE paraphernalia
 .idea
+*.swp
+*.swo
+*~

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -55,7 +55,7 @@ type Informers interface {
 	GetInformerForKind(gvk schema.GroupVersionKind) (toolscache.SharedIndexInformer, error)
 
 	// Start runs all the informers known to this cache until the given channel is closed.
-	// It does not block.
+	// It blocks.
 	Start(stopCh <-chan struct{}) error
 
 	// WaitForCacheSync waits for all the caches to sync.  Returns false if it could not sync a cache.


### PR DESCRIPTION
The cache refactor broke the cache reader implementation (invalid
assumptions about names, arguments, and the way reflection works).
This fixes it, and adds back in some working tests to ensure that
it doesn't break again.