### PR TITLE
config: fix using the KUBECONFIG to build the client

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -62,7 +62,7 @@ func GetConfig() (*rest.Config, error) {
 	}
 	// If an env variable is specified with the config locaiton, use that
 	if len(os.Getenv("KUBECONFIG")) > 0 {
-		return clientcmd.BuildConfigFromFlags(masterURL, kubeconfig)
+		return clientcmd.BuildConfigFromFlags(masterURL, os.Getenv("KUBECONFIG"))
 	}
 	// If no explicit location, try the in-cluster config
 	if c, err := rest.InClusterConfig(); err == nil {


### PR DESCRIPTION
Fix passing the kubeconfig to the client factory.