### PR TITLE
fix vendor zapr

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -143,7 +143,7 @@
   branch = "master"
   name = "github.com/go-logr/zapr"
   packages = ["."]
-  revision = "7719b12d150e27231f2c113e7d40901f35e92287"
+  revision = "7536572e8d55209135cd5e7ccf7fce43dca217ab"
 
 [[projects]]
   branch = "master"

--- a/pkg/runtime/log/log.go
+++ b/pkg/runtime/log/log.go
@@ -25,7 +25,7 @@ func ZapLogger(development bool) logr.Logger {
 	}
 	// who watches the watchmen?
 	fatalIfErr(err, log.Fatalf)
-	return zaplogr.NewLogger(zapLog)
+	return zapr.NewLogger(zapLog)
 }
 
 func fatalIfErr(err error, f func(format string, v ...interface{})) {

--- a/vendor/github.com/go-logr/zapr/zapr.go
+++ b/vendor/github.com/go-logr/zapr/zapr.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// package zaplogr defines an implementation of the github.com/go-logr/logr
+// package zapr defines an implementation of the github.com/go-logr/logr
 // interfaces built on top of Zap (go.uber.org/zap).
 //
 // Usage
@@ -20,7 +20,7 @@
 // A new logr.Logger can be constructed from an existing zap.Logger using
 // the NewLogger function:
 //
-//  log := zaplogr.NewLogger(someZapLogger)
+//  log := zapr.NewLogger(someZapLogger)
 //
 // Implementation Details
 //
@@ -35,7 +35,7 @@
 // in logr is represents by its inverse in zap (`zapLevel = -1*logrLevel`).
 // For example V(2) is equivalent to log level -2 in Zap, while V(1) is
 // equivalent to Zap's DebugLevel.
-package zaplogr
+package zapr
 
 import (
 	"github.com/go-logr/logr"


### PR DESCRIPTION
fix vendor zapr, otherwise generated project will not compile due to https://github.com/go-logr/zapr/commit/7536572e8d55209135cd5e7ccf7fce43dca217ab