### PR TITLE
Add a resync option to manager options

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -77,7 +77,7 @@ type Options struct {
 	// Mapper is the RESTMapper to use for mapping GroupVersionKinds to Resources
 	Mapper meta.RESTMapper
 
-	// Resync is the resync period
+	// Resync is the resync period. Defaults to defaultResyncTime.
 	Resync *time.Duration
 }
 


### PR DESCRIPTION
Allows setting the resync interval to something besides the default of 10 hours for all informers managed by the cache.

I'm not sure how to test this, because the resync interval seems to be irretrievable from the cache or its informers.

Fixes #87.

