### PR TITLE
Remove kube-aggregator from Gopkg.toml

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -46,9 +46,5 @@ required = ["sigs.k8s.io/testing_frameworks/integration",
   name = "k8s.io/client-go"
   version = "kubernetes-1.10.1"
 
-[[constraint]]
-  name = "k8s.io/kube-aggregator"
-  version = "kubernetes-1.10.1"
-
 [prune]
   go-tests = true


### PR DESCRIPTION
It's not directly used by anything, and the transitive deps should pull
in the proper version if needed.

Partial fix for #89 