### PR TITLE
:sparkles: adding ability to get a APIReader from the client.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -144,6 +144,10 @@ func (c *client) Status() StatusWriter {
 	return &statusWriter{client: c}
 }
 
+func (c *client) APIReader() Reader {
+	return c
+}
+
 // statusWriter is client.StatusWriter that writes status subresource
 type statusWriter struct {
 	client *client

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -154,6 +154,10 @@ func (c *fakeClient) Status() client.StatusWriter {
 	return &fakeStatusWriter{client: c}
 }
 
+func (c *fakeClient) APIReader() client.Reader {
+	return c
+}
+
 func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
 	gvk, err := apiutil.GVKForObject(obj, scheme)
 	if err != nil {

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -81,11 +81,17 @@ type StatusWriter interface {
 	Update(ctx context.Context, obj runtime.Object) error
 }
 
+// APIClient knows how to return a reader that will contact the kubernetes api.
+type APIClient interface {
+	APIReader() Reader
+}
+
 // Client knows how to perform CRUD operations on Kubernetes objects.
 type Client interface {
 	Reader
 	Writer
 	StatusClient
+	APIClient
 }
 
 // IndexerFunc knows how to take an object and turn it into a series

--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -30,6 +30,7 @@ type DelegatingClient struct {
 	Reader
 	Writer
 	StatusClient
+	APIClient
 }
 
 // DelegatingReader forms a interface Reader that will cause Get and List

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -248,6 +248,7 @@ func defaultNewClient(cache cache.Cache, config *rest.Config, options client.Opt
 		},
 		Writer:       c,
 		StatusClient: c,
+		APIClient:    c,
 	}, nil
 }
 


### PR DESCRIPTION
Adding a new interface `APIClient` to expose as part of the client
a non-caching reader interface.

fixes #180
fixes #245