### PR TITLE
:sparkles: allow user to specify metrics

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -45,13 +45,10 @@ var (
 )
 
 func init() {
-	metrics.Registry.MustRegister(
+	metrics.DefaultMetrics = append(
+		metrics.DefaultMetrics,
 		QueueLength,
 		ReconcileErrors,
 		ReconcileTime,
-		// expose process metrics like CPU, Memory, file descriptor usage etc.
-		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
-		// expose Go runtime metrics like GC stats, memory stats etc.
-		prometheus.NewGoCollector(),
 	)
 }

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -18,6 +18,14 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+// DefaultMetrics are the default metrics provided by controller-runtime.
+var DefaultMetrics = []prometheus.Collector{
+	// expose process metrics like CPU, Memory, file descriptor usage etc.
+	prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
+	// expose Go runtime metrics like GC stats, memory stats etc.
+	prometheus.NewGoCollector(),
+}
+
 // Registry is a prometheus registry for storing metrics within the
 // controller-runtime
 var Registry = prometheus.NewRegistry()


### PR DESCRIPTION
fixes #258

The tests are failing because currently different test cases try to register same metrics in the shared Registry. I will fix tests if we decide to proceed with this approach.
