### PR TITLE
:bug: try manager's config before kubeconfig

### DIFF
--- a/pkg/builder/build.go
+++ b/pkg/builder/build.go
@@ -183,6 +183,10 @@ func (blder *Builder) doConfig() error {
 	if blder.config != nil {
 		return nil
 	}
+	if blder.mgr != nil {
+		blder.config = blder.mgr.GetConfig()
+		return nil
+	}
 	var err error
 	blder.config, err = getConfig()
 	return err


### PR DESCRIPTION
When use builder pkg to construct a controller, if a config is provided, we should use it.
If a config is not provided by the user, we should try to use manager's config.
If manager is not specified, we should then try to use [GetConfig()](https://github.com/kubernetes-sigs/controller-runtime/blob/c84fba842c566876050ccfea7fe9f33d870fb451/pkg/client/config/config.go#L60-L82).
