### PR TITLE
Fix non-cache client list

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -142,8 +142,12 @@ func (c *client) List(ctx context.Context, opts *ListOptions, obj runtime.Object
 	if err != nil {
 		return err
 	}
+	namespace := ""
+	if opts != nil {
+		namespace = opts.Namespace
+	}
 	return r.Get().
-		NamespaceIfScoped(opts.Namespace, r.isNamespaced()).
+		NamespaceIfScoped(namespace, r.isNamespaced()).
 		Resource(r.resource()).
 		Body(obj).
 		VersionedParams(opts.AsListOptions(), c.paramCodec).

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -18,9 +18,7 @@ package client_test
 
 import (
 	"context"
-
 	"fmt"
-
 	"sync/atomic"
 
 	. "github.com/onsi/ginkgo"
@@ -353,7 +351,26 @@ var _ = Describe("Client", func() {
 
 	Describe("List", func() {
 		It("should fetch collection of objects", func() {
+			By("creating an initial object")
+			dep, err := clientset.AppsV1().Deployments(ns).Create(dep)
+			Expect(err).NotTo(HaveOccurred())
 
+			cl, err := client.New(cfg, client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("listing all objects of that type in the cluster")
+			deps := &appsv1.DeploymentList{}
+			Expect(cl.List(context.Background(), nil, deps)).NotTo(HaveOccurred())
+
+			Expect(deps.Items).NotTo(BeEmpty())
+			hasDep := false
+			for _, item := range deps.Items {
+				if item.Name == dep.Name && item.Namespace == dep.Namespace {
+					hasDep = true
+					break
+				}
+			}
+			Expect(hasDep).To(BeTrue())
 		})
 
 		It("should return an empty list if there are no matching objects", func() {

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -127,10 +127,14 @@ func (o *ListOptions) SetFieldSelector(selRaw string) error {
 // This may mutate the Raw field.
 func (o *ListOptions) AsListOptions() *metav1.ListOptions {
 	if o == nil {
-		return nil
+		return &metav1.ListOptions{}
 	}
-	o.Raw.LabelSelector = o.LabelSelector.String()
-	o.Raw.FieldSelector = o.FieldSelector.String()
+	if o.LabelSelector != nil {
+		o.Raw.LabelSelector = o.LabelSelector.String()
+	}
+	if o.FieldSelector != nil {
+		o.Raw.FieldSelector = o.FieldSelector.String()
+	}
 	return o.Raw
 }
 


### PR DESCRIPTION
This fixes the non-cache client list, which had a null pointer
dereference (opts.Namespace), incorrect resource handling (need the
resource for the items, not the list itself), and incorrect handling of
nil list options (the underlying metav1.ListOptions needs to always be
non-nil, even if empty).