### PR TITLE
:bug: EnqueueRequestForOwner correctly enqueue cluster-scoped owner

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -948,6 +948,7 @@
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/admissionregistration/v1beta1",
     "k8s.io/api/apps/v1",
+    "k8s.io/api/autoscaling/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -19,6 +19,7 @@ package handler
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -51,6 +52,9 @@ type EnqueueRequestForOwner struct {
 
 	// groupKind is the cached Group and Kind from OwnerType
 	groupKind schema.GroupKind
+
+	// mapper maps GroupVersionKinds to Resources
+	mapper meta.RESTMapper
 }
 
 // Create implements EventHandler
@@ -126,10 +130,21 @@ func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object) 
 		// object in the event.
 		if ref.Kind == e.groupKind.Kind && refGV.Group == e.groupKind.Group {
 			// Match found - add a Request for the object referred to in the OwnerReference
-			result = append(result, reconcile.Request{NamespacedName: types.NamespacedName{
-				Namespace: object.GetNamespace(),
-				Name:      ref.Name,
-			}})
+			request := reconcile.Request{NamespacedName: types.NamespacedName{
+				Name: ref.Name,
+			}}
+
+			// if owner is not namespaced then we should set the namespace to the empty
+			mapping, err := e.mapper.RESTMapping(e.groupKind, refGV.Version)
+			if err != nil {
+				log.Error(err, "Could not retrieve rest mapping", "kind", e.groupKind)
+				return nil
+			}
+			if mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				request.Namespace = object.GetNamespace()
+			}
+
+			result = append(result, request)
 		}
 	}
 
@@ -162,4 +177,12 @@ var _ inject.Scheme = &EnqueueRequestForOwner{}
 // InjectScheme is called by the Controller to provide a singleton scheme to the EnqueueRequestForOwner.
 func (e *EnqueueRequestForOwner) InjectScheme(s *runtime.Scheme) error {
 	return e.parseOwnerTypeGroupKind(s)
+}
+
+var _ inject.Mapper = &EnqueueRequestForOwner{}
+
+// InjectMapper  is called by the Controller to provide the rest mapper used by the manager.
+func (e *EnqueueRequestForOwner) InjectMapper(m meta.RESTMapper) error {
+	e.mapper = m
+	return nil
 }

--- a/pkg/handler/eventhandler_suite_test.go
+++ b/pkg/handler/eventhandler_suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,6 +32,18 @@ func TestEventhandler(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, "Eventhandler Suite", []Reporter{envtest.NewlineReporter{}})
 }
 
+var testenv *envtest.Environment
+var cfg *rest.Config
+
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	testenv = &envtest.Environment{}
+	var err error
+	cfg, err = testenv.Start()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	testenv.Stop()
 })

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -139,6 +139,9 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 	if _, err := inject.DecoderInto(cm.admissionDecoder, i); err != nil {
 		return err
 	}
+	if _, err := inject.MapperInto(cm.mapper, i); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/runtime/inject/inject.go
+++ b/pkg/runtime/inject/inject.go
@@ -17,6 +17,7 @@ limitations under the License.
 package inject
 
 import (
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -109,6 +110,20 @@ type Stoppable interface {
 func StopChannelInto(stop <-chan struct{}, i interface{}) (bool, error) {
 	if s, ok := i.(Stoppable); ok {
 		return true, s.InjectStopChannel(stop)
+	}
+	return false, nil
+}
+
+// Mapper is used to inject the rest mapper to components that may need it
+type Mapper interface {
+	InjectMapper(meta.RESTMapper) error
+}
+
+// MapperInto will set the rest mapper on i and return the result if it implements Mapper.
+// Returns false if i does not implement Mapper.
+func MapperInto(mapper meta.RESTMapper, i interface{}) (bool, error) {
+	if m, ok := i.(Mapper); ok {
+		return true, m.InjectMapper(mapper)
 	}
 	return false, nil
 }


### PR DESCRIPTION
Determines if the owner object is cluster scoped, and if it is will not use the object's namespace in the reconcile request.

To complete this, it adds dependency injection for the managers RESTMapper. 
