### PR TITLE
pkg/client: Pass ctx to typedClient requests

### DIFF
--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -30,7 +30,7 @@ type typedClient struct {
 }
 
 // Create implements client.Client
-func (c *typedClient) Create(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) Create(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -39,12 +39,13 @@ func (c *typedClient) Create(_ context.Context, obj runtime.Object) error {
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // Update implements client.Client
-func (c *typedClient) Update(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) Update(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -54,12 +55,13 @@ func (c *typedClient) Update(_ context.Context, obj runtime.Object) error {
 		Resource(o.resource()).
 		Name(o.GetName()).
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // Delete implements client.Client
-func (c *typedClient) Delete(_ context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error {
+func (c *typedClient) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -71,12 +73,13 @@ func (c *typedClient) Delete(_ context.Context, obj runtime.Object, opts ...Dele
 		Resource(o.resource()).
 		Name(o.GetName()).
 		Body(deleteOpts.ApplyOptions(opts).AsDeleteOptions()).
+		Context(ctx).
 		Do().
 		Error()
 }
 
 // Get implements client.Client
-func (c *typedClient) Get(_ context.Context, key ObjectKey, obj runtime.Object) error {
+func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
 	r, err := c.cache.getResource(obj)
 	if err != nil {
 		return err
@@ -84,11 +87,12 @@ func (c *typedClient) Get(_ context.Context, key ObjectKey, obj runtime.Object) 
 	return r.Get().
 		NamespaceIfScoped(key.Namespace, r.isNamespaced()).
 		Resource(r.resource()).
+		Context(ctx).
 		Name(key.Name).Do().Into(obj)
 }
 
 // List implements client.Client
-func (c *typedClient) List(_ context.Context, opts *ListOptions, obj runtime.Object) error {
+func (c *typedClient) List(ctx context.Context, opts *ListOptions, obj runtime.Object) error {
 	r, err := c.cache.getResource(obj)
 	if err != nil {
 		return err
@@ -102,12 +106,13 @@ func (c *typedClient) List(_ context.Context, opts *ListOptions, obj runtime.Obj
 		Resource(r.resource()).
 		Body(obj).
 		VersionedParams(opts.AsListOptions(), c.paramCodec).
+		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // UpdateStatus used by StatusWriter to write status.
-func (c *typedClient) UpdateStatus(_ context.Context, obj runtime.Object) error {
+func (c *typedClient) UpdateStatus(ctx context.Context, obj runtime.Object) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -122,6 +127,7 @@ func (c *typedClient) UpdateStatus(_ context.Context, obj runtime.Object) error 
 		Name(o.GetName()).
 		SubResource("status").
 		Body(obj).
+		Context(ctx).
 		Do().
 		Into(obj)
 }


### PR DESCRIPTION
This change passes the context in the client methods to the underlying
object requests created using client-go's Request for `typedClient`.
Context isn't passed to the `unstructuredClient` because the
`dynamicResourceClient` in client-go doesn't accepts any context.

Fixes #40 