### PR TITLE
Clarify SyncPeriod comment

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -76,12 +76,10 @@ type Options struct {
 	// MapperProvider provides the rest mapper used to map go types to Kubernetes APIs
 	MapperProvider func(c *rest.Config) (meta.RESTMapper, error)
 
-	// SyncPeriod determines the minimum frequency at which watched objects are
-	// reconciled. A lower period will correct entropy more quickly but reduce
-	// responsiveness to change. Choose a low value if reconciles are fast and/or
-	// there are few objects to reconcile. Choose a high value if reconciles are
-	// slow and/or there are many object to reconcile. Defaults to 10 hours if
-	// unset.
+	// SyncPeriod determines the minimum frequency at which watched resources are
+	// reconciled. A lower period will correct entropy more quickly, but reduce
+	// responsiveness to change if there are many watched resources. Change this
+	// value only if you know what you are doing. Defaults to 10 hours if unset.
 	SyncPeriod *time.Duration
 
 	// Dependency injection for testing


### PR DESCRIPTION
Removes the advice about when to change, since sync period is more subtle than can be explained in a comment. Replaces it with a warning to know what you're doing before changing it.

Followup from the conversation with @DirectXMan12 in #88.