### PR TITLE
:sparkles: adding APIReader to the manager and injection.

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -58,6 +58,9 @@ type controllerManager struct {
 	// client is the client injected into Controllers (and EventHandlers, Sources and Predicates).
 	client client.Client
 
+	// apiReader is the reader that will make requests to the api server and not the cache.
+	apiReader client.Reader
+
 	// fieldIndexes knows how to add field indexes over the Cache used by this controller,
 	// which can later be consumed via field selectors from the injected client.
 	fieldIndexes client.FieldIndexer
@@ -121,6 +124,9 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 	if _, err := inject.ClientInto(cm.client, i); err != nil {
 		return err
 	}
+	if _, err := inject.APIReaderInto(cm.apiReader, i); err != nil {
+		return err
+	}
 	if _, err := inject.SchemeInto(cm.scheme, i); err != nil {
 		return err
 	}
@@ -165,6 +171,10 @@ func (cm *controllerManager) GetEventRecorderFor(name string) record.EventRecord
 
 func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {
 	return cm.mapper
+}
+
+func (cm *controllerManager) GetAPIReader() client.Reader {
+	return cm.apiReader
 }
 
 func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -74,6 +74,11 @@ type Manager interface {
 
 	// GetRESTMapper returns a RESTMapper
 	GetRESTMapper() meta.RESTMapper
+
+	// GetAPIReader returns a reader that will be configured to use the API server.
+	// This should be used sparingly and only when the client does not fit your
+	// use case.
+	GetAPIReader() client.Reader
 }
 
 // Options are the arguments for creating a new Manager
@@ -179,6 +184,11 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
+	apiReader, err := client.New(config, client.Options{Scheme: options.Scheme, Mapper: mapper})
+	if err != nil {
+		return nil, err
+	}
+
 	writeObj, err := options.NewClient(cache, config, client.Options{Scheme: options.Scheme, Mapper: mapper})
 	if err != nil {
 		return nil, err
@@ -217,6 +227,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		cache:            cache,
 		fieldIndexes:     cache,
 		client:           writeObj,
+		apiReader:        apiReader,
 		recorderProvider: recorderProvider,
 		resourceLock:     resourceLock,
 		mapper:           mapper,

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -606,6 +606,11 @@ var _ = Describe("manger.Manager", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(m.GetEventRecorderFor("test")).NotTo(BeNil())
 	})
+	It("should provide a function to get the APIReader", func() {
+		m, err := New(cfg, Options{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(m.GetAPIReader()).NotTo(BeNil())
+	})
 })
 
 var _ reconcile.Reconciler = &failRec{}

--- a/pkg/runtime/inject/inject.go
+++ b/pkg/runtime/inject/inject.go
@@ -41,6 +41,20 @@ func CacheInto(c cache.Cache, i interface{}) (bool, error) {
 	return false, nil
 }
 
+// APIReader is used by the Manager to inject the APIReader into necessary types.
+type APIReader interface {
+	InjectAPIReader(client.Reader) error
+}
+
+// APIReaderInto will set APIReader on i and return the result if it implements APIReaderInto.
+// Returns false if i does not implement APIReader
+func APIReaderInto(reader client.Reader, i interface{}) (bool, error) {
+	if s, ok := i.(APIReader); ok {
+		return true, s.InjectAPIReader(reader)
+	}
+	return false, nil
+}
+
 // Config is used by the ControllerManager to inject Config into Sources, EventHandlers, Predicates, and
 // Reconciles
 type Config interface {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Adding the APIReader onto the manager and allowing users to use dependency injection to add this to their types.