### PR TITLE
fix nil stop value for source.Channel

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -180,6 +180,8 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
+	stop := make(chan struct{})
+
 	return &controllerManager{
 		config:           config,
 		scheme:           options.Scheme,
@@ -191,6 +193,8 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		recorderProvider: recorderProvider,
 		resourceLock:     resourceLock,
 		mapper:           mapper,
+		stop:             stop,
+		stopper:          stop,
 	}, nil
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -327,8 +327,7 @@ var _ = Describe("manger.Manager", func() {
 				},
 				stop: func(stop <-chan struct{}) error {
 					defer GinkgoRecover()
-					// Manager stop chan has not been initialized.
-					Expect(stop).To(BeNil())
+					Expect(stop).NotTo(BeNil())
 					return nil
 				},
 				f: func(f inject.Func) error {


### PR DESCRIPTION
fixes #103

Creates a stop channel for the manager in New(), which will get passed to any
source.Channel instances that are added. When the manager's start method is
called and a new stop channel is passed in, that channel will be joined in a
goroutine with the manager's existing channel so that if the newer channel gets
closed, so will the manager's.