### PR TITLE
:sparkles: add metrics for webhooks

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -108,8 +108,8 @@ func main() {
 
 	entryLog.Info("setting up webhook server")
 	as, err := webhook.NewServer("foo-admission-server", mgr, webhook.ServerOptions{
-		Port:    9876,
-		CertDir: "/tmp/cert",
+		Port:                          9876,
+		CertDir:                       "/tmp/cert",
 		DisableWebhookConfigInstaller: &disableWebhookConfigInstaller,
 		BootstrapOptions: &webhook.BootstrapOptions{
 			Secret: &apitypes.NamespacedName{

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -134,7 +134,7 @@ var _ = Describe("admission webhook http handler", func() {
 			Type:     types.WebhookTypeValidating,
 			Handlers: []Handler{h},
 		}
-		expected := []byte(`{"response":{"uid":"","allowed":true}}
+		expected := []byte(`{"response":{"uid":"","allowed":true,"status":{"metadata":{},"code":200}}}
 `)
 		It("should return a response successfully", func() {
 			wh.ServeHTTP(w, req)

--- a/pkg/webhook/admission/webhook_test.go
+++ b/pkg/webhook/admission/webhook_test.go
@@ -83,7 +83,7 @@ var _ = Describe("admission webhook", func() {
 			})
 
 			It("should deny the request", func() {
-				expected := []byte(`{"response":{"uid":"","allowed":false}}
+				expected := []byte(`{"response":{"uid":"","allowed":false,"status":{"metadata":{},"code":200}}}
 `)
 				wh.ServeHTTP(w, req)
 				Expect(w.Body.Bytes()).To(Equal(expected))
@@ -102,7 +102,7 @@ var _ = Describe("admission webhook", func() {
 			})
 
 			It("should deny the request", func() {
-				expected := []byte(`{"response":{"uid":"","allowed":false}}
+				expected := []byte(`{"response":{"uid":"","allowed":false,"status":{"metadata":{},"code":200}}}
 `)
 				wh.ServeHTTP(w, req)
 				Expect(w.Body.Bytes()).To(Equal(expected))
@@ -162,7 +162,8 @@ var _ = Describe("admission webhook", func() {
 				Handlers: []Handler{patcher1, patcher2},
 			}
 			expected := []byte(
-				`{"response":{"uid":"","allowed":true,"patch":"W3sib3AiOiJhZGQiLCJwYXRoIjoiL21ldGFkYXRhL2Fubm90YXRpb2` +
+				`{"response":{"uid":"","allowed":true,"status":{"metadata":{},"code":200},` +
+					`"patch":"W3sib3AiOiJhZGQiLCJwYXRoIjoiL21ldGFkYXRhL2Fubm90YXRpb2` +
 					`4vbmV3LWtleSIsInZhbHVlIjoibmV3LXZhbHVlIn0seyJvcCI6InJlcGxhY2UiLCJwYXRoIjoiL3NwZWMvcmVwbGljYXMiLC` +
 					`J2YWx1ZSI6IjIifSx7Im9wIjoiYWRkIiwicGF0aCI6Ii9tZXRhZGF0YS9hbm5vdGF0aW9uL2hlbGxvIiwidmFsdWUiOiJ3b3JsZCJ9XQ==",` +
 					`"patchType":"JSONPatch"}}
@@ -213,7 +214,7 @@ var _ = Describe("admission webhook", func() {
 				Type:     types.WebhookTypeMutating,
 				Handlers: []Handler{errPatcher},
 			}
-			expected := []byte(`{"response":{"uid":"","allowed":false}}
+			expected := []byte(`{"response":{"uid":"","allowed":false,"status":{"metadata":{},"code":200}}}
 `)
 			It("should deny the request", func() {
 				wh.ServeHTTP(w, req)

--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// TotalRequests is a prometheus metric which counts the total number of requests that
+	// the webhook server has received.
+	TotalRequests = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "controller_runtime_webhook_requests_total",
+			Help: "Total number of admission requests",
+		},
+		[]string{"webhook", "succeeded"},
+	)
+
+	// RequestLatency is a prometheus metric which is a histogram of the latency
+	// of processing admission requests.
+	RequestLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "controller_runtime_webhook_latency_seconds",
+			Help: "Histogram of the latency of processing admission requests",
+		},
+		[]string{"webhook"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		TotalRequests,
+		RequestLatency)
+}


### PR DESCRIPTION
Add 2 metrics for webhook:
- Number of total requests
- Latency of processing admission requests
