### PR TITLE
:warning: Call MutateFn on CreateOrUpdate regardless of the operation

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -114,48 +114,39 @@ const ( // They should complete the sentence "Deployment default/foo has been ..
 	OperationResultUpdated OperationResult = "updated"
 )
 
-// CreateOrUpdate creates or updates the given object obj in the Kubernetes
-// cluster. The object's desired state should be reconciled with the existing
-// state using the passed in MutateFn. obj is just a struct pointer so that
-// obj can be updated with the content returned by the Server.
+// CreateOrUpdate creates or updates the given object in the Kubernetes
+// cluster. The object's desired state must be reconciled with the existing
+// state inside the passed in callback MutateFn.
 //
 // The MutateFn is called regardless of creating or updating an object.
 //
 // It returns the executed operation and an error.
-func CreateOrUpdate(ctx context.Context, c client.Client, obj runtime.Object, f MutateFn) (OperationResult, error) { // nolint: gocyclo
+func CreateOrUpdate(ctx context.Context, c client.Client, obj runtime.Object, f MutateFn) (OperationResult, error) {
 	key, err := client.ObjectKeyFromObject(obj)
 	if err != nil {
 		return OperationResultNone, err
 	}
 
 	if err := c.Get(ctx, key, obj); err != nil {
-		if errors.IsNotFound(err) {
-			if err := f(obj); err != nil {
-				return OperationResultNone, err
-			}
-			if err := c.Create(ctx, obj); err != nil {
-				return OperationResultNone, err
-			}
-			return OperationResultCreated, nil
+		if !errors.IsNotFound(err) {
+			return OperationResultNone, err
 		}
-		return OperationResultNone, err
+		if err := mutate(f, key, obj); err != nil {
+			return OperationResultNone, err
+		}
+		if err := c.Create(ctx, obj); err != nil {
+			return OperationResultNone, err
+		}
+		return OperationResultCreated, nil
 	}
 
 	existing := obj.DeepCopyObject()
-	if err := f(obj); err != nil {
+	if err := mutate(f, key, obj); err != nil {
 		return OperationResultNone, err
 	}
 
 	if reflect.DeepEqual(existing, obj) {
 		return OperationResultNone, nil
-	}
-
-	newKey, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return OperationResultNone, err
-	}
-	if key != newKey {
-		return OperationResultNone, fmt.Errorf("MutateFn cannot mutate object namespace and/or object name")
 	}
 
 	if err := c.Update(ctx, obj); err != nil {
@@ -164,5 +155,16 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj runtime.Object, f 
 	return OperationResultUpdated, nil
 }
 
+// mutate wraps a MutateFn and applies validation to its result
+func mutate(f MutateFn, key client.ObjectKey, obj runtime.Object) error {
+	if err := f(); err != nil {
+		return err
+	}
+	if newKey, err := client.ObjectKeyFromObject(obj); err != nil || key != newKey {
+		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
+	}
+	return nil
+}
+
 // MutateFn is a function which mutates the existing object into it's desired state.
-type MutateFn func(existing runtime.Object) error
+type MutateFn func() error

--- a/pkg/controller/controllerutil/example_test.go
+++ b/pkg/controller/controllerutil/example_test.go
@@ -22,7 +22,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -37,10 +36,9 @@ func ExampleCreateOrUpdate() {
 	// c is client.Client
 
 	// Create or Update the deployment default/foo
-	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
+	deploy := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 
-	op, err := controllerutil.CreateOrUpdate(context.TODO(), c, deployment, func(existing runtime.Object) error {
-		deploy := existing.(*appsv1.Deployment)
+	op, err := controllerutil.CreateOrUpdate(context.TODO(), c, deploy, func() error {
 
 		// Deployment selector is immutable so we set this value only if
 		// a new object is going to be created
@@ -59,7 +57,7 @@ func ExampleCreateOrUpdate() {
 			},
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
-					corev1.Container{
+					{
 						Name:  "busybox",
 						Image: "busybox",
 					},


### PR DESCRIPTION
#313 breaks `CreateOrUpdate` by not calling the `MutateFn` when new objects are created. This patch fixes that and updates the tests to better reflect the expected behavior. 