### PR TITLE
Support Patch request in client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -122,6 +123,22 @@ func (c *client) Delete(ctx context.Context, obj runtime.Object) error {
 		Name(o.GetName()).
 		Do().
 		Error()
+}
+
+// Patch implements client.Client
+func (c *client) Patch(ctx context.Context, pt types.PatchType, data []byte, obj runtime.Object, subresources ...string) error {
+	o, err := c.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+	return o.Patch(pt).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		SubResource(subresources...).
+		Name(o.GetName()).
+		Body(data).
+		Do().
+		Into(obj)
 }
 
 // Get implements client.Client

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -55,6 +55,10 @@ type Writer interface {
 	// Update updates the given obj in the Kubernetes cluster. obj must be a
 	// struct pointer so that obj can be updated with the content returned by the Server.
 	Update(ctx context.Context, obj runtime.Object) error
+
+	// Patch patches the given obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Patch(ctx context.Context, pt types.PatchType, data []byte, obj runtime.Object, subresources ...string) error
 }
 
 // Client knows how to perform CRUD operations on Kubernetes objects.


### PR DESCRIPTION
Patch is similar to Update but submits the patch data in the request body instead of the object content. Patch data is accompanied by a patch type specifying the patch strategy, e.g. `types.MergePatchType`.

A subresource can be patched by passing the subresource path as variadic string arguments.