### PR TITLE
[WIP] :warning: dependency injection rev2 experiment

### DIFF
--- a/example/mutatingwebhook.go
+++ b/example/mutatingwebhook.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 )
@@ -62,9 +61,7 @@ func (a *podAnnotator) mutatePodsFn(ctx context.Context, pod *corev1.Pod) error 
 	return nil
 }
 
-// podValidator implements inject.Client.
 // A client will be automatically injected.
-var _ inject.Client = &podValidator{}
 
 // InjectClient injects the client.
 func (v *podAnnotator) InjectClient(c client.Client) error {
@@ -72,9 +69,7 @@ func (v *podAnnotator) InjectClient(c client.Client) error {
 	return nil
 }
 
-// podValidator implements inject.Decoder.
 // A decoder will be automatically injected.
-var _ inject.Decoder = &podValidator{}
 
 // InjectDecoder injects the decoder.
 func (v *podAnnotator) InjectDecoder(d types.Decoder) error {

--- a/example/validatingwebhook.go
+++ b/example/validatingwebhook.go
@@ -23,7 +23,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 )
@@ -68,9 +67,7 @@ func (v *podValidator) validatePodsFn(ctx context.Context, pod *corev1.Pod) (boo
 	return false, "", nil
 }
 
-// podValidator implements inject.Client.
 // A client will be automatically injected.
-var _ inject.Client = &podValidator{}
 
 // InjectClient injects the client.
 func (v *podValidator) InjectClient(c client.Client) error {
@@ -79,8 +76,6 @@ func (v *podValidator) InjectClient(c client.Client) error {
 }
 
 // podValidator implements inject.Decoder.
-// A decoder will be automatically injected.
-var _ inject.Decoder = &podValidator{}
 
 // InjectDecoder injects the decoder.
 func (v *podValidator) InjectDecoder(d types.Decoder) error {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/inject"
 	"sigs.k8s.io/controller-runtime/pkg/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -72,7 +73,7 @@ func New(name string, mgr manager.Manager, options Options) (Controller, error) 
 	}
 
 	// Inject dependencies into Reconciler
-	if err := mgr.SetFields(options.Reconciler); err != nil {
+	if _, err := inject.Into(mgr, options.Reconciler); err != nil {
 		return nil, err
 	}
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 var _ = Describe("controller.Controller", func() {
@@ -94,7 +93,6 @@ var _ = Describe("controller.Controller", func() {
 })
 
 var _ reconcile.Reconciler = &failRec{}
-var _ inject.Client = &failRec{}
 
 type failRec struct{}
 

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 
@@ -156,8 +155,6 @@ func (e *EnqueueRequestForOwner) getOwnersReferences(object metav1.Object) []met
 	// No Controller OwnerReference found
 	return nil
 }
-
-var _ inject.Scheme = &EnqueueRequestForOwner{}
 
 // InjectScheme is called by the Controller to provide a singleton scheme to the EnqueueRequestForOwner.
 func (e *EnqueueRequestForOwner) InjectScheme(s *runtime.Scheme) error {

--- a/pkg/inject/context.go
+++ b/pkg/inject/context.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inject
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Context carries dependencies across component boundaries.
+type Context interface {
+	// PopulateThis populates the given pointer with an instance of its type,
+	// if available.  The target *must* be a pointer.  Key is an optional key
+	// to differentiate different values of the same type.  If it's the same
+	// as the type name, pass the empty string.
+	PopulateThis(key string, target interface{}) bool
+}
+
+// Nothing returns a new Context that doesn't provide any dependencies.
+func Nothing() Context {
+	return emptyContext{}
+}
+
+// emptyContext doesn't provide anything
+type emptyContext struct{}
+
+func (c emptyContext) PopulateThis(_ string, _ interface{}) bool { return false }
+
+// depContext is a Context that provides a dependency of a given type.
+// It'll call out to next if it can provide the type asked for.
+type depContext struct {
+	typ         reflect.Type
+	value       reflect.Value
+	key         string
+	keyOptional bool
+	next        Context
+}
+
+func (c *depContext) PopulateThis(key string, target interface{}) bool {
+	targetVal := extractOrCheckValue(target)
+	if matchesType(targetVal.Type(), c.typ) && ((c.keyOptional && key == "") || key == c.key) {
+		targetVal.Set(c.value)
+		return true
+	}
+
+	return c.next.PopulateThis(key, target)
+}
+
+// matchesType checks if the given two types are the same, or if the second implements the first
+// (if the first is an interface).
+func matchesType(targetType reflect.Type, otherType reflect.Type) bool {
+	if otherType == targetType {
+		return true
+	} else if targetType.Kind() == reflect.Interface && otherType.Implements(targetType) {
+		return true
+	}
+
+	return false
+}
+
+// extractOrCheckValue checks to make sure the given object is acceptable
+// for use as an injection target (it's a pointer) and pulls out the
+// underlying value.
+func extractOrCheckValue(target interface{}) reflect.Value {
+	targetVal := reflect.ValueOf(target)
+	if targetVal.Type().Kind() != reflect.Ptr {
+		// We need a pointer to set
+		panic(fmt.Sprintf("must pass a pointer to PopulateThis, not a %v", targetVal.Type()))
+	}
+	targetVal = reflect.Indirect(targetVal)
+
+	return targetVal
+}
+
+// ProvideA provides the given dependency in the given context.
+func ProvideA(ctx Context, obj interface{}) Context {
+	return ProvideASpecific(ctx, "", obj)
+}
+
+// ProvideASpecific provides the given dependency in the specific case where
+// the given name is asked for.  If this type implements any interfaces, it will
+// automatically be the implementation of those interfaces.
+func ProvideASpecific(ctx Context, key string, obj interface{}) Context {
+	val := reflect.ValueOf(obj)
+	return &depContext{
+		typ:   val.Type(),
+		value: val,
+		key:   key,
+		next:  ctx,
+	}
+}
+
+// ProvideSome provides the given dependencies in the given context.
+// It's roughly equivalent to calling ProvideA repeatedly.
+func ProvideSome(ctx Context, objs ...interface{}) Context {
+	for _, obj := range objs {
+		ctx = ProvideA(ctx, obj)
+	}
+
+	return ctx
+}

--- a/pkg/inject/context_test.go
+++ b/pkg/inject/context_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inject_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/inject"
+)
+
+type fakeInterface interface {
+	doAThing()
+}
+
+type fakeImplOne struct {
+	v int
+}
+
+func (f fakeImplOne) doAThing() {}
+
+type fakeImplTwo struct {
+	v int
+}
+
+func (f *fakeImplTwo) doAThing() {}
+
+var _ = Describe("Injection Contexts", func() {
+	Context("when populating directly", func() {
+		It("should populate a provided type", func() {
+			By("providing a type")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("populating a value of that type")
+			var obj fakeImplOne
+			Expect(ctx.PopulateThis("", &obj)).To(BeTrue(), "should have indicate that a value was populated")
+
+			By("checking that the right value was populated")
+			Expect(obj).To(Equal(srcObj))
+		})
+
+		It("should panic if not passed a pointer", func() {
+			By("providing a type")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("trying to populate a non-pointer value")
+			var obj fakeImplOne
+			Expect(func() { ctx.PopulateThis("", obj) }).To(Panic())
+		})
+
+		It("should populate a provided instance of an interface", func() {
+			By("providing a interface")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("populating a value of that type")
+			var obj fakeInterface
+			ctx.PopulateThis("", &obj)
+
+			By("checking that the right value was populated")
+			Expect(obj).To(Equal(srcObj))
+		})
+		It("should not populate the wrong type", func() {
+			By("providing a type")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("populating a value of a different type")
+			obj := fakeImplTwo{v: 2}
+			Expect(ctx.PopulateThis("", &obj)).To(BeFalse(), "should have indicated that no value was populated")
+
+			By("checking that our obj is not populated")
+			Expect(obj).To(Equal(fakeImplTwo{v: 2}))
+		})
+
+		It("should populate a provided type after providing another type", func() {
+			By("providing a type")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("providing another type")
+			ctx = inject.ProvideA(ctx, fakeImplTwo{v: 128})
+
+			By("populating a value of the first type")
+			var obj fakeImplOne
+			Expect(ctx.PopulateThis("", &obj)).To(BeTrue(), "should have indicate that a value was populated")
+
+			By("checking that the right value was populated")
+			Expect(obj).To(Equal(srcObj))
+		})
+
+		It("should only populate the most recent value for a type", func() {
+			By("providing a type")
+			srcObj := fakeImplOne{v: 42}
+			ctx := inject.ProvideA(inject.Nothing(), srcObj)
+
+			By("providing another type")
+			ctx = inject.ProvideA(ctx, fakeImplTwo{v: 128})
+
+			By("providing a different first type value")
+			ctx = inject.ProvideA(ctx, fakeImplOne{v: 256})
+
+			By("populating a value of the first type")
+			var obj fakeImplOne
+			Expect(ctx.PopulateThis("", &obj)).To(BeTrue(), "should have indicate that a value was populated")
+
+			By("checking that the right value was populated")
+			Expect(obj).To(Equal(fakeImplOne{v: 256}))
+		})
+
+		It("should support providing multiple dependencies at once", func() {
+			By("providing multiple dependencies")
+			ctx := inject.ProvideSome(inject.Nothing(), fakeImplOne{v: 42}, &fakeImplTwo{v: 21})
+
+			By("fetching those dependencies")
+			var targetOne fakeImplOne
+			var targetTwo *fakeImplTwo
+			Expect(ctx.PopulateThis("", &targetOne)).To(BeTrue(), "should have indicated that a value was populated")
+			Expect(ctx.PopulateThis("", &targetTwo)).To(BeTrue(), "should have indicated that a value was populated")
+
+			By("checking that those values are correct")
+			Expect(targetOne).To(Equal(fakeImplOne{v: 42}))
+			Expect(targetTwo).To(Equal(&fakeImplTwo{v: 21}))
+		})
+
+		It("should support passing dependencies with specific names", func() {
+			By("providing a dependency with a specific name")
+			stopCh := make(chan struct{})
+			ctx := inject.ProvideASpecific(inject.Nothing(), "StopChannel", stopCh)
+
+			By("fetching that dependency without a key and verifying that it fails")
+			var otherCh chan struct{}
+			Expect(ctx.PopulateThis("", &otherCh)).To(BeFalse())
+			Expect(otherCh).To(BeNil())
+
+			By("fetching that dependency with a key and verifying that it succeeds")
+			Expect(ctx.PopulateThis("StopChannel", &otherCh)).To(BeTrue())
+			Expect(otherCh).To(Equal(stopCh))
+		})
+	})
+})

--- a/pkg/inject/inject.go
+++ b/pkg/inject/inject.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inject
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type aggregateError []error
+
+func (e aggregateError) Error() string {
+	var errStrs []string
+	for _, err := range e {
+		errStrs = append(errStrs, err.Error())
+	}
+	return strings.Join(errStrs, ",")
+}
+
+var errorType = reflect.TypeOf((*error)(nil)).Elem()
+
+// provideCtx provides the given context with or without the
+// key "Dependencies" (to allow avoiding conflict with the normal
+// context object in injection methods)
+func provideCtx(ctx Context) Context {
+	ctxVal := reflect.ValueOf(ctx)
+	return &depContext{
+		key:         "Dependencies",
+		value:       ctxVal,
+		typ:         ctxVal.Type(),
+		keyOptional: true,
+		next:        ctx,
+	}
+}
+
+// Into reads the given object for implementations
+// of injectable pseudo-interfaces and struct tags,
+// and injects dependencies based on those.
+// As a special case, the given context will also "Provide" itself
+// with or without key "Dependencies".
+func Into(ctx Context, target interface{}) (bool, error) {
+	// the context provides itself
+	ctx = provideCtx(ctx)
+
+	targetV := reflect.ValueOf(target)
+	targetType := targetV.Type()
+
+	// NB(directxman12): certain conditions here are panics,
+	// because they violate the pseudo-signature of the method or violate invariants
+	// (we can't actually express that signature without generics)
+
+	populatedAll := true
+
+	// check for struct tags
+	isStructPtr := targetType.Kind() == reflect.Ptr && targetType.Elem().Kind() == reflect.Struct
+	if isStructPtr {
+		targetElemType := targetType.Elem()
+		targetElemV := targetV.Elem()
+
+		// check for the simple case of struct tags
+		for i := 0; i < targetElemType.NumField(); i++ {
+			if !injectForField(ctx, targetElemType, targetElemV, i) {
+				populatedAll = false
+			}
+		}
+	}
+
+	var callErrs []error
+
+	// check for methods implementing pseudo-interfaces
+	for i := 0; i < targetType.NumMethod(); i++ {
+		populated, err := injectForMethod(ctx, targetType, targetV, i)
+		if err != nil {
+			callErrs = append(callErrs, err)
+		}
+		if !populated {
+			populatedAll = false
+		}
+	}
+
+	var err error
+	if len(callErrs) > 0 {
+		err = aggregateError(callErrs)
+	}
+
+	return populatedAll, err
+}
+
+// injectForField injects into the given field if the it has an `inject:""` tag.
+// It will return false only if a given field should have been injected but was not.
+func injectForField(ctx Context, targetType reflect.Type, targetV reflect.Value, fieldInd int) bool {
+	fieldType := targetType.Field(fieldInd)
+	key, tagPresent := fieldType.Tag.Lookup("inject")
+	if !tagPresent {
+		return true
+	}
+
+	fieldVal := targetV.Field(fieldInd)
+	if !fieldVal.CanSet() {
+		panic(fmt.Sprintf("field %q is private, and cannot be injected", fieldType.Name))
+	}
+	if !ctx.PopulateThis(key, fieldVal.Addr().Interface()) {
+		return false
+	}
+
+	return true
+}
+
+// injectForMethod injects by calling the given method if it has the right signature.
+// It will return false only if a given method should have been called but was not,
+// or if there was an error while calling it.
+func injectForMethod(ctx Context, targetPtrType reflect.Type, targetPtrV reflect.Value, methodInd int) (bool, error) {
+	methodType := targetPtrType.Method(methodInd)
+	meetsSig, key := meetsInjectPseudoSignature(methodType)
+	if !meetsSig {
+		return true, nil
+	}
+	argVal := reflect.New(methodType.Type.In(1)).Elem()
+	if !ctx.PopulateThis(key, argVal.Addr().Interface()) {
+		return false, nil
+	}
+
+	ret := targetPtrV.Method(methodInd).Call([]reflect.Value{argVal})
+	if !ret[0].IsNil() {
+		return false, ret[0].Interface().(error)
+	}
+
+	return true, nil
+}
+
+// meetsInjectPseudoSignature checks that we meet the pseudo-signature
+// required for inject methods (`Inject<XYZ>(<SomeType>) error` or `Inject<XYZ>(*<SomeType>) error`).
+// If true and XYZ isn't SomeType, the value of XYZ is returned.
+func meetsInjectPseudoSignature(method reflect.Method) (bool, string) {
+	if !strings.HasPrefix(method.Name, "Inject") {
+		return false, ""
+	}
+	if method.Type.NumIn() != 2 { // first in is the receiver
+		return false, ""
+	}
+	if method.Type.NumOut() != 1 || method.Type.Out(0) != errorType {
+		return false, ""
+	}
+	argType := method.Type.In(1)
+	isPtr := argType.Kind() == reflect.Ptr
+	var argName string
+	if isPtr {
+		argName = argType.Elem().Name()
+	} else {
+		argName = argType.Name()
+	}
+	key := method.Name[6:]
+	if key == argName {
+		key = ""
+	}
+
+	return true, key
+}

--- a/pkg/inject/inject_suite_test.go
+++ b/pkg/inject/inject_suite_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inject_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestSource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Dependency Injection Suite", []Reporter{envtest.NewlineReporter{}})
+}

--- a/pkg/inject/inject_test.go
+++ b/pkg/inject/inject_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inject_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/inject"
+)
+
+type FakeConcrete struct {
+	V float64
+}
+
+type fakeTarget struct {
+	// NB(directxman12): these are in order so that our "failure" test
+	// below checks that we continue on skip
+	Interface    fakeInterface `inject:""`
+	ConcreteImpl FakeConcrete
+	Interface2   fakeInterface `inject:""`
+}
+
+func (f *fakeTarget) InjectFakeConcrete(v FakeConcrete) error {
+	f.ConcreteImpl = FakeConcrete{V: v.V * 2}
+	return nil
+}
+
+type fakeTargetBadField struct {
+	// NB(directxman12): these are in order so that our "failure" test
+	// below checks that we continue on skip
+	iface        fakeInterface `inject:""`
+	ConcreteImpl FakeConcrete  `inject:""`
+}
+
+type fakeTargetErrMethod struct {
+	// NB(directxman12): these are in order so that our "failure" test
+	// below checks that we continue on skip
+	concrete  FakeConcrete
+	Interface fakeInterface `inject:""`
+}
+
+func (f *fakeTargetErrMethod) InjectFakeConcrete(v FakeConcrete) error {
+	return errors.New("why is your injector even erroring anyway?")
+}
+
+type wantsContext struct {
+	Context inject.Context `inject:""`
+}
+
+type nonStructTarget func(FakeConcrete)
+
+func (t nonStructTarget) InjectFakeConcrete(c FakeConcrete) error {
+	t(c)
+	return nil
+}
+
+var _ = Describe("Injection Contexts", func() {
+	Context("when injecting indirectly", func() {
+		Context("on struct pointers", func() {
+			It("should populate based on struct tags and methods", func() {
+				By("populating a context with dependencies")
+				fakeImpl := &fakeImplTwo{v: 42}
+				ctx := inject.ProvideA(inject.Nothing(), fakeImpl)
+				ctx = inject.ProvideA(ctx, FakeConcrete{V: 21})
+
+				By("injecting into a target")
+				target := &fakeTarget{}
+				all, err := inject.Into(ctx, target)
+
+				By("checking that no errors occurred and everything was marked as injected")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(all).To(BeTrue())
+
+				By("checking that struct tag values were injected")
+				Expect(target.Interface).To(Equal(fakeImpl))
+				Expect(target.Interface2).To(Equal(fakeImpl))
+
+				By("checking that method values were injected")
+				Expect(target.ConcreteImpl).To(Equal(FakeConcrete{V: 42}))
+			})
+
+			It("should panic on unsettable fields", func() {
+				By("populating a context with dependencies")
+				ctx := inject.ProvideA(inject.Nothing(), &fakeImplTwo{v: 42})
+				ctx = inject.ProvideA(ctx, FakeConcrete{V: 21})
+
+				By("injecting into a target with a marked private field")
+				target := &fakeTargetBadField{}
+				Expect(func() { inject.Into(ctx, target) }).To(Panic())
+			})
+		})
+
+		Context("on non-struct-pointers", func() {
+			It("should populate based on methods", func() {
+				By("populating a context with dependencies")
+				ctx := inject.ProvideA(inject.Nothing(), FakeConcrete{V: 21})
+
+				By("injecting into a target")
+				var val FakeConcrete
+				target := nonStructTarget(func(c FakeConcrete) { val = c })
+				all, err := inject.Into(ctx, target)
+
+				By("checking that no errors occurred and everything was marked as injected")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(all).To(BeTrue())
+
+				By("checking that method was called")
+				Expect(val).To(Equal(FakeConcrete{V: 21}))
+			})
+		})
+
+		Context("on any type", func() {
+			It("should always be able to inject the Context itself", func() {
+				By("populating a context with some (unused) dependencies")
+				ctx := inject.ProvideA(inject.Nothing(), &fakeImplTwo{v: 42})
+
+				By("injecting into a target that wants a Context")
+				target := &wantsContext{}
+				all, err := inject.Into(ctx, target)
+
+				By("expecting everything to have been marked injected")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(all).To(BeTrue())
+
+				By("checking that the context was actually injected")
+				Expect(target.Context).To(Equal(ctx))
+			})
+
+			It("should report injection method errors", func() {
+				By("populating a context with dependencies")
+				ctx := inject.ProvideA(inject.Nothing(), &fakeImplTwo{v: 42})
+				ctx = inject.ProvideA(ctx, FakeConcrete{V: 21})
+
+				By("injecting into a target with a method that returns an error")
+				target := &fakeTargetErrMethod{}
+				all, err := inject.Into(ctx, target)
+
+				By("expecting an error to have been reported and not all fields to have been marked injected")
+				Expect(err).To(HaveOccurred())
+				Expect(all).To(BeFalse())
+
+				By("confirming that our other field was still set")
+				Expect(target.Interface).To(Equal(&fakeImplTwo{v: 42}))
+			})
+
+			It("should indicate if not all available injection points were used, and populate all available", func() {
+				By("populating a context with only some dependencies")
+				fakeImpl := &fakeImplTwo{v: 42}
+				ctx := inject.ProvideA(inject.Nothing(), fakeImpl)
+
+				By("injecting into a target")
+				target := &fakeTarget{}
+				all, err := inject.Into(ctx, target)
+
+				By("checking that no errors occurred and our main values were injected")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(target.Interface).To(Equal(fakeImpl))
+				Expect(target.Interface2).To(Equal(fakeImpl))
+
+				By("checking that we marked not all fields as settable")
+				Expect(all).To(BeFalse())
+			})
+
+		})
+	})
+})

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source/internal"
 
@@ -102,8 +101,6 @@ func (ks *Kind) String() string {
 	return fmt.Sprintf("kind source: unknown GVK")
 }
 
-var _ inject.Cache = &Kind{}
-
 // InjectCache is internal should be called only by the Controller.  InjectCache is used to inject
 // the Cache dependency initialized by the ControllerManager.
 func (ks *Kind) InjectCache(c cache.Cache) error {
@@ -142,8 +139,6 @@ type Channel struct {
 func (cs *Channel) String() string {
 	return fmt.Sprintf("channel source: %p", cs)
 }
-
-var _ inject.Stoppable = &Channel{}
 
 // InjectStopChannel is internal should be called only by the Controller.
 // It is used to inject the stop channel initialized by the ControllerManager.

--- a/pkg/source/source_integration_test.go
+++ b/pkg/source/source_integration_test.go
@@ -22,7 +22,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	. "github.com/onsi/ginkgo"
@@ -62,10 +61,10 @@ var _ = Describe("Source", func() {
 
 	JustBeforeEach(func() {
 		instance1 = &source.Kind{Type: obj}
-		inject.CacheInto(icache, instance1)
+		instance1.InjectCache(icache)
 
 		instance2 = &source.Kind{Type: obj}
-		inject.CacheInto(icache, instance2)
+		instance2.InjectCache(icache)
 	})
 
 	AfterEach(func(done Done) {

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -25,7 +25,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	corev1 "k8s.io/api/core/v1"
@@ -67,7 +66,7 @@ var _ = Describe("Source", func() {
 				instance := &source.Kind{
 					Type: &corev1.Pod{},
 				}
-				inject.CacheInto(ic, instance)
+				instance.InjectCache(ic)
 				err := instance.Start(handler.Funcs{
 					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
@@ -158,7 +157,7 @@ var _ = Describe("Source", func() {
 				instance := &source.Kind{
 					Type: &corev1.Pod{},
 				}
-				inject.CacheInto(ic, instance)
+				instance.InjectCache(ic)
 				err := instance.Start(handler.Funcs{
 					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
@@ -288,7 +287,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Channel{Source: ch}
-				inject.StopChannelInto(stop, instance)
+				instance.InjectStopChannel(stop)
 				err := instance.Start(handler.Funcs{
 					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
@@ -330,7 +329,7 @@ var _ = Describe("Source", func() {
 				// Add a handler to get distribution blocked
 				instance := &source.Channel{Source: ch}
 				instance.DestBufferSize = 1
-				inject.StopChannelInto(stop, instance)
+				instance.InjectStopChannel(stop)
 				err := instance.Start(handler.Funcs{
 					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
@@ -382,7 +381,7 @@ var _ = Describe("Source", func() {
 			It("should get error if no source specified", func(done Done) {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Channel{ /*no source specified*/ }
-				inject.StopChannelInto(stop, instance)
+				instance.InjectStopChannel(stop)
 				err := instance.Start(handler.Funcs{}, q)
 				Expect(err).To(Equal(fmt.Errorf("must specify Channel.Source")))
 				close(done)
@@ -413,7 +412,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Channel{Source: ch}
-				inject.StopChannelInto(stop, instance)
+				instance.InjectStopChannel(stop)
 				err := instance.Start(handler.Funcs{
 					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -31,8 +31,7 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/inject"
 	atypes "sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/types"
 )
@@ -234,26 +233,13 @@ func (w *Webhook) Validate() error {
 	return nil
 }
 
-var _ inject.Client = &Webhook{}
-
-// InjectClient injects the client into the handlers
-func (w *Webhook) InjectClient(c client.Client) error {
+// InjectDependencies injects received dependencies into its handlers.
+func (w *Webhook) InjectDependencies(ctx inject.Context) error {
 	for _, handler := range w.Handlers {
-		if _, err := inject.ClientInto(c, handler); err != nil {
+		if _, err := inject.Into(ctx, handler); err != nil {
 			return err
 		}
 	}
-	return nil
-}
-
-var _ inject.Decoder = &Webhook{}
-
-// InjectDecoder injects the decoder into the handlers
-func (w *Webhook) InjectDecoder(d atypes.Decoder) error {
-	for _, handler := range w.Handlers {
-		if _, err := inject.DecoderInto(d, handler); err != nil {
-			return err
-		}
-	}
+	
 	return nil
 }


### PR DESCRIPTION
This is an experiment around improving our dependency injection story.  The implementation is a bit hairy, but the actual usage mechanics are fairly straightforward.

All dependencies are stored in a special dependency context:

```go
ctx := inject.Nothing()
```

New dependencies can be add or overwritten by adding a new link to the context:

```go
ctx = inject.ProvideA(ctx, mySpecialClient)
```

Dependencies (including the context itself, which gets automatically injected) can be injected into a struct:

```go
type Foo struct {
  Client client.Client `inject:""`
  specialDep FooBar
}

func (f *Foo) InjectFooBar(fb FooBar) error {
  f.specialDep = fb
}

...

myFoo := &Foo{}
inject.Into(ctx, myFoo)
```

Dependencies can also be fetched directly:

```go
var myClient client.Client
ctx.PopulateThis("", &myClient) // the first argument is an optional "key" for things like InjectStopChannel, where the type name doesn't correspond to the "name" of the dependency
```

Finally, things wishing to dynamically provide dependencies without constructing a new context every time can implement a link in the `Context` chain themselves (by adding `PopulateThis`, which implements `Context`) -- `manager.Manager` does this.

There's a *lot* of reflection under the hood, but this model has a number of nice properties:

- dependencies can be fetched directly
- dependencies can be "masked" by other dependencies for specific scopes
- dependencies can be added for specific scopes
- adding new dependencies is pretty easy
