### PR TITLE
Use read mutex when iterating over informers map

### DIFF
--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -127,6 +127,8 @@ func (ip *specificInformersMap) Start(stop <-chan struct{}) {
 
 // HasSyncedFuncs returns all the HasSynced functions for the informers in this map.
 func (ip *specificInformersMap) HasSyncedFuncs() []cache.InformerSynced {
+	ip.mu.RLock()
+	defer ip.mu.RUnlock()
 	syncedFuncs := make([]cache.InformerSynced, 0, len(ip.informersByGVK))
 	for _, informer := range ip.informersByGVK {
 		syncedFuncs = append(syncedFuncs, informer.Informer.HasSynced)


### PR DESCRIPTION
I'm building a controller using the package and have been running my tests using `ginkgo -race`, I came across this race condition which led me to a small fix.

```
WARNING: DATA RACE
Write at 0x00c000e65440 by goroutine 23:
  runtime.mapassign()
      /usr/local/Cellar/go/1.11/libexec/src/runtime/map.go:549 +0x0
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal.(*specificInformersMap).Get.func2()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:180 +0x456
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal.(*specificInformersMap).Get()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:190 +0x161
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal.(*InformersMap).Get()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/deleg_map.go:84 +0x1f0
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache.(*informerCache).Get()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/informer_cache.go:53 +0x1c1
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/client.(*DelegatingReader).Get()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/client/split.go:49 +0x1a4
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/client.(*DelegatingClient).Get()
      <autogenerated>:1 +0xd1
  github.com/pusher/faros/pkg/controller/gittrack.(*ReconcileGitTrack).fetchDeployKey()
      /Users/joel/go/src/github.com/pusher/faros/pkg/controller/gittrack/gittrack_controller.go:157 +0x28b
  github.com/pusher/faros/pkg/controller/gittrack.glob..func3.9.1.4()
      /Users/joel/go/src/github.com/pusher/faros/pkg/controller/gittrack/gittrack_controller_test.go:836 +0xfd
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:113 +0xbd
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).run()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes/runner.go:64 +0x16a
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*ItNode).Run()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/leafnodes/it_node.go:26 +0xa2
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).runSample()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:203 +0x766
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/spec.(*Spec).Run()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/spec/spec.go:138 +0x145
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpec()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:200 +0x172
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).runSpecs()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:170 +0x4ad
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner.(*SpecRunner).Run()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/specrunner/spec_runner.go:66 +0x149
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/suite.(*Suite).Run()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/internal/suite/suite.go:62 +0x3e1
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo.RunSpecsWithCustomReporters()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:221 +0x367
  github.com/pusher/faros/vendor/github.com/onsi/ginkgo.RunSpecsWithDefaultAndCustomReporters()
      /Users/joel/go/src/github.com/pusher/faros/vendor/github.com/onsi/ginkgo/ginkgo_dsl.go:209 +0x129
  github.com/pusher/faros/pkg/controller/gittrack.TestBee()
      /Users/joel/go/src/github.com/pusher/faros/pkg/controller/gittrack/gittrack_controller_suite_test.go:65 +0xc4
  testing.tRunner()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:827 +0x162

Previous read at 0x00c000e65440 by goroutine 242:
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal.(*specificInformersMap).HasSyncedFuncs()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:130 +0x87
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal.(*InformersMap).WaitForCacheSync()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache/internal/deleg_map.go:67 +0x66
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache.(*informerCache).WaitForCacheSync()
      <autogenerated>:1 +0x63
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/cache.Cache.WaitForCacheSync-fm()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:139 +0x50
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:141 +0x28f
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).start.func1.2()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go:270 +0x4c

Goroutine 23 (running) created at:
  testing.(*T).Run()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:878 +0x650
  testing.runTests.func1()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1119 +0xa8
  testing.tRunner()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:827 +0x162
  testing.runTests()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1117 +0x4ee
  testing.(*M).Run()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:1034 +0x2ee
  main.main()
      _testmain.go:42 +0x221

Goroutine 242 (running) created at:
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).start.func1()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go:269 +0x215
  github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).start()
      /Users/joel/go/src/github.com/pusher/faros/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go:275 +0x42
```

The `Get` and the `HasSynced` methods are getting called concurrently in my tests and I noticed there is a read lock used in one but not the other, this PR fixes that