### PR TITLE
Surface reconcile error in logs

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -206,7 +206,7 @@ func (c *Controller) processNextWorkItem() bool {
 	// resource to be synced.
 	if result, err := c.Do.Reconcile(req); err != nil {
 		c.Queue.AddRateLimited(req)
-		log.Error(nil, "Reconciler error", "Controller", c.Name, "Request", req)
+		log.Error(err, "Reconciler error", "Controller", c.Name, "Request", req)
 
 		return false
 	} else if result.Requeue {


### PR DESCRIPTION
Currently errors returned by reconcilers are discarded from logs. This PR surfaces them.