### PR TITLE
:running: Add default PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/breaking_change.md
@@ -1,9 +1,3 @@
----
-name: Breaking change (X)
-about: A breaking change to the API surface or expected behavior of this project. 
-
----
-
 <!-- please add a :warning: (`:warning:`) to the title of this PR, and delete this line and similar ones -->
 
 <!-- What does this do, and why do we need it? -->

--- a/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug_fix.md
@@ -1,9 +1,3 @@
----
-name: Bug fix (Z)
-about: A bug fix that doesn't otherwise change API surface
-
----
-
 <!-- please add a :bug: (`:bug:`) to the title of this PR, and delete this line and similar ones -->
 
 <!-- What does this do, and why do we need it? -->

--- a/.github/PULL_REQUEST_TEMPLATE/compat_feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/compat_feature.md
@@ -1,9 +1,3 @@
----
-name: Backwards-compatible feature (Y)
-about: A new feature that adds to the API surface or behavior, but doesn't break backwards compatibility
-
----
-
 <!-- please add a :sparkles: (`:sparkles:`) to the title of this PR, and delete this line and similar ones -->
 
 <!-- What does this do, and why do we need it? -->

--- a/.github/PULL_REQUEST_TEMPLATE/docs.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs.md
@@ -1,9 +1,3 @@
----
-name: Documentation
-about: A change to the documentation of this repository
-
----
-
 <!-- please add a :book: (`:book:`) to the title of this PR, and delete this line and similar ones -->
 
 <!-- What docs does this change, and why? -->

--- a/.github/PULL_REQUEST_TEMPLATE/other.md
+++ b/.github/PULL_REQUEST_TEMPLATE/other.md
@@ -1,9 +1,3 @@
----
-name: Tests/Infra/Other
-about: A change to the tests in this repo, the utilities scripts, or some other piece of infrastructure tooling
-
----
-
 <!-- please add a :running: (`:running:`) to the title of this PR, and delete this line and similar ones -->
 
 <!-- What does this do, and why do we need it? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
+<!-- the icon will be either :warning: (major), :sparkles: (minor), :bug: (patch), :book: (docs), or :running: (other) -->
+
+<!-- What does this do, and why do we need it? -->

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Contributors:
 
 - All code PR must be labeled with :bug: (patch fixes), :sparkles: (backwards-compatible features), or :warning: (breaking changes)
 - Breaking changes will find their way into the next major release, other changes will go into an semi-immediate patch or minor release
+- For a quick PR template suggesting the right information, use one of these PR templates:
+  * [Breaking Changes/Features](/.github/PULL_REQUEST_TEMPLATE/breaking_change.md)
+  * [Backwards-Compatible Features](/.github/PULL_REQUEST_TEMPLATE/compat_feature.md)
+  * [Bug fixes](/.github/PULL_REQUEST_TEMPLATE/bug_fix.md)
+  * [Documentation Changes](/.github/PULL_REQUEST_TEMPLATE/docs.md)
+  * [Test/Build/Other Changes](/.github/PULL_REQUEST_TEMPLATE/other.md)
 
 ## Community, discussion, contribution, and support
 


### PR DESCRIPTION
The template picker only works for issues, but you can still have
multiple PR templates that can be used with a query parameter, but
that's kind-of unweildy.  We'll have the default PR template, and keep
the separate ones around linked-to from the readme as examples.