### PR TITLE
:sparkles: Fix up error reporting and logging in envtest

### DIFF
--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -174,6 +174,7 @@ func CreateCRDs(config *rest.Config, crds []*apiextensionsv1beta1.CustomResource
 
 	// Create each CRD
 	for _, crd := range crds {
+		log.V(1).Info("installing CRD", "crd", crd)
 		if _, err := cs.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd); err != nil {
 			return err
 		}
@@ -186,6 +187,7 @@ func readCRDs(path string) ([]*apiextensionsv1beta1.CustomResourceDefinition, er
 	// Get the CRD files
 	var files []os.FileInfo
 	var err error
+	log.V(1).Info("reading CRDs from path", "path", path)
 	if files, err = ioutil.ReadDir(path); err != nil {
 		return nil, err
 	}
@@ -215,6 +217,7 @@ func readCRDs(path string) ([]*apiextensionsv1beta1.CustomResourceDefinition, er
 			continue
 		}
 
+		log.V(1).Info("read CRD from file", "file", file)
 		crds = append(crds, crd)
 	}
 	return crds, nil

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -26,7 +26,11 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/testing_frameworks/integration"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
+
+var log = logf.KBLog.WithName("test-env")
 
 // Default binary path for test framework
 const (
@@ -117,9 +121,11 @@ func (te Environment) getAPIServerFlags() []string {
 // Start starts a local Kubernetes server and updates te.ApiserverPort with the port it is listening on
 func (te *Environment) Start() (*rest.Config, error) {
 	if te.UseExistingCluster {
+		log.V(1).Info("using existing cluster")
 		if te.Config == nil {
 			// we want to allow people to pass in their own config, so
 			// only load a config if it hasn't already been set.
+			log.V(1).Info("automatically acquiring client configuration")
 
 			var err error
 			te.Config, err = config.GetConfig()
@@ -153,6 +159,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 		te.ControlPlane.APIServer.StartTimeout = te.ControlPlaneStartTimeout
 		te.ControlPlane.APIServer.StopTimeout = te.ControlPlaneStopTimeout
 
+		log.V(1).Info("starting control plane", "api server flags", te.ControlPlane.APIServer.Args)
 		if err := te.startControlPlane(); err != nil {
 			return nil, err
 		}
@@ -163,6 +170,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 		}
 	}
 
+	log.V(1).Info("installing CRDs")
 	_, err := InstallCRDs(te.Config, CRDInstallOptions{
 		Paths: te.CRDDirectoryPaths,
 		CRDs:  te.CRDs,
@@ -179,6 +187,7 @@ func (te *Environment) startControlPlane() error {
 		if err == nil {
 			break
 		}
+		log.Error(err, "unable to start the controlplane", "tries", numTries)
 	}
 	if numTries == maxRetries {
 		return fmt.Errorf("failed to start the controlplane. retried %d times: %v", numTries, err)

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -181,7 +181,7 @@ func (te *Environment) startControlPlane() error {
 		}
 	}
 	if numTries == maxRetries {
-		return fmt.Errorf("failed to start the controlplane. retried %d times: %s", numTries, err.Error())
+		return fmt.Errorf("failed to start the controlplane. retried %d times: %v", numTries, err)
 	}
 	return nil
 }


### PR DESCRIPTION
There was a minor style violation in the style of error reporting in envtest, plus envtest lacked logging entirely.  This fixes both of those issues.