### PR TITLE
Support delaying requeue for objectkey.

### DIFF
--- a/pkg/admission/cert/writer/internal/atomic/atomic_writer_test.go
+++ b/pkg/admission/cert/writer/internal/atomic/atomic_writer_test.go
@@ -28,9 +28,9 @@ import (
 	"strings"
 	"testing"
 
+	log "github.com/go-logr/logr/testing"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utiltesting "k8s.io/client-go/util/testing"
-	log "github.com/go-logr/logr/testing"
 )
 
 func TestNewAtomicWriter(t *testing.T) {

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -209,6 +209,9 @@ func (c *Controller) processNextWorkItem() bool {
 		log.Error(err, "Reconciler error", "Controller", c.Name, "Request", req)
 
 		return false
+	} else if result.RequeueAfter > 0 {
+		c.Queue.AddAfter(req, result.RequeueAfter)
+		return true
 	} else if result.Requeue {
 		c.Queue.AddRateLimited(req)
 		return true

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -17,6 +17,8 @@ limitations under the License.
 package reconcile
 
 import (
+	"time"
+
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -24,6 +26,9 @@ import (
 type Result struct {
 	// Requeue tells the Controller to requeue the reconcile key.  Defaults to false.
 	Requeue bool
+
+	// RequeueAfter if greater than 0, tells the Controller to requeue the reconcile key after the Duration.
+	RequeueAfter time.Duration
 }
 
 // Request contains the information necessary to reconcile a Kubernetes object.  This includes the


### PR DESCRIPTION
This is a requirement for migrating cluster-api to controller-runtime.