### PR TITLE
Option to restrict informer cache to a namespace

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -79,6 +79,10 @@ type Options struct {
 
 	// Resync is the resync period. Defaults to defaultResyncTime.
 	Resync *time.Duration
+
+	// Namespace restricts the cache's ListWatch to the desired namespace
+	// Default watches all namespaces
+	Namespace string
 }
 
 var defaultResyncTime = 10 * time.Hour
@@ -89,7 +93,7 @@ func New(config *rest.Config, opts Options) (Cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	im := internal.NewInformersMap(config, opts.Scheme, opts.Mapper, *opts.Resync)
+	im := internal.NewInformersMap(config, opts.Scheme, opts.Mapper, *opts.Resync, opts.Namespace)
 	return &informerCache{InformersMap: im}, nil
 }
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -44,11 +44,12 @@ type InformersMap struct {
 func NewInformersMap(config *rest.Config,
 	scheme *runtime.Scheme,
 	mapper meta.RESTMapper,
-	resync time.Duration) *InformersMap {
+	resync time.Duration,
+	namespace string) *InformersMap {
 
 	return &InformersMap{
-		structured:   newStructuredInformersMap(config, scheme, mapper, resync),
-		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync),
+		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace),
+		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace),
 
 		Scheme: scheme,
 	}
@@ -85,11 +86,11 @@ func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object) (*Ma
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.
-func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, createStructuredListWatch)
+func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createStructuredListWatch)
 }
 
 // newUnstructuredInformersMap creates a new InformersMap for unstructured objects.
-func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, createUnstructuredListWatch)
+func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createUnstructuredListWatch)
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -106,6 +106,12 @@ type Options struct {
 	// will use for holding the leader lock.
 	LeaderElectionID string
 
+	// Namespace if specified restricts the manager's cache to watch objects in the desired namespace
+	// Defaults to all namespaces
+	// Note: If a namespace is specified then controllers can still Watch for a cluster-scoped resource e.g Node
+	// For namespaced resources the cache will only hold objects from the desired namespace.
+	Namespace string
+
 	// Dependency injection for testing
 	newCache            func(config *rest.Config, opts cache.Options) (cache.Cache, error)
 	newClient           func(config *rest.Config, options client.Options) (client.Client, error)
@@ -153,7 +159,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}
 
 	// Create the cache for the cached read client and registering informers
-	cache, err := options.newCache(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod})
+	cache, err := options.newCache(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod, Namespace: options.Namespace})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #124 

A namespace option can be passed from the manager to the cache which restricts the ListWatch for all informers to the desired namespace. 
This way a manager can be run with a Role instead of a ClusterRole.