### PR TITLE
Use typed lists in cert writer tests

### DIFF
--- a/pkg/webhook/internal/cert/writer/secret_test.go
+++ b/pkg/webhook/internal/cert/writer/secret_test.go
@@ -17,14 +17,11 @@ limitations under the License.
 package writer
 
 import (
-	"encoding/json"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +35,6 @@ var _ = Describe("secretCertWriter", func() {
 	var certWriter CertWriter
 	var sCertWriter *secretCertWriter
 	var secret *corev1.Secret
-	var expectedSecret runtime.RawExtension
 
 	BeforeEach(func(done Done) {
 		var err error
@@ -111,15 +107,9 @@ var _ = Describe("secretCertWriter", func() {
 			It("should default it and return no error", func() {
 				_, _, err := certWriter.EnsureCert(dnsName)
 				Expect(err).NotTo(HaveOccurred())
-				list := &corev1.List{}
+				list := &corev1.SecretList{}
 				err = sCertWriter.Client.List(nil, &client.ListOptions{
 					Namespace: "namespace-bar",
-					Raw: &metav1.ListOptions{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "v1",
-							Kind:       "Secret",
-						},
-					},
 				}, list)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(list.Items).To(HaveLen(1))
@@ -127,27 +117,15 @@ var _ = Describe("secretCertWriter", func() {
 		})
 
 		Context("no existing secret", func() {
-			BeforeEach(func(done Done) {
-				j, _ := json.Marshal(secret)
-				expectedSecret = runtime.RawExtension{Raw: j}
-				close(done)
-			})
-
 			It("should create new secrets with certs", func() {
 				_, changed, err := certWriter.EnsureCert(dnsName)
 				Expect(err).NotTo(HaveOccurred())
-				list := &corev1.List{}
+				list := &corev1.SecretList{}
 				err = sCertWriter.Client.List(nil, &client.ListOptions{
 					Namespace: "namespace-bar",
-					Raw: &metav1.ListOptions{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: "v1",
-							Kind:       "Secret",
-						},
-					},
 				}, list)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(list.Items).To(ConsistOf(expectedSecret))
+				Expect(list.Items).To(ConsistOf(*secret))
 				Expect(list.Items).To(HaveLen(1))
 				Expect(changed).To(BeTrue())
 			})
@@ -157,12 +135,6 @@ var _ = Describe("secretCertWriter", func() {
 			var oldSecret *corev1.Secret
 
 			Context("cert is invalid", func() {
-				BeforeEach(func(done Done) {
-					j, _ := json.Marshal(secret)
-					expectedSecret = runtime.RawExtension{Raw: j}
-					close(done)
-				})
-
 				Describe("cert in secret is incomplete", func() {
 					BeforeEach(func(done Done) {
 						oldSecret = secret.DeepCopy()
@@ -174,18 +146,12 @@ var _ = Describe("secretCertWriter", func() {
 					It("should replace with new certs", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
+						list := &corev1.SecretList{}
 						err = sCertWriter.Client.List(nil, &client.ListOptions{
 							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
 						}, list)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(list.Items).To(ConsistOf(expectedSecret))
+						Expect(list.Items).To(ConsistOf(*secret))
 						Expect(list.Items).To(HaveLen(1))
 						Expect(changed).To(BeTrue())
 					})
@@ -207,18 +173,12 @@ var _ = Describe("secretCertWriter", func() {
 					It("should replace with new certs", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
+						list := &corev1.SecretList{}
 						err = sCertWriter.Client.List(nil, &client.ListOptions{
 							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
 						}, list)
 						Expect(err).NotTo(HaveOccurred())
-						Expect(list.Items).To(ConsistOf(expectedSecret))
+						Expect(list.Items).To(ConsistOf(*secret))
 						Expect(list.Items).To(HaveLen(1))
 						Expect(changed).To(BeTrue())
 					})
@@ -233,8 +193,6 @@ var _ = Describe("secretCertWriter", func() {
 						ServerKeyName:  []byte(certs2.Key),
 						ServerCertName: []byte(certs2.Cert),
 					}
-					j, _ := json.Marshal(oldSecret)
-					expectedSecret = runtime.RawExtension{Raw: j}
 					sCertWriter.Client = fake.NewFakeClient(oldSecret)
 					close(done)
 				})
@@ -248,8 +206,6 @@ var _ = Describe("secretCertWriter", func() {
 							ServerKeyName:  []byte(certs2.Key),
 							ServerCertName: []byte(certs2.Cert),
 						}
-						j, _ := json.Marshal(oldSecret)
-						expectedSecret = runtime.RawExtension{Raw: j}
 
 						sCertWriter.Client = fake.NewFakeClient(oldSecret)
 						close(done)
@@ -257,19 +213,13 @@ var _ = Describe("secretCertWriter", func() {
 					It("should keep the secret", func() {
 						_, changed, err := certWriter.EnsureCert(dnsName)
 						Expect(err).NotTo(HaveOccurred())
-						list := &corev1.List{}
+						list := &corev1.SecretList{}
 						err = sCertWriter.Client.List(nil, &client.ListOptions{
 							Namespace: "namespace-bar",
-							Raw: &metav1.ListOptions{
-								TypeMeta: metav1.TypeMeta{
-									APIVersion: "v1",
-									Kind:       "Secret",
-								},
-							},
 						}, list)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(list.Items).To(HaveLen(1))
-						Expect(list.Items[0]).To(Equal(expectedSecret))
+						Expect(list.Items[0]).To(Equal(*oldSecret))
 						Expect(changed).To(BeFalse())
 					})
 				})


### PR DESCRIPTION
Now that #213 is in, these tests can be updated to use typed lists instead of `corev1.List`. I find the tests are clearer without the use of `Raw` hacks.

@mengqiy I'm assuming the use of `corev1.List` and JSON marshaling was a workaround for the issue with the fake client fixed in #213, but I could be wrong about that. You can decide what style you prefer. :smile: