### PR TITLE
Update OWNERS_ALIASES to fix approver bot

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,8 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
 
 aliases:
-  - controller-runtime-admins:
-    - directxman12
-    - droot
-    - pwittrock
-  - controller-runtime-maintainers:
+  controller-runtime-admins:
+  - directxman12
+  - droot
+  - pwittrock
+  controller-runtime-maintainers: []


### PR DESCRIPTION
The OWNERS_ALIASES needs aliases as map keys, not as list items.