### PR TITLE
Support optional identifier for handlers

### DIFF
--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -42,6 +42,13 @@ type Handler interface {
 	Handle(context.Context, atypes.Request) atypes.Response
 }
 
+// NameGetter gets the name of the Handler
+type NameGetter interface {
+	// Name returns the name of the Handler.
+	// The name should be a feature name that can be the identifier for the handler.
+	Name() string
+}
+
 // HandlerFunc implements Handler interface using a single function.
 type HandlerFunc func(context.Context, atypes.Request) atypes.Response
 


### PR DESCRIPTION
One handler may represent a feature and people may want to disable a feature at runtime.
So a handler should have an optional identifier.