### PR TITLE
Removes logic that checks for a "port already in use" error

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -18,10 +18,8 @@ package envtest
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -168,17 +166,6 @@ func (te *Environment) startControlPlane() error {
 		err := te.ControlPlane.Start()
 		if err == nil {
 			break
-		}
-		// code snippet copied from following answer on stackoverflow
-		// https://stackoverflow.com/questions/51151973/catching-bind-address-already-in-use-in-golang
-		if opErr, ok := err.(*net.OpError); ok {
-			if opErr.Op == "listen" && strings.Contains(opErr.Error(), "address already in use") {
-				if stopErr := te.ControlPlane.Stop(); stopErr != nil {
-					return fmt.Errorf("failed to stop controlplane in response to bind error 'address already in use'")
-				}
-			}
-		} else {
-			return err
 		}
 	}
 	if numTries == maxRetries {


### PR DESCRIPTION
Instead, retry on any error.

The "port already in use" error is only present in
the stderr logs of the separate process (etcd or apiserver) and will
not be surfaced in the go error.

Checking the stderr logs is an alternative solution, but it's
fragile (the message could change in the future and varies across
operating systems).