### PR TITLE
:bug: Fix reconcile duration metric

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -175,7 +175,9 @@ func (c *Controller) processNextWorkItem() bool {
 
 	// Update metrics after processing each item
 	reconcileStartTS := time.Now()
-	defer c.updateMetrics(time.Now().Sub(reconcileStartTS))
+	defer func() {
+		c.updateMetrics(time.Now().Sub(reconcileStartTS))
+	}()
 
 	obj, shutdown := c.Queue.Get()
 	if obj == nil {


### PR DESCRIPTION
The previous implementation lacked delayed execution, leading to
`end - now` not reflecting the duration of the reconcile request handling.
