### PR TITLE
Avoid adding test flags when using the null logger

### DIFF
--- a/pkg/runtime/log/log.go
+++ b/pkg/runtime/log/log.go
@@ -6,7 +6,6 @@ import (
 	"log"
 
 	"github.com/go-logr/logr"
-	tlogr "github.com/go-logr/logr/testing"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 )
@@ -45,7 +44,7 @@ func SetLogger(l logr.Logger) {
 // to another logr.Logger.  You *must* call SetLogger to
 // get any actual logging.
 var Log = &DelegatingLogger{
-	Logger:  tlogr.NullLogger{},
+	Logger:  NullLogger{},
 	promise: &loggerPromise{},
 }
 

--- a/pkg/runtime/log/null.go
+++ b/pkg/runtime/log/null.go
@@ -1,0 +1,44 @@
+package log
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// NB: this is the same as the null logger logr/testing,
+// but avoids accidentally adding the testing flags to
+// all binaries.
+
+// NullLogger is a logr.Logger that does nothing.
+type NullLogger struct{}
+
+var _ logr.Logger = NullLogger{}
+
+// Info implements logr.InfoLogger
+func (NullLogger) Info(_ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+// Enabled implements logr.InfoLogger
+func (NullLogger) Enabled() bool {
+	return false
+}
+
+// Error implements logr.Logger
+func (NullLogger) Error(_ error, _ string, _ ...interface{}) {
+	// Do nothing.
+}
+
+// V implements logr.Logger
+func (log NullLogger) V(_ int) logr.InfoLogger {
+	return log
+}
+
+// WithName implements logr.Logger
+func (log NullLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+// WithValues implements logr.Logger
+func (log NullLogger) WithValues(_ ...interface{}) logr.Logger {
+	return log
+}


### PR DESCRIPTION
The null logger from logr is in the same package as the testing logger,
which means it accidentally adds testing flags to all binaries that
import it.  Copy the null logger into the pkg/runtime/log package
to avoid this.