### PR TITLE
Support for client-go code generated controllers as Controller Watch …

### DIFF
--- a/pkg/source/source_integration_test.go
+++ b/pkg/source/source_integration_test.go
@@ -18,6 +18,7 @@ package source_test
 
 import (
 	"fmt"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -30,6 +31,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	kubeinformers "k8s.io/client-go/informers"
+	toolscache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -206,6 +209,163 @@ var _ = Describe("Source", func() {
 		Context("for a Foo CRD resource", func() {
 			It("should provide Foo Events", func() {
 
+			})
+		})
+	})
+
+	Describe("Informer", func() {
+		var c chan struct{}
+		var rs *appsv1.ReplicaSet
+		var depInformer toolscache.SharedIndexInformer
+		var informerFactory kubeinformers.SharedInformerFactory
+		var stopTest chan struct{}
+
+		BeforeEach(func(done Done) {
+			stopTest = make(chan struct{})
+			informerFactory = kubeinformers.NewSharedInformerFactory(clientset, time.Second*30)
+			depInformer = informerFactory.Apps().V1().ReplicaSets().Informer()
+			informerFactory.Start(stopTest)
+			Eventually(depInformer.HasSynced).Should(BeTrue())
+
+			c = make(chan struct{})
+			rs = &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{Name: "informer-rs-name"},
+				Spec: appsv1.ReplicaSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			}
+			close(done)
+		})
+
+		AfterEach(func(done Done) {
+			close(stopTest)
+			close(done)
+		})
+
+		Context("for a ReplicaSet resource", func() {
+			It("should provide a ReplicaSet CreateEvent", func(done Done) {
+				c := make(chan struct{})
+
+				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
+				instance := &source.Informer{Informer: depInformer}
+				err := instance.Start(handler.Funcs{
+					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						var err error
+						rs, err = clientset.AppsV1().ReplicaSets("default").Get(rs.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(q2).To(BeIdenticalTo(q))
+						Expect(evt.Meta).To(Equal(rs))
+						Expect(evt.Object).To(Equal(rs))
+						close(c)
+					},
+					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected UpdateEvent")
+					},
+					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected DeleteEvent")
+					},
+					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected GenericEvent")
+					},
+				}, q)
+				Expect(err).NotTo(HaveOccurred())
+
+				rs, err = clientset.AppsV1().ReplicaSets("default").Create(rs)
+				Expect(err).NotTo(HaveOccurred())
+				<-c
+				close(done)
+			}, 30)
+
+			It("should provide a ReplicaSet UpdateEvent", func(done Done) {
+				var err error
+				rs, err = clientset.AppsV1().ReplicaSets("default").Get(rs.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				rs2 := rs.DeepCopy()
+				rs2.SetLabels(map[string]string{"biz": "baz"})
+
+				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
+				instance := &source.Informer{Informer: depInformer}
+				err = instance.Start(handler.Funcs{
+					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+					},
+					UpdateFunc: func(evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						var err error
+						rs2, err = clientset.AppsV1().ReplicaSets("default").Get(rs.Name, metav1.GetOptions{})
+						Expect(err).NotTo(HaveOccurred())
+
+						Expect(q2).To(Equal(q))
+						Expect(evt.MetaOld).To(Equal(rs))
+						Expect(evt.ObjectOld).To(Equal(rs))
+
+						Expect(evt.MetaNew).To(Equal(rs2))
+						Expect(evt.ObjectNew).To(Equal(rs2))
+
+						close(c)
+					},
+					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected DeleteEvent")
+					},
+					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected GenericEvent")
+					},
+				}, q)
+				Expect(err).NotTo(HaveOccurred())
+
+				rs2, err = clientset.AppsV1().ReplicaSets("default").Update(rs2)
+				Expect(err).NotTo(HaveOccurred())
+				<-c
+				close(done)
+			})
+
+			It("should provide a ReplicaSet DeletedEvent", func(done Done) {
+				c := make(chan struct{})
+
+				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
+				instance := &source.Informer{Informer: depInformer}
+				err := instance.Start(handler.Funcs{
+					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					},
+					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					},
+					DeleteFunc: func(evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Expect(q2).To(Equal(q))
+						Expect(evt.Meta.GetName()).To(Equal(rs.Name))
+						close(c)
+					},
+					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+						defer GinkgoRecover()
+						Fail("Unexpected GenericEvent")
+					},
+				}, q)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = clientset.AppsV1().ReplicaSets("default").Delete(rs.Name, &metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				<-c
+				close(done)
 			})
 		})
 	})

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -116,7 +116,7 @@ var _ = Describe("Source", func() {
 					},
 					UpdateFunc: func(evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
-						Expect(q2).To(Equal(q))
+						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.MetaOld).To(Equal(p))
 						Expect(evt.ObjectOld).To(Equal(p))
 
@@ -170,7 +170,7 @@ var _ = Describe("Source", func() {
 					},
 					DeleteFunc: func(evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
-						Expect(q2).To(Equal(q))
+						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Meta).To(Equal(p))
 						Expect(evt.Object).To(Equal(p))
 						close(c)
@@ -306,7 +306,7 @@ var _ = Describe("Source", func() {
 						defer GinkgoRecover()
 						// The empty event should have been filtered out by the predicates,
 						// and will not be passed to the handler.
-						Expect(q2).To(Equal(q))
+						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Meta).To(Equal(p))
 						Expect(evt.Object).To(Equal(p))
 						close(c)
@@ -429,7 +429,7 @@ var _ = Describe("Source", func() {
 					},
 					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
-						Expect(q2).To(Equal(q))
+						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Meta).To(Equal(p))
 						Expect(evt.Object).To(Equal(p))
 						resEvent1 = evt
@@ -453,7 +453,7 @@ var _ = Describe("Source", func() {
 					},
 					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
-						Expect(q2).To(Equal(q))
+						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Meta).To(Equal(p))
 						Expect(evt.Object).To(Equal(p))
 						resEvent2 = evt


### PR DESCRIPTION
This is useful for projects that either:

1. Want to migrate to controller-runtime client incrementally from client-go generated libraries
1. Prefer to use the client-go generated libraries