### PR TITLE
WIP adds Context support to manager in place of stop channels.

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 
@@ -128,7 +129,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-signals.SetupSignalHandler()
+		cancel()
+	}()
+
+	if err := mgr.Start(ctx); err != nil {
 		entryLog.Error(err, "unable to run manager")
 		os.Exit(1)
 	}

--- a/pkg/builder/build_test.go
+++ b/pkg/builder/build_test.go
@@ -37,9 +37,11 @@ import (
 
 var _ = Describe("application", func() {
 	var stop chan struct{}
+	var ctx context.Context
 
 	BeforeEach(func() {
 		stop = make(chan struct{})
+		ctx = context.Background()
 		getConfig = func() (*rest.Config, error) { return cfg, nil }
 		newController = controller.New
 		newManager = manager.New
@@ -138,7 +140,7 @@ var _ = Describe("application", func() {
 			By("Starting the application")
 			go func() {
 				defer GinkgoRecover()
-				Expect(instance.Start(stop)).NotTo(HaveOccurred())
+				Expect(instance.Start(ctx)).NotTo(HaveOccurred())
 				By("Stopping the application")
 			}()
 

--- a/pkg/builder/example_test.go
+++ b/pkg/builder/example_test.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 // NB: don't call SetLogger in init(), or else you'll mess up logging in the main suite.
@@ -49,7 +48,7 @@ func ExampleBuilder() {
 		os.Exit(1)
 	}
 
-	if err := rs.Start(signals.SetupSignalHandler()); err != nil {
+	if err := rs.Start(context.TODO()); err != nil {
 		log.Error(err, "Unable to run controller")
 		os.Exit(1)
 	}

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller_test
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,9 +37,11 @@ import (
 var _ = Describe("controller", func() {
 	var reconciled chan reconcile.Request
 	var stop chan struct{}
+	var ctx context.Context
 
 	BeforeEach(func() {
 		stop = make(chan struct{})
+		ctx = context.Background()
 		reconciled = make(chan reconcile.Request)
 		Expect(cfg).NotTo(BeNil())
 	})
@@ -76,7 +80,7 @@ var _ = Describe("controller", func() {
 			By("Starting the Manager")
 			go func() {
 				defer GinkgoRecover()
-				Expect(cm.Start(stop)).NotTo(HaveOccurred())
+				Expect(cm.Start(ctx)).NotTo(HaveOccurred())
 			}()
 
 			deployment := &appsv1.Deployment{

--- a/pkg/controller/example_test.go
+++ b/pkg/controller/example_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller_test
 
 import (
+	"context"
 	"os"
 
 	"k8s.io/api/core/v1"
@@ -25,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -75,5 +75,5 @@ func ExampleController() {
 	}
 
 	// Start the Controller through the manager.
-	mgr.Start(signals.SetupSignalHandler())
+	mgr.Start(context.TODO())
 }

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package recorder_test
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,9 +37,11 @@ import (
 
 var _ = Describe("recorder", func() {
 	var stop chan struct{}
+	var ctx context.Context
 
 	BeforeEach(func() {
 		stop = make(chan struct{})
+		ctx = context.Background()
 		Expect(cfg).NotTo(BeNil())
 	})
 
@@ -71,7 +75,7 @@ var _ = Describe("recorder", func() {
 			By("Starting the Manager")
 			go func() {
 				defer GinkgoRecover()
-				Expect(cm.Start(stop)).NotTo(HaveOccurred())
+				Expect(cm.Start(ctx)).NotTo(HaveOccurred())
 			}()
 
 			deployment := &appsv1.Deployment{

--- a/pkg/manager/example_test.go
+++ b/pkg/manager/example_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package manager_test
 
 import (
+	"context"
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
 var (
@@ -61,7 +61,7 @@ func ExampleManager_Add() {
 
 // This example starts a Manager that has had Runnables added.
 func ExampleManager_Start() {
-	err := mgr.Start(signals.SetupSignalHandler())
+	err := mgr.Start(context.TODO())
 	if err != nil {
 		log.Error(err, "unable start the manager")
 		os.Exit(1)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -52,7 +53,7 @@ type Manager interface {
 
 	// Start starts all registered Controllers and blocks until the Stop channel is closed.
 	// Returns an error if there is an error starting any controller.
-	Start(<-chan struct{}) error
+	Start(context.Context) error
 
 	// GetConfig returns an initialized Config
 	GetConfig() *rest.Config
@@ -204,6 +205,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		recorderProvider: recorderProvider,
 		resourceLock:     resourceLock,
 		mapper:           mapper,
+		stop:             make(chan struct{}),
 	}, nil
 }
 


### PR DESCRIPTION
This is backward-incompatible. The manager accepts Context instead of a stop
channel, which helps simplify cancellation workflow and is more in line with
the direction related projects are moving.

This pattern can be expanded in a similar way to controllers, the cache, and
so on if people like it.

fixes #103