### PR TITLE
:sparkles: change metrics default to off

### DIFF
--- a/pkg/metrics/listener.go
+++ b/pkg/metrics/listener.go
@@ -23,7 +23,9 @@ import (
 
 // DefaultBindAddress sets the default bind address for the metrics
 // listener
-var DefaultBindAddress = ":8080"
+// The metrics is off by default.
+// TODO: Flip the default by changing DefaultBindAddress back to ":8080" in the v0.2.0.
+var DefaultBindAddress = "0"
 
 // NewListener creates a new TCP listener bound to the given address.
 func NewListener(addr string) (net.Listener, error) {


### PR DESCRIPTION
The PR flips the default of the unreleased metrics feature.
The reason is that we spin up a controller-manager in each of our controller's unit test, e.g. https://github.com/kubernetes-sigs/kubebuilder/blob/master/test/project/pkg/controller/firstmate/firstmate_controller_test.go
When there are multiple controllers in the same project, they will race for binding to the same default port which will cause some of them failing.

The plan is that in v0.1 branch we leave it off by default and in v0.2 release (happening very soon) we flip the default to on.
