### PR TITLE
⚠️ Implement Patch method

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -928,6 +928,7 @@
   input-imports = [
     "github.com/appscode/jsonpatch",
     "github.com/emicklei/go-restful",
+    "github.com/evanphx/json-patch",
     "github.com/ghodss/yaml",
     "github.com/go-logr/logr",
     "github.com/go-logr/logr/testing",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -130,6 +130,15 @@ func (c *client) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteO
 	return c.typedClient.Delete(ctx, obj, opts...)
 }
 
+// Patch implements client.Client
+func (c *client) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOptionFunc) error {
+	_, ok := obj.(*unstructured.Unstructured)
+	if ok {
+		return c.unstructuredClient.Patch(ctx, obj, patch, opts...)
+	}
+	return c.typedClient.Patch(ctx, obj, patch, opts...)
+}
+
 // Get implements client.Client
 func (c *client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
 	_, ok := obj.(*unstructured.Unstructured)

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package fake
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
@@ -204,6 +206,30 @@ var _ = Describe("Fake client", func() {
 				Expect(err).To(BeNil())
 				Expect(obj).To(Equal(cm))
 			})
+		})
+
+		It("should be able to Patch", func() {
+			By("Patching a deployment")
+			mergePatch, err := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = cl.Patch(nil, dep, client.ConstantPatch(types.JSONPatchType, mergePatch))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the patched deployment")
+			namespacedName := types.NamespacedName{
+				Name:      "test-deployment",
+				Namespace: "ns1",
+			}
+			obj := &appsv1.Deployment{}
+			err = cl.Get(nil, namespacedName, obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Annotations["foo"]).To(Equal("bar"))
 		})
 	}
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Fake client", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			err = cl.Patch(nil, dep, client.ConstantPatch(types.JSONPatchType, mergePatch))
+			err = cl.Patch(nil, dep, client.ConstantPatch(types.StrategicMergePatchType, mergePatch))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting the patched deployment")

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -39,6 +39,14 @@ func ObjectKeyFromObject(obj runtime.Object) (ObjectKey, error) {
 	return ObjectKey{Namespace: accessor.GetNamespace(), Name: accessor.GetName()}, nil
 }
 
+// Patch is a patch that can be applied to a Kubernetes object.
+type Patch interface {
+	// Type is the PatchType of the patch.
+	Type() types.PatchType
+	// Data is the raw data representing the patch.
+	Data(obj runtime.Object) ([]byte, error)
+}
+
 // TODO(directxman12): is there a sane way to deal with get/delete options?
 
 // Reader knows how to read and list Kubernetes objects.
@@ -65,6 +73,10 @@ type Writer interface {
 	// Update updates the given obj in the Kubernetes cluster. obj must be a
 	// struct pointer so that obj can be updated with the content returned by the Server.
 	Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error
+
+	// Patch patches the given obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOptionFunc) error
 }
 
 // StatusClient knows how to create a client which can update status subresource
@@ -428,3 +440,12 @@ func UpdateDryRunAll() UpdateOptionFunc {
 		opts.DryRun = []string{metav1.DryRunAll}
 	}
 }
+
+// PatchOptions contains options for patch requests.
+type PatchOptions struct {
+}
+
+// PatchOptionFunc is a function that mutates a PatchOptions struct. It implements
+// the functional options pattern. See
+// https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md.
+type PatchOptionFunc func(*PatchOptions)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -443,9 +443,31 @@ func UpdateDryRunAll() UpdateOptionFunc {
 
 // PatchOptions contains options for patch requests.
 type PatchOptions struct {
+	UpdateOptions
+}
+
+// ApplyOptions executes the given PatchOptionFuncs, mutating these PatchOptions.
+// It returns the mutated PatchOptions for convenience.
+func (o *PatchOptions) ApplyOptions(optFuncs []PatchOptionFunc) *PatchOptions {
+	for _, optFunc := range optFuncs {
+		optFunc(o)
+	}
+	return o
 }
 
 // PatchOptionFunc is a function that mutates a PatchOptions struct. It implements
 // the functional options pattern. See
 // https://github.com/tmrts/go-patterns/blob/master/idiom/functional-options.md.
 type PatchOptionFunc func(*PatchOptions)
+
+// Sadly, we need a separate function to "adapt" PatchOptions to the constituent
+// update options, since there's no way to write a function that works for both.
+
+// UpdatePatchWith adapts the given UpdateOptionFuncs to be a PatchOptionFunc.
+func UpdatePatchWith(optFuncs ...UpdateOptionFunc) PatchOptionFunc {
+	return func(opts *PatchOptions) {
+		for _, optFunc := range optFuncs {
+			optFunc(&opts.UpdateOptions)
+		}
+	}
+}

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"github.com/evanphx/json-patch"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+)
+
+type patch struct {
+	patchType types.PatchType
+	data      []byte
+}
+
+// Type implements Patch.
+func (s *patch) Type() types.PatchType {
+	return s.patchType
+}
+
+// Data implements Patch.
+func (s *patch) Data(obj runtime.Object) ([]byte, error) {
+	return s.data, nil
+}
+
+// ConstantPatch constructs a new Patch with the given PatchType and data.
+func ConstantPatch(patchType types.PatchType, data []byte) Patch {
+	return &patch{patchType, data}
+}
+
+type mergeFromPatch struct {
+	from runtime.Object
+}
+
+// Type implements patch.
+func (s *mergeFromPatch) Type() types.PatchType {
+	return types.MergePatchType
+}
+
+// Data implements Patch.
+func (s *mergeFromPatch) Data(obj runtime.Object) ([]byte, error) {
+	originalJSON, err := json.Marshal(s.from)
+	if err != nil {
+		return nil, err
+	}
+
+	modifiedJSON, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+
+	return jsonpatch.CreateMergePatch(originalJSON, modifiedJSON)
+}
+
+// MergeFrom creates a Patch that patches using the merge-patch strategy with the given object as base.
+func MergeFrom(obj runtime.Object) Patch {
+	return &mergeFromPatch{obj}
+}

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -17,7 +17,7 @@ limitations under the License.
 package client
 
 import (
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -86,6 +86,28 @@ func (c *typedClient) Delete(ctx context.Context, obj runtime.Object, opts ...De
 		Error()
 }
 
+// Patch implements client.Client
+func (c *typedClient) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOptionFunc) error {
+	o, err := c.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(data).
+		Context(ctx).
+		Do().
+		Into(obj)
+}
+
 // Get implements client.Client
 func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
 	r, err := c.cache.getResource(obj)

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -98,10 +98,12 @@ func (c *typedClient) Patch(ctx context.Context, obj runtime.Object, patch Patch
 		return err
 	}
 
+	patchOpts := &PatchOptions{}
 	return o.Patch(patch.Type()).
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.GetName()).
+		VersionedParams(patchOpts.ApplyOptions(opts).AsUpdateOptions(), c.paramCodec).
 		Body(data).
 		Context(ctx).
 		Do().

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -107,7 +107,8 @@ func (uc *unstructuredClient) Patch(_ context.Context, obj runtime.Object, patch
 		return err
 	}
 
-	i, err := r.Patch(u.GetName(), patch.Type(), data, metav1.UpdateOptions{})
+	patchOpts := &PatchOptions{}
+	i, err := r.Patch(u.GetName(), patch.Type(), data, *patchOpts.ApplyOptions(opts).AsUpdateOptions())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This adds the `Patch` method to the `Client` interface as well as to the two implementations (`typedClient`, `unstructuredClient`).