### PR TITLE
gas linter renamed to gosec

### DIFF
--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -39,7 +39,7 @@ gometalinter.v2 --disable-all \
     --enable=errcheck \
     --enable=varcheck \
     --enable=goconst \
-    --enable=gas \
+    --enable=gosec \
     --enable=unparam \
     --enable=ineffassign \
     --enable=nakedret \


### PR DESCRIPTION
This PR fixes an failing linter check due to renaming.