### PR TITLE
Convert client.List to use functional options

### DIFF
--- a/pkg/builder/example_test.go
+++ b/pkg/builder/example_test.go
@@ -77,7 +77,7 @@ func (a *ReplicaSetReconciler) Reconcile(req reconcile.Request) (reconcile.Resul
 
 	// List the Pods matching the PodTemplate Labels
 	pods := &corev1.PodList{}
-	err = a.List(context.TODO(), client.InNamespace(req.Namespace).MatchingLabels(rs.Spec.Template.Labels), pods)
+	err = a.List(context.TODO(), pods, client.InNamespace(req.Namespace), client.MatchingLabels(rs.Spec.Template.Labels))
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Informer Cache", func() {
 		It("should be able to list objects that haven't been watched previously", func() {
 			By("listing all services in the cluster")
 			listObj := &kcorev1.ServiceList{}
-			Expect(informerCache.List(context.Background(), nil, listObj)).To(Succeed())
+			Expect(informerCache.List(context.Background(), listObj)).To(Succeed())
 
 			By("verifying that the returned list contains the Kubernetes service")
 			// NB: kubernetes default service is automatically created in testenv.
@@ -143,8 +143,10 @@ var _ = Describe("Informer Cache", func() {
 			By("listing pods with a particular label")
 			// NB: each pod has a "test-label": <pod-name>
 			out := kcorev1.PodList{}
-			Expect(informerCache.List(context.Background(), client.InNamespace(testNamespaceTwo).
-				MatchingLabels(map[string]string{"test-label": "test-pod-2"}), &out)).To(Succeed())
+			Expect(informerCache.List(context.Background(), &out,
+				client.InNamespace(testNamespaceTwo),
+				client.MatchingLabels(map[string]string{"test-label": "test-pod-2"}),
+			)).To(Succeed())
 
 			By("verifying the returned pods have the correct label")
 			Expect(out.Items).NotTo(BeEmpty())
@@ -161,8 +163,9 @@ var _ = Describe("Informer Cache", func() {
 			// NB: each pod has a "test-label": <pod-name>
 			out := kcorev1.PodList{}
 			labels := map[string]string{"test-label": "test-pod-2"}
-			Expect(informerCache.List(context.Background(),
-				client.MatchingLabels(labels), &out)).To(Succeed())
+			Expect(informerCache.List(context.Background(), &out,
+				client.MatchingLabels(labels),
+			)).To(Succeed())
 
 			By("verifying multiple pods with the same label in different namespaces are returned")
 			Expect(out.Items).NotTo(BeEmpty())
@@ -177,9 +180,9 @@ var _ = Describe("Informer Cache", func() {
 		It("should be able to list objects by namespace", func() {
 			By("listing pods in test-namespace-1")
 			listObj := &kcorev1.PodList{}
-			Expect(informerCache.List(context.Background(),
+			Expect(informerCache.List(context.Background(), listObj,
 				client.InNamespace(testNamespaceOne),
-				listObj)).To(Succeed())
+			)).To(Succeed())
 
 			By("verifying that the returned pods are in test-namespace-1")
 			Expect(listObj.Items).NotTo(BeEmpty())
@@ -317,9 +320,9 @@ var _ = Describe("Informer Cache", func() {
 
 			By("listing Pods with restartPolicyOnFailure")
 			listObj := &kcorev1.PodList{}
-			Expect(informer.List(context.Background(),
+			Expect(informer.List(context.Background(), listObj,
 				client.MatchingField("spec.restartPolicy", "OnFailure"),
-				listObj)).To(Succeed())
+			)).To(Succeed())
 
 			By("verifying that the returned pods have correct restart policy")
 			Expect(listObj.Items).NotTo(BeEmpty())

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runt
 }
 
 // List implements Reader
-func (ip *informerCache) List(ctx context.Context, opts *client.ListOptions, out runtime.Object) error {
+func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...client.ListOptionFunc) error {
 	itemsPtr, err := apimeta.GetItemsPtr(out)
 	if err != nil {
 		return nil
@@ -87,7 +87,7 @@ func (ip *informerCache) List(ctx context.Context, opts *client.ListOptions, out
 		return err
 	}
 
-	return cache.Reader.List(ctx, opts, out)
+	return cache.Reader.List(ctx, out, opts...)
 }
 
 // GetInformerForKind returns the informer for the GroupVersionKind

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -136,6 +136,6 @@ func (c *FakeInformers) Get(ctx context.Context, key client.ObjectKey, obj runti
 }
 
 // List implements Cache
-func (c *FakeInformers) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
+func (c *FakeInformers) List(ctx context.Context, list runtime.Object, opts ...client.ListOptionFunc) error {
 	return nil
 }

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -86,23 +86,26 @@ func (c *CacheReader) Get(_ context.Context, key client.ObjectKey, out runtime.O
 }
 
 // List lists items out of the indexer and writes them to out
-func (c *CacheReader) List(ctx context.Context, opts *client.ListOptions, out runtime.Object) error {
+func (c *CacheReader) List(ctx context.Context, out runtime.Object, opts ...client.ListOptionFunc) error {
 	var objs []interface{}
 	var err error
 
-	if opts != nil && opts.FieldSelector != nil {
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	if listOpts.FieldSelector != nil {
 		// TODO(directxman12): support more complicated field selectors by
 		// combining multiple indicies, GetIndexers, etc
-		field, val, requiresExact := requiresExactMatch(opts.FieldSelector)
+		field, val, requiresExact := requiresExactMatch(listOpts.FieldSelector)
 		if !requiresExact {
 			return fmt.Errorf("non-exact field matches are not supported by the cache")
 		}
 		// list all objects by the field selector.  If this is namespaced and we have one, ask for the
 		// namespaced index key.  Otherwise, ask for the non-namespaced variant by using the fake "all namespaces"
 		// namespace.
-		objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(opts.Namespace, val))
-	} else if opts != nil && opts.Namespace != "" {
-		objs, err = c.indexer.ByIndex(cache.NamespaceIndex, opts.Namespace)
+		objs, err = c.indexer.ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
+	} else if listOpts.Namespace != "" {
+		objs, err = c.indexer.ByIndex(cache.NamespaceIndex, listOpts.Namespace)
 	} else {
 		objs = c.indexer.List()
 	}
@@ -110,8 +113,8 @@ func (c *CacheReader) List(ctx context.Context, opts *client.ListOptions, out ru
 		return err
 	}
 	var labelSel labels.Selector
-	if opts != nil && opts.LabelSelector != nil {
-		labelSel = opts.LabelSelector
+	if listOpts.LabelSelector != nil {
+		labelSel = listOpts.LabelSelector
 	}
 
 	outItems, err := c.getListItems(objs, labelSel)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -140,20 +140,19 @@ func (c *client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) err
 }
 
 // List implements client.Client
-func (c *client) List(ctx context.Context, opts *ListOptions, obj runtime.Object) error {
+func (c *client) List(ctx context.Context, obj runtime.Object, opts ...ListOptionFunc) error {
 	r, err := c.cache.getResource(obj)
 	if err != nil {
 		return err
 	}
-	namespace := ""
-	if opts != nil {
-		namespace = opts.Namespace
-	}
+
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
 	return r.Get().
-		NamespaceIfScoped(namespace, r.isNamespaced()).
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
 		Resource(r.resource()).
 		Body(obj).
-		VersionedParams(opts.AsListOptions(), c.paramCodec).
+		VersionedParams(listOpts.AsListOptions(), c.paramCodec).
 		Do().
 		Into(obj)
 }

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -19,7 +19,9 @@ package fake
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -77,10 +79,23 @@ func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.
 	return err
 }
 
-func (c *fakeClient) List(ctx context.Context, opts *client.ListOptions, list runtime.Object) error {
-	gvk := opts.Raw.TypeMeta.GroupVersionKind()
+func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...client.ListOptionFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
-	o, err := c.tracker.List(gvr, gvk, opts.Namespace)
+	o, err := c.tracker.List(gvr, gvk, listOpts.Namespace)
 	if err != nil {
 		return err
 	}
@@ -89,7 +104,7 @@ func (c *fakeClient) List(ctx context.Context, opts *client.ListOptions, list ru
 		return err
 	}
 	decoder := scheme.Codecs.UniversalDecoder()
-	_, _, err = decoder.Decode(j, nil, list)
+	_, _, err = decoder.Decode(j, nil, obj)
 	return err
 }
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -17,15 +17,12 @@ limitations under the License.
 package fake
 
 import (
-	"encoding/json"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -69,22 +66,11 @@ var _ = Describe("Fake client", func() {
 
 	It("should be able to List", func() {
 		By("Listing all deployments in a namespace")
-		list := &metav1.List{}
-		err := cl.List(nil, &client.ListOptions{
-			Namespace: "ns1",
-			Raw: &metav1.ListOptions{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-				},
-			},
-		}, list)
+		list := &appsv1.DeploymentList{}
+		err := cl.List(nil, list, client.InNamespace("ns1"))
 		Expect(err).To(BeNil())
 		Expect(list.Items).To(HaveLen(1))
-		j, err := json.Marshal(dep)
-		Expect(err).To(BeNil())
-		expectedDep := runtime.RawExtension{Raw: j}
-		Expect(list.Items).To(ConsistOf(expectedDep))
+		Expect(list.Items).To(ConsistOf(*dep))
 	})
 
 	It("should be able to Create", func() {
@@ -140,16 +126,8 @@ var _ = Describe("Fake client", func() {
 		Expect(err).To(BeNil())
 
 		By("Listing all deployments in the namespace")
-		list := &metav1.List{}
-		err = cl.List(nil, &client.ListOptions{
-			Namespace: "ns1",
-			Raw: &metav1.ListOptions{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-				},
-			},
-		}, list)
+		list := &appsv1.DeploymentList{}
+		err = cl.List(nil, list, client.InNamespace("ns1"))
 		Expect(err).To(BeNil())
 		Expect(list.Items).To(HaveLen(0))
 	})

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -51,7 +51,7 @@ type Reader interface {
 	// List retrieves list of objects for a given namespace and list options. On a
 	// successful call, Items field in the list will be populated with the
 	// result returned from the server.
-	List(ctx context.Context, opts *ListOptions, list runtime.Object) error
+	List(ctx context.Context, list runtime.Object, opts ...ListOptionFunc) error
 }
 
 // Writer knows how to create, delete, and update Kubernetes objects.
@@ -185,7 +185,7 @@ func PropagationPolicy(p metav1.DeletionPropagation) DeleteOptionFunc {
 	}
 }
 
-// ListOptions contains options for limitting or filtering results.
+// ListOptions contains options for limiting or filtering results.
 // It's generally a subset of metav1.ListOptions, with support for
 // pre-parsed selectors (since generally, selectors will be executed
 // against the cache).
@@ -248,6 +248,20 @@ func (o *ListOptions) AsListOptions() *metav1.ListOptions {
 	return o.Raw
 }
 
+// ApplyOptions executes the given ListOptionFuncs and returns the mutated
+// ListOptions.
+func (o *ListOptions) ApplyOptions(optFuncs []ListOptionFunc) *ListOptions {
+	for _, optFunc := range optFuncs {
+		optFunc(o)
+	}
+	return o
+}
+
+// ListOptionFunc is a function that mutates a ListOptions struct. It implements
+// the functional options pattern. See
+// https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md.
+type ListOptionFunc func(*ListOptions)
+
 // MatchingLabels is a convenience function that sets the label selector
 // to match the given labels, and then returns the options.
 // It mutates the list options.
@@ -273,20 +287,42 @@ func (o *ListOptions) InNamespace(ns string) *ListOptions {
 	return o
 }
 
-// MatchingLabels is a convenience function that constructs list options
-// to match the given labels.
-func MatchingLabels(lbls map[string]string) *ListOptions {
-	return (&ListOptions{}).MatchingLabels(lbls)
+// MatchingLabels is a functional option that sets the LabelSelector field of
+// a ListOptions struct.
+func MatchingLabels(lbls map[string]string) ListOptionFunc {
+	sel := labels.SelectorFromSet(lbls)
+	return func(opts *ListOptions) {
+		opts.LabelSelector = sel
+	}
 }
 
-// MatchingField is a convenience function that constructs list options
-// to match the given field.
-func MatchingField(name, val string) *ListOptions {
-	return (&ListOptions{}).MatchingField(name, val)
+// MatchingField is a functional option that sets the FieldSelector field of
+// a ListOptions struct.
+func MatchingField(name, val string) ListOptionFunc {
+	sel := fields.SelectorFromSet(fields.Set{name: val})
+	return func(opts *ListOptions) {
+		opts.FieldSelector = sel
+	}
 }
 
-// InNamespace is a convenience function that constructs list
-// options to list in the given namespace.
-func InNamespace(ns string) *ListOptions {
-	return (&ListOptions{}).InNamespace(ns)
+// InNamespace is a functional option that sets the Namespace field of
+// a ListOptions struct.
+func InNamespace(ns string) ListOptionFunc {
+	return func(opts *ListOptions) {
+		opts.Namespace = ns
+	}
+}
+
+// UseListOptions is a functional option that replaces the fields of a
+// ListOptions struct with those of a different ListOptions struct.
+//
+// Example:
+// cl.List(ctx, list, client.UseListOptions(lo.InNamespace(ns).MatchingLabels(labels)))
+func UseListOptions(newOpts *ListOptions) ListOptionFunc {
+	return func(opts *ListOptions) {
+		opts.LabelSelector = newOpts.LabelSelector
+		opts.FieldSelector = newOpts.FieldSelector
+		opts.Namespace = newOpts.Namespace
+		opts.Raw = newOpts.Raw
+	}
 }

--- a/pkg/webhook/internal/cert/writer/secret_test.go
+++ b/pkg/webhook/internal/cert/writer/secret_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package writer
 
 import (
-	"encoding/json"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +35,6 @@ var _ = Describe("secretCertWriter", func() {
 	var certWriter CertWriter
 	var sCertWriter *secretCertWriter
 	var secret *corev1.Secret
-	var expectedSecret runtime.RawExtension
 
 	BeforeEach(func(done Done) {
 		var err error
@@ -105,43 +101,21 @@ var _ = Describe("secretCertWriter", func() {
 			It("should default it and return no error", func() {
 				_, _, err := certWriter.EnsureCert(dnsName, false)
 				Expect(err).NotTo(HaveOccurred())
-				list := &corev1.List{}
-				err = sCertWriter.Client.List(nil, &client.ListOptions{
-					Namespace: "namespace-bar",
-					Raw: &metav1.ListOptions{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "v1",
-							Kind:       "Secret",
-						},
-					},
-				}, list)
+				list := &corev1.SecretList{}
+				err = sCertWriter.Client.List(nil, list, client.InNamespace("namespace-bar"))
 				Expect(err).NotTo(HaveOccurred())
 				Expect(list.Items).To(HaveLen(1))
 			})
 		})
 
 		Context("no existing secret", func() {
-			BeforeEach(func(done Done) {
-				j, _ := json.Marshal(secret)
-				expectedSecret = runtime.RawExtension{Raw: j}
-				close(done)
-			})
-
 			It("should create new secrets with certs", func() {
 				_, changed, err := certWriter.EnsureCert(dnsName, false)
 				Expect(err).NotTo(HaveOccurred())
-				list := &corev1.List{}
-				err = sCertWriter.Client.List(nil, &client.ListOptions{
-					Namespace: "namespace-bar",
-					Raw: &metav1.ListOptions{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "v1",
-							Kind:       "Secret",
-						},
-					},
-				}, list)
+				list := &corev1.SecretList{}
+				err = sCertWriter.Client.List(nil, list, client.InNamespace("namespace-bar"))
 				Expect(err).NotTo(HaveOccurred())
-				Expect(list.Items).To(ConsistOf(expectedSecret))
+				Expect(list.Items).To(ConsistOf(*secret))
 				Expect(list.Items).To(HaveLen(1))
 				Expect(changed).To(BeTrue())
 			})
@@ -151,12 +125,6 @@ var _ = Describe("secretCertWriter", func() {
 			var oldSecret *corev1.Secret
 
 			Context("cert is invalid", func() {
-				BeforeEach(func(done Done) {
-					j, _ := json.Marshal(secret)
-					expectedSecret = runtime.RawExtension{Raw: j}
-					close(done)
-				})
-
 				Describe("cert in secret is incomplete", func() {
 					BeforeEach(func(done Done) {
 						oldSecret = secret.DeepCopy()
@@ -168,18 +136,10 @@ var _ = Describe("secretCertWriter", func() {
 					It("should replace with new certs", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName, false)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
-						err = sCertWriter.Client.List(nil, &client.ListOptions{
-							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
-						}, list)
+						list := &corev1.SecretList{}
+						err = sCertWriter.Client.List(nil, list, client.InNamespace("namespace-bar"))
 						Expect(err).NotTo(HaveOccurred())
-						Expect(list.Items).To(ConsistOf(expectedSecret))
+						Expect(list.Items).To(ConsistOf(*secret))
 						Expect(list.Items).To(HaveLen(1))
 						Expect(changed).To(BeTrue())
 					})
@@ -200,18 +160,10 @@ var _ = Describe("secretCertWriter", func() {
 					It("should replace with new certs", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName, false)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
-						err = sCertWriter.Client.List(nil, &client.ListOptions{
-							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
-						}, list)
+						list := &corev1.SecretList{}
+						err = sCertWriter.Client.List(nil, list, client.InNamespace("namespace-bar"))
 						Expect(err).NotTo(HaveOccurred())
-						Expect(list.Items).To(ConsistOf(expectedSecret))
+						Expect(list.Items).To(ConsistOf(*secret))
 						Expect(list.Items).To(HaveLen(1))
 						Expect(changed).To(BeTrue())
 					})
@@ -225,8 +177,6 @@ var _ = Describe("secretCertWriter", func() {
 						ServerKeyName:  []byte(certs2.Key),
 						ServerCertName: []byte(certs2.Cert),
 					}
-					j, _ := json.Marshal(oldSecret)
-					expectedSecret = runtime.RawExtension{Raw: j}
 					sCertWriter.Client = fake.NewFakeClient(oldSecret)
 					close(done)
 				})
@@ -239,28 +189,17 @@ var _ = Describe("secretCertWriter", func() {
 							ServerKeyName:  []byte(certs2.Key),
 							ServerCertName: []byte(certs2.Cert),
 						}
-						j, _ := json.Marshal(oldSecret)
-						expectedSecret = runtime.RawExtension{Raw: j}
-
 						sCertWriter.Client = fake.NewFakeClient(oldSecret)
 						close(done)
 					})
 					It("should keep the secret", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName, false)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
-						err = sCertWriter.Client.List(nil, &client.ListOptions{
-							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
-						}, list)
+						list := &corev1.SecretList{}
+						err = sCertWriter.Client.List(nil, list, client.InNamespace("namespace-bar"))
 						Expect(err).NotTo(HaveOccurred())
 						Expect(list.Items).To(HaveLen(1))
-						Expect(list.Items[0]).To(Equal(expectedSecret))
+						Expect(list.Items).To(ConsistOf(*oldSecret))
 						Expect(changed).To(BeFalse())
 					})
 				})


### PR DESCRIPTION
Replaces:

`List(ctx, ListOptions, list)`

with:

`List(ctx, list, ...Option)`

This matches the functional options signature of `client.Delete` in #94.

A few examples (I tried formatting these as a table but it wasn't wide enough):

Select all:
```go
// current
List(ctx, nil, list)
// proposed
List(ctx, list)
```

Filter by namespace:
```go
// current
List(ctx, client.InNamespace(ns), list)
// proposed
List(ctx, list, client.InNamespace(ns))
```

Filter by namespace and labels:
```go
// current
List(ctx, client.InNamespace(ns).MatchingLabels(labels), list)
// proposed
List(ctx, list, client.InNamespace(ns), client.MatchingLabels(labels))
```

To assemble a `ListOptions` with the builder methods or some other strategy, use the `UseListOptions` functional option:

```go
lo := &client.ListOptions{}
client.List(ctx, list, client.UseListOptions(
  lo.InNamespace(ns).MatchingLabels(labels)
))
```