### PR TITLE
:sparkles: default namespace selector for webhook

### DIFF
--- a/pkg/webhook/bootstrap.go
+++ b/pkg/webhook/bootstrap.go
@@ -297,6 +297,17 @@ func (s *Server) validatingWHConfigs() (runtime.Object, error) {
 }
 
 func (s *Server) admissionWebhook(path string, wh *admission.Webhook) (*admissionregistration.Webhook, error) {
+	if wh.NamespaceSelector == nil && len(s.Service.Namespace) > 0 {
+		wh.NamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				{
+					Key:      "control-plane",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				},
+			},
+		}
+	}
+
 	webhook := &admissionregistration.Webhook{
 		Name:              wh.GetName(),
 		Rules:             wh.Rules,


### PR DESCRIPTION
This feature is useful for webhook to not block themselves.

The following scenario can be problematic: a webhook intercepts all pod creation requests. The user brings down the webhook server (maybe a statefulSet or deployment) and leave the webhook configuration object in the APIServer. The user recreates the webhook server (maybe a statefulSet or deployment), the workload API (statefulSet or deployment) will try to create new pods. This operations will be blocked by failing to call the webhook.
