### PR TITLE
Rename InstallWebhookConfig and change it to a pointer

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -39,9 +39,9 @@ import (
 var log = logf.Log.WithName("example-controller")
 
 func main() {
-	var installWebhookConfig bool
-	flag.BoolVar(&installWebhookConfig, "install-webhook-config", false,
-		"enable the installer in the webhook server, so it will install webhook related resources during bootstrapping")
+	var disableWebhookConfigInstaller bool
+	flag.BoolVar(&disableWebhookConfigInstaller, "disable-webhook-config-installer", false,
+		"disable the installer in the webhook server, so it won't install webhook configuration resources during bootstrapping")
 
 	flag.Parse()
 	logf.SetLogger(logf.ZapLogger(false))
@@ -108,9 +108,9 @@ func main() {
 
 	entryLog.Info("setting up webhook server")
 	as, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
-		Port:                 9876,
-		CertDir:              "/tmp/cert",
-		InstallWebhookConfig: installWebhookConfig,
+		Port:    9876,
+		CertDir: "/tmp/cert",
+		DisableWebhookConfigInstaller: &disableWebhookConfigInstaller,
 		BootstrapOptions: &webhook.BootstrapOptions{
 			Secret: &apitypes.NamespacedName{
 				Namespace: "default",

--- a/pkg/webhook/bootstrap.go
+++ b/pkg/webhook/bootstrap.go
@@ -63,6 +63,10 @@ func (s *Server) setServerDefault() {
 	if len(s.CertDir) == 0 {
 		s.CertDir = path.Join("k8s-webhook-server", "cert")
 	}
+	if s.DisableWebhookConfigInstaller == nil {
+		diwc := false
+		s.DisableWebhookConfigInstaller = &diwc
+	}
 
 	if s.Client == nil {
 		cfg, err := config.GetConfig()


### PR DESCRIPTION
This PR changes an option introduced in #174.

We always install webhook config prior v0.1.5 releases.
We introduced an option `InstallWebhookConfig` recently and was released on Oct 25 in v0.1.5.

If `InstallWebhookConfig` is not an pointer, it will be defaulted to `false` by golang.
That means existing user who are upgrading from previous controller-runtime version will be break, because they expect webhook config installer to be on.
