### PR TITLE
[WIP] :running: External k8s.io References Checker

### DIFF
--- a/hack/external-objects/README.md
+++ b/hack/external-objects/README.md
@@ -1,0 +1,34 @@
+External Imports Checker
+========================
+
+This tool knows how to check for external imports, to make sure that we
+don't accidentally break ourselves because of Kubernetes.  It's also
+a general framework for doing this kind of thing, so it could be adapted
+to general type signature checking, etc.
+
+Usage
+-----
+
+### Printing all external references
+
+This will print out all external references, plus their type signatures
+(non-exported parts excluded on structs).  You can diff this against the
+output from a previous commit to check for differences.
+
+```bash
+$ go run ./*.go --root ../.. find
+```
+
+### Investigating a new reference
+
+This will print out the "top-level" objects (functions, interfaces,
+variables, etc) that eventually reference the given external type, as well
+as the intermediate types to get there.
+
+For instance, if controller-runtime method `Foo` references external
+struct `Bar` that includes the target type `Baz`, it'll show the chain
+from `Foo` to `Bar` to `Baz`.
+
+```bash
+$ go run ./*.go --root ../.. what-refs "k8s.io/some/other/package#SomeType"
+```

--- a/hack/external-objects/filter/env.go
+++ b/hack/external-objects/filter/env.go
@@ -1,0 +1,60 @@
+package filter
+
+import (
+	"path"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+)
+
+// PackageInfoResolver knows how to resolve package info for a
+// particular path.
+type PackageInfoResolver interface {
+	// PackageInfoFor resolves the package information for the
+	// given package path (can be a filesystem path) retrieved
+	// from a types.Package object imported by the source of this
+	// resolver.  It may return nil for paths from other sources.
+	PackageInfoFor(path string) *locate.PackageInfo
+
+	// FetchPackageInfoFor resolves the package information for the
+	// the given path (like PackageInfoFor), but may also attempt to
+	// load basic package info if the given package info hasn't been
+	// cached.
+	FetchPackageInfoFor(path string) (*locate.PackageInfo, error)
+}
+
+// FilterEnvironment represents commonly required information for executing filters
+type FilterEnvironment struct {
+	// RootPackage is the base package to which all filtered packages and objects belong
+	RootPackage *locate.PackageInfo
+
+	// Loader can be used to locate import path information
+	Loader PackageInfoResolver
+	
+	// VendorImportPrefix is the import path prefix
+	// for the vendor directory (including the root package).
+	// If empty, it will be ignored.
+	VendorImportPrefix string
+}
+
+func NewFilterEnvironment(rootPackage *locate.PackageInfo, loader PackageInfoResolver, isProject bool) *FilterEnvironment {
+	vendorPrefix := ""
+	if isProject {
+		vendorPrefix = path.Join(rootPackage.BuildInfo.ImportPath, "vendor") + "/"
+	}
+
+	return &FilterEnvironment{
+		RootPackage: rootPackage,
+		Loader: loader,
+		VendorImportPrefix: vendorPrefix,
+	}
+}
+
+// StripVendor strips the vendor prefix from the given path, if set and applicable.
+func (e *FilterEnvironment) StripVendor(importPath string) string {
+	if e.VendorImportPrefix != "" {
+		return strings.TrimPrefix(importPath, e.VendorImportPrefix)
+	}
+
+	return importPath
+}

--- a/hack/external-objects/filter/external.go
+++ b/hack/external-objects/filter/external.go
@@ -1,0 +1,76 @@
+package filter
+
+import (
+	"go/types"
+	"strings"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/process"
+)
+
+// FindExternalReferences returns all external references in the
+// type signature of the given object, and all referenced types,
+// in public types/fields/etc.
+func FindExternalReferences(obj types.Object, env *FilterEnvironment) []*types.TypeName {
+	externalRefsRaw := process.FilterMapTypesInObject(obj, ExternalReferencesFilter(env))
+	externalRefs := make([]*types.TypeName, len(externalRefsRaw))
+	for i, ref := range externalRefsRaw {
+		externalRefs[i] = ref.(*types.TypeName)
+	}
+
+	return externalRefs
+}
+
+// ExternalReferencesFind returns a FilterMapFunc that finds all references to packages outside
+// the given "root" package (and subpackages).  The returned objects are *types.TypeName objects.
+// The loader is used to figure out actual import paths for packages.
+func ExternalReferencesFilter(env *FilterEnvironment) process.FilterMapFunc {
+	return func(typ types.Type) interface{} {
+		if typ == nil {
+			// we don't care about the end of a given type
+			return nil
+		}
+		ref := GetExternalReference(env, typ)
+		// avoid a present-but-nil-valued interface{} object
+		if ref == nil {
+			return nil
+		}
+		return ref
+	}
+}
+
+// GetExternalReference checks the given type to see if it's a named type, and if so,
+// if that name refers to a package outside the given root package's package hierarchy.
+// If so, it returns that name, otherwise returning nil.  The given file loader is used
+// to produce actual import paths for any type (since the package info might have relative
+// filesystem paths, depending on where we're called from).  Packages in the GoRoot
+// (the Go standard library) are skipped.
+func GetExternalReference(env *FilterEnvironment, typ types.Type) *types.TypeName {
+	namedType, isNamedType := typ.(*types.Named)
+	if !isNamedType {
+		return nil
+	}
+
+	typeName := namedType.Obj()
+
+	if typeName.Pkg() == nil {
+		// a built-in type like "error"
+		return nil
+	}
+
+	packageInfo, err := env.Loader.FetchPackageInfoFor(typeName.Pkg().Path())
+	if err != nil {
+		panic(fmt.Sprintf("unknown package %s while proccessing %s: %v", typeName.Pkg().Path(), typ, err))
+		return nil
+	}
+	if packageInfo.BuildInfo.Goroot {
+		// skip builtins
+		return nil
+	}
+	actualPackagePath := env.StripVendor(packageInfo.BuildInfo.ImportPath)
+	if strings.HasPrefix(actualPackagePath, env.RootPackage.BuildInfo.ImportPath) {
+		return nil
+	}
+
+	return typeName
+}

--- a/hack/external-objects/findall.go
+++ b/hack/external-objects/findall.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/types"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/filter"
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+)
+
+var (
+	useSignatures = flag.Bool("with-sig", true, "print public type signatures when finding all references")
+)
+
+func findAll(loader *locate.FileLoader, allExternalRefs refsMap, filterEnv *filter.FilterEnvironment) {
+	// sort by package name, then type name
+	sortedRefs := make([]*types.TypeName, 0, len(allExternalRefs))
+	for ref := range allExternalRefs {
+		sortedRefs = append(sortedRefs, ref)
+	}
+	sort.Slice(sortedRefs, func(i, j int) bool {
+		refI := sortedRefs[i]
+		refJ := sortedRefs[j]
+		pkgInfoI := loader.PackageInfoFor(refI.Pkg().Path())
+		pkgInfoJ := loader.PackageInfoFor(refJ.Pkg().Path())
+		if pkgInfoI.BuildInfo.ImportPath == pkgInfoJ.BuildInfo.ImportPath {
+			return refI.Name() < refJ.Name()
+		}
+
+		return pkgInfoI.BuildInfo.ImportPath < pkgInfoJ.BuildInfo.ImportPath
+	})
+
+	// print all the sorted, deduped external types
+	for _, ref := range sortedRefs {
+		pkgInfo := loader.PackageInfoFor(ref.Pkg().Path())
+		importPath := filterEnv.StripVendor(pkgInfo.BuildInfo.ImportPath)
+		if *skipNonKube && !strings.HasPrefix(importPath, "k8s.io/") {
+			continue
+		}
+		fmt.Printf("%q.%s", importPath, ref.Name())
+		if *useSignatures {
+			fmt.Printf(" -- %s", typeSig(ref.Type().Underlying()))
+		}
+		fmt.Printf("\n")
+	}
+}
+
+func typeSig(ref types.Type) string {
+	// like types.TypeString, but only exported fields for structs (and no struct tags)
+	switch typ := ref.(type) {
+	case *types.Struct:
+		var buff bytes.Buffer
+		buff.WriteString("struct{")
+		for i := 0; i < typ.NumFields(); i++ {
+			field := typ.Field(i)
+			if !field.Embedded() && !ast.IsExported(field.Name()) {
+				continue
+			}
+			if i > 0 {
+				buff.WriteString("; ")
+			}
+			if !field.Embedded() {
+				if !ast.IsExported(field.Name()) {
+					continue
+				}
+				buff.WriteString(field.Name())
+				buff.WriteByte(' ')
+			}
+			buff.WriteString(typeSig(field.Type()))
+		}
+		buff.WriteString("}")
+		return buff.String()
+	default:
+		return ref.String()
+	}
+
+}

--- a/hack/external-objects/locate/import.go
+++ b/hack/external-objects/locate/import.go
@@ -1,0 +1,186 @@
+package locate
+
+import (
+	"sync"
+	"path/filepath"
+	"fmt"
+
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"go/build"
+	"go/types"
+	"go/importer"
+
+	"github.com/go-logr/logr"
+)
+
+type PackageInfo struct {
+	BuildInfo *build.Package
+	Parsed *types.Package
+}
+
+// FileLoader knows loads normal Go files from a package,
+// or from stdin, and turns them into file ASTs, feeding those
+// into a channel for later use.
+type FileLoader struct {
+	fset *token.FileSet
+	packages map[string]*PackageInfo
+
+	mainImporter types.ImporterFrom
+	cwd string
+
+	log logr.Logger
+}
+
+func NewLoader(cwd string, log logr.Logger) *FileLoader {
+	return &FileLoader{
+		fset: token.NewFileSet(),
+		packages: make(map[string]*PackageInfo),
+		mainImporter: importer.For("gc", nil).(types.ImporterFrom),
+		cwd: cwd,
+		log: log.WithName("loader"),
+	}
+}
+
+func (l *FileLoader) FileSet() *token.FileSet {
+	return l.fset
+}
+
+// parse parses the given file source with the given name,
+// returning a file AST.  parse may be called concurrently
+func (l *FileLoader) parse(filename string, src interface{}) (*ast.File, error) {
+	return parser.ParseFile(l.fset, filename, src, 0) // ok to access fset concurrently
+}
+
+// getPackageFiles gets the list of files belonging to a single package
+func (l *FileLoader) getFilesFromPackage(path string) ([]*ast.File, error) {
+	ctxt := build.Default
+	packageInfo, err := ctxt.ImportDir(path, 0)
+	if _, noGoPresent := err.(*build.NoGoError); err != nil && !noGoPresent {
+		// try the main importer (builtins, etc)
+		return nil, err
+	}
+
+	files := make([]*ast.File, len(packageInfo.GoFiles))
+	errors := make([]error, len(packageInfo.GoFiles))
+
+	var wg sync.WaitGroup
+	for i, filename := range packageInfo.GoFiles {
+		wg.Add(1)
+		go func(i int, filepath string) {
+			defer wg.Done()
+			files[i], errors[i] = l.parse(filepath, nil)
+		}(i, filepath.Join(path, filename))
+	}
+	wg.Wait()
+
+	// if there are errors, return the first one for deterministic results
+	for _, err := range errors {
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return files, nil
+}
+
+func (l *FileLoader) Import(path string) (*types.Package, error) {
+	return l.ImportFrom(path, "", 0)
+}
+
+// Import implements types.Importer
+func (l *FileLoader) ImportFrom(path, dir string, mode types.ImportMode) (*types.Package, error) {
+	// TODO(directxman12): we probably need the key to be {dir,path}, not just path
+	pkg, present := l.packages[path]
+	if present {
+		if pkg == nil {
+			return nil, fmt.Errorf("cycle on package %q", path)
+		}
+
+		return pkg.Parsed, nil
+	}
+
+	var parsedPkg *types.Package
+
+	buildInfo, err := build.Default.Import(path, filepath.Join(l.cwd, dir), build.FindOnly)
+	if err != nil {
+		return nil, err
+	}
+	if buildInfo.Goroot {
+		l.log.V(1).Info("falling back to built-in importer for builtin package", "package path", path)
+		parsedPkg, err = l.mainImporter.ImportFrom(path, dir, mode)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// cache built-ins, too
+	if parsedPkg != nil {
+		l.packages[path] = &PackageInfo{
+			BuildInfo: buildInfo,
+			Parsed: parsedPkg,
+		}
+		return parsedPkg, nil
+	}
+
+	l.packages[path] = nil  // put an explicit placeholder in order to detect loops
+
+	// TODO: deal with if dir is ""
+	files, err := l.getFilesFromPackage(buildInfo.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	conf := types.Config{
+		IgnoreFuncBodies: true,
+		FakeImportC:      true,
+		Importer:         l,
+	}
+	parsedPkg, err = conf.Check(path, l.fset, files, nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to typecheck package %q: %v", path, err)
+	}
+
+	// actually set the cache
+	l.packages[path] = &PackageInfo{
+		BuildInfo: buildInfo,
+		Parsed: parsedPkg,
+	}
+
+	return parsedPkg, nil
+}
+
+// Packages returns all packages known to this FileLoader.
+func (l *FileLoader) Packages() []*PackageInfo {
+	pkgs := make([]*PackageInfo, 0, len(l.packages))
+
+	for _, pkg := range l.packages {
+		pkgs = append(pkgs, pkg)
+	}
+
+	return pkgs
+}
+
+// PackageInfoFor returns the computed package information for the given package.
+func (l *FileLoader) PackageInfoFor(pkg string) *PackageInfo {
+	return l.packages[pkg]
+}
+
+// FetchPackageInfoFor returns the computed package information for the given package,
+// or loads and saves basic information if not found (returning an error if do so failed).
+func (l *FileLoader) FetchPackageInfoFor(pkg string) (*PackageInfo, error) {
+	info, ok := l.packages[pkg]
+	if !ok {
+		buildInfo, err := build.Default.Import(pkg, l.cwd, build.FindOnly)
+		if err != nil {
+			return nil, err
+		}
+		info = &PackageInfo{
+			BuildInfo: buildInfo,
+		}
+		l.packages[pkg] = info
+	}
+
+	return info, nil
+}

--- a/hack/external-objects/locate/match.go
+++ b/hack/external-objects/locate/match.go
@@ -1,0 +1,44 @@
+package locate
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// TODO: convert this to just use the code from the Go builtins,
+// to get full `...` matching.  See cmd/go/internal/search/search.go
+
+// ImportProject imports the contents of a entire project, assuming
+// the project is structured in the standard Kubernetes-style fashion,
+// with code under `pkg`.  It returns whether or not this seemed to be
+// a "project" like that, as well as any errors.  It can also be forced
+// to ignore the lack of a pkg directory, and treat all subdirectories
+// as packages (in which case it always treats paths as a "project").
+func ImportProject(loader *FileLoader, projectPath string, force bool) (bool, error) {
+	startPath := projectPath
+	if !force {
+		startPath = filepath.Join(projectPath, "pkg")
+		if pathInfo, err := os.Stat(startPath); err != nil || !pathInfo.IsDir() {
+			if err == nil || os.IsNotExist(err) {
+				return false, nil
+			}
+			return false, err
+		}
+	}
+
+	return true, filepath.Walk(startPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if !info.IsDir() {
+			// if SkipDir is returned on a non-directory, Walk skips the rest of the files
+			// in the current directory.  We don't care about files, so we want to skip
+			// them.
+			return filepath.SkipDir
+		}
+
+		_, err = loader.Import(path)
+		return err
+	})
+}

--- a/hack/external-objects/main.go
+++ b/hack/external-objects/main.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/types"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/filter"
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+	"sigs.k8s.io/controller-runtime/hack/external-objects/process"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	forceTraverse = flag.Bool("f", false, "force traversing subdirectories when passed a path that doesn't look like a full project")
+	skipNonKube   = flag.Bool("skip-non-k8s", true, "skip printing non-k8s.io external types")
+	rootPath      = flag.String("root", ".", "root package path")
+	log           = logf.Log.WithName("main")
+)
+
+type refsMap map[*types.TypeName][]types.Object
+
+func main() {
+	flag.Parse()
+	logf.SetLogger(logf.ZapLogger(true))
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n%s (find|what-refs package#Name[ package#Name...]) [flags]\n", os.Args[0], os.Args[0])
+		flag.PrintDefaults()
+	}
+
+	if flag.NArg() < 1 {
+		fmt.Fprintf(flag.CommandLine.Output(), "must specify a command")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	cmd := flag.Arg(0)
+	otherArgs := flag.Args()[1:]
+
+	loader, isProject := setupLoader()
+	allExternalRefs, filterEnv := getExternalRefs(loader, isProject)
+
+	switch cmd {
+	case "what-refs":
+		whatRefs(loader, allExternalRefs, filterEnv, otherArgs)
+	case "find":
+		findAll(loader, allExternalRefs, filterEnv)
+	default:
+		fmt.Fprintf(flag.CommandLine.Output(), "unknown command %s\n", cmd)
+		flag.Usage()
+		os.Exit(1)
+	}
+}
+
+func setupLoader() (*locate.FileLoader, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Error(err, "can't figure out the current working directory")
+		os.Exit(1)
+	}
+	loader := locate.NewLoader(cwd, log)
+
+	// import the root package and all subpackages
+	isProject, err := locate.ImportProject(loader, *rootPath, *forceTraverse)
+	if err != nil {
+		log.Error(err, "unable to import path", "is project", isProject)
+		os.Exit(1)
+	}
+
+	// fall back to just the given package if needed (if we already loaded
+	// the project, this does nothing)
+	_, err = loader.Import(*rootPath)
+	if err != nil {
+		log.Error(err, "unable to import package")
+		os.Exit(1)
+	}
+	log.V(1).Info("finished loading packages", "package path", *rootPath, "is project", isProject)
+
+	return loader, isProject
+}
+
+func getExternalRefs(loader *locate.FileLoader, isProject bool) (refsMap, *filter.FilterEnvironment) {
+	// set up the info we need to actually do the filtering
+	projectPackage := loader.PackageInfoFor(*rootPath)
+	filterEnv := filter.NewFilterEnvironment(projectPackage, loader, isProject)
+
+	allExternalRefs := map[*types.TypeName][]types.Object{}
+
+	// find all type-referencingObject pairs
+	for _, pkg := range process.OwnedPackages(loader.Packages(), projectPackage.BuildInfo.ImportPath, isProject) {
+		log := log.WithValues("import path", pkg.BuildInfo.ImportPath)
+		log.V(1).Info("considering package")
+
+		// for all objects in each of those
+		for _, obj := range process.AllObjects(pkg) {
+			// find the external references
+			externalRefs := filter.FindExternalReferences(obj, filterEnv)
+			if len(externalRefs) == 0 {
+				continue
+			}
+			log := log.WithValues("object", obj)
+			for _, ref := range externalRefs {
+				// and add them to the set
+				pkgInfo := loader.PackageInfoFor(ref.Pkg().Path())
+				pkgPath := filterEnv.StripVendor(pkgInfo.BuildInfo.ImportPath)
+				log.V(1).Info("external reference found", "package", pkgPath)
+				allExternalRefs[ref] = append(allExternalRefs[ref], obj)
+			}
+		}
+	}
+
+	return allExternalRefs, filterEnv
+}

--- a/hack/external-objects/process/packages.go
+++ b/hack/external-objects/process/packages.go
@@ -1,0 +1,25 @@
+package process
+
+import (
+	"strings"
+	"path"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+)
+
+// OwnedPackages returns all packages whose names match the given prefix.
+func OwnedPackages(allPackages []*locate.PackageInfo, prefix string, skipVendor bool) []*locate.PackageInfo {
+	vendorPath := path.Join(prefix, "vendor")
+	var owned []*locate.PackageInfo
+	for _, pkg := range allPackages {
+		if pkg.BuildInfo.Goroot || !strings.HasPrefix(pkg.BuildInfo.ImportPath, prefix) {
+			continue
+		}
+		if skipVendor && strings.HasPrefix(pkg.BuildInfo.ImportPath, vendorPath) {
+			continue
+		}
+		owned = append(owned, pkg)
+	}
+
+	return owned
+}

--- a/hack/external-objects/process/signatures.go
+++ b/hack/external-objects/process/signatures.go
@@ -1,0 +1,138 @@
+package process
+
+import (
+	"go/ast"
+	"go/types"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+)
+
+// AllObjects returns all top-level exported objects
+// (variables, types, functions) for the given package.
+func AllObjects(pkg *locate.PackageInfo) []types.Object {
+	var exported []types.Object
+	scope := pkg.Parsed.Scope()
+	for _, name := range scope.Names() {
+		// we don't care about private things
+		if !ast.IsExported(name) {
+			continue
+		}
+
+		exported = append(exported, scope.Lookup(name))
+	}
+
+	return exported
+}
+
+// FilterMapFunc takes in a Type, and returns either nil to not return any results,
+// or some other results.
+type FilterMapFunc func(types.Type) interface{}
+
+// filterMapper knows how to filter-map-visit types and all referenced types
+// in exported locations (fields, signatures, etc), avoiding cycles from
+// self-referential types.
+type filterMapper struct {
+	typeCache map[types.Type]struct{}
+	results []interface{}
+}
+
+// FilterMapTypesInObject calls FilterMapType on the type signature of the given object.
+func FilterMapTypesInObject(obj types.Object, filterMap FilterMapFunc) []interface{} {
+	return FilterMapType(obj.Type(), filterMap)
+}
+
+// FilterMapType calls the given function on all types in the given type signature
+// and types referenced in exported locations thereof. If the function returns a
+// non-nil result, that result is saved for the eventual return value.
+// It will automatically visit types within a given signature.  In case type hierarchy or paths
+// are desired, it will call filterMap with nil when a given is done being processed.
+func FilterMapType(typ types.Type, filterMap FilterMapFunc) []interface{} {
+	mapper := &filterMapper{
+		typeCache: make(map[types.Type]struct{}),
+	}
+
+	mapper.filterMap(typ, filterMap)
+
+	return mapper.results
+}
+
+// filterMap calls the given function on all types in the given type signature
+// If the function returns a non-nil result, that result is saved for the eventual return value.
+// It will automatically visit types within a given signature.  It will automatically detect cycles.
+func (m *filterMapper) filterMap(rawType types.Type, filterMap FilterMapFunc) {
+	rawTypeDesc := rawType.String()
+	rawTypeDesc += "+"
+	// check for cycles...
+	if _, seen := m.typeCache[rawType]; seen {
+		return
+	}
+	// ...and avoid them
+	m.typeCache[rawType] = struct{}{}
+
+	rootRes := filterMap(rawType)
+	if rootRes != nil {
+		m.results = append(m.results, rootRes)
+	}
+
+	switch typ := rawType.(type) {
+	case *types.Basic:
+		// do nothing, it's a basic type (e.g. int, string, etc)
+	case *types.Array:
+		m.filterMap(typ.Elem(), filterMap)
+	case *types.Slice:
+		m.filterMap(typ.Elem(), filterMap)
+	case *types.Struct:
+		for i := 0; i < typ.NumFields(); i++ {
+			field := typ.Field(i)
+			if !ast.IsExported(field.Name()) {
+				continue
+			}
+			m.filterMap(field.Type(), filterMap)
+		}
+	case *types.Pointer:
+		m.filterMap(typ.Elem(), filterMap)
+	case *types.Tuple:
+		for i := 0; i < typ.Len(); i++ {
+			m.filterMap(typ.At(i).Type(), filterMap)
+		}
+	case *types.Signature:
+		m.filterMap(typ.Params(), filterMap)
+		if typ.Recv() != nil {
+			m.filterMap(typ.Recv().Type(), filterMap)
+		}
+		m.filterMap(typ.Results(), filterMap)
+	case *types.Interface:
+		for i := 0; i < typ.NumExplicitMethods(); i++ {
+			meth := typ.ExplicitMethod(i)
+			if !ast.IsExported(meth.Name()) {
+				// private methods are package-only anyway,
+				// so we don't need to care too much here
+				// if we're just looking for breakage.
+				continue
+			}
+			m.filterMap(meth.Type(), filterMap)
+		}
+		for i := 0; i < typ.NumEmbeddeds(); i++ {
+			m.filterMap(typ.EmbeddedType(i), filterMap)
+		}
+	case *types.Map:
+		m.filterMap(typ.Key(), filterMap)
+		m.filterMap(typ.Elem(), filterMap)
+	case *types.Chan:
+		m.filterMap(typ.Elem(), filterMap)
+	case *types.Named:
+		if ast.IsExported(typ.Obj().Name()) {
+			m.filterMap(typ.Underlying(), filterMap)
+		}
+	default:
+		panic(fmt.Sprintf("unknown type %#v", rawType))
+	}
+
+	// indicate that we're done
+	endRes := filterMap(nil)
+	if endRes != nil {
+		m.results = append(m.results, endRes)
+	}
+		
+}

--- a/hack/external-objects/whatrefs.go
+++ b/hack/external-objects/whatrefs.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/types"
+	"os"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/hack/external-objects/filter"
+	"sigs.k8s.io/controller-runtime/hack/external-objects/locate"
+	"sigs.k8s.io/controller-runtime/hack/external-objects/process"
+)
+
+type typeIdent struct {
+	path, name string
+}
+
+func whatRefs(loader *locate.FileLoader, allExternalRefs refsMap, filterEnv *filter.FilterEnvironment, namesToFind []string) {
+	typesToFind := make(map[typeIdent]struct{}, len(namesToFind))
+	for _, name := range namesToFind {
+		nameParts := strings.Split(name, "#")
+		if len(nameParts) != 2 {
+			fmt.Fprintf(flag.CommandLine.Output(), "invalid type %s\n", name)
+			flag.Usage()
+			os.Exit(1)
+		}
+		typesToFind[typeIdent{name: nameParts[1], path: nameParts[0]}] = struct{}{}
+	}
+
+	for ref, sourceObjects := range allExternalRefs {
+		pkgInfo := loader.PackageInfoFor(ref.Pkg().Path())
+		ident := typeIdent{
+			name: ref.Name(),
+			path: filterEnv.StripVendor(pkgInfo.BuildInfo.ImportPath),
+		}
+		if _, isRelevant := typesToFind[ident]; !isRelevant {
+			continue
+		}
+		fmt.Printf("\nexternal reference %q.%s\n", pkgInfo.BuildInfo.ImportPath, ref.Name())
+		for _, sourceObject := range sourceObjects {
+			fmt.Printf("\n  from %s\n    via ", sourceObject)
+			v := &typePathRecorder{
+				target: ref,
+			}
+			process.FilterMapTypesInObject(sourceObject, v.Record)
+			for _, typ := range v.typeStack {
+				fmt.Printf("%s\n        ", typ)
+			}
+		}
+	}
+}
+
+type typePathRecorder struct {
+	typeStack []types.Type
+	done      bool
+	target    *types.TypeName
+}
+
+func (s *typePathRecorder) Record(typ types.Type) interface{} {
+	if s.done {
+		return nil
+	}
+
+	if typ == nil {
+		s.typeStack = s.typeStack[:len(s.typeStack)-1]
+		return nil
+	}
+
+	if namedType, isNamedType := typ.(*types.Named); isNamedType && namedType.Obj() == s.target {
+		s.done = true
+		return nil
+	}
+
+	s.typeStack = append(s.typeStack, typ)
+
+	return nil
+}


### PR DESCRIPTION
This introduces a tool for checking all our external references to
Kubernetes in our public API surface, so that we can make sure we don't
accidentally break people in an update due to changing Kubernetes API
surface.