### PR TITLE
External clusters in envtest

### DIFF
--- a/pkg/envtest/ginkgo.go
+++ b/pkg/envtest/ginkgo.go
@@ -1,51 +1,11 @@
-/*
-Copyright 2016 The Kubernetes Authors.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package envtest
 
 import (
-	"fmt"
-
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/config"
-	"github.com/onsi/ginkgo/types"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
-
-var _ ginkgo.Reporter = NewlineReporter{}
 
 // NewlineReporter is Reporter that Prints a newline after the default Reporter output so that the results
 // are correctly parsed by test automation.
 // See issue https://github.com/jstemmer/go-junit-report/issues/31
-type NewlineReporter struct{}
-
-// SpecSuiteWillBegin implements ginkgo.Reporter
-func (NewlineReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
-}
-
-// BeforeSuiteDidRun implements ginkgo.Reporter
-func (NewlineReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
-
-// AfterSuiteDidRun implements ginkgo.Reporter
-func (NewlineReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {}
-
-// SpecWillRun implements ginkgo.Reporter
-func (NewlineReporter) SpecWillRun(specSummary *types.SpecSummary) {}
-
-// SpecDidComplete implements ginkgo.Reporter
-func (NewlineReporter) SpecDidComplete(specSummary *types.SpecSummary) {}
-
-// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
-func (NewlineReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) { fmt.Printf("\n") }
+// It's re-exported here to avoid compatibility breakage/mass rewrites.
+type NewlineReporter = printer.NewlineReporter

--- a/pkg/envtest/printer/ginkgo.go
+++ b/pkg/envtest/printer/ginkgo.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printer
+
+import (
+	"fmt"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/types"
+)
+
+var _ ginkgo.Reporter = NewlineReporter{}
+
+// NewlineReporter is Reporter that Prints a newline after the default Reporter output so that the results
+// are correctly parsed by test automation.
+// See issue https://github.com/jstemmer/go-junit-report/issues/31
+type NewlineReporter struct{}
+
+// SpecSuiteWillBegin implements ginkgo.Reporter
+func (NewlineReporter) SpecSuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+}
+
+// BeforeSuiteDidRun implements ginkgo.Reporter
+func (NewlineReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+// AfterSuiteDidRun implements ginkgo.Reporter
+func (NewlineReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {}
+
+// SpecWillRun implements ginkgo.Reporter
+func (NewlineReporter) SpecWillRun(specSummary *types.SpecSummary) {}
+
+// SpecDidComplete implements ginkgo.Reporter
+func (NewlineReporter) SpecDidComplete(specSummary *types.SpecSummary) {}
+
+// SpecSuiteDidEnd Prints a newline between "35 Passed | 0 Failed | 0 Pending | 0 Skipped" and "--- PASS:"
+func (NewlineReporter) SpecSuiteDidEnd(summary *types.SuiteSummary) { fmt.Printf("\n") }

--- a/pkg/runtime/log/log_suite_test.go
+++ b/pkg/runtime/log/log_suite_test.go
@@ -21,10 +21,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 )
 
 func TestSource(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecsWithDefaultAndCustomReporters(t, "Runtime Log Suite", []Reporter{envtest.NewlineReporter{}})
+	RunSpecsWithDefaultAndCustomReporters(t, "Runtime Log Suite", []Reporter{printer.NewlineReporter{}})
 }


### PR DESCRIPTION
This allows you to use an external cluster with envtest.  In the
case where `UseExistingCluster` is set to true, envtest will skip
initializing the control plane, and if config is not otherwise set,
it will populate the config from local kubeconfigs or in-cluster config.