### PR TITLE
:warning: Add Server-Side DryRun support to Client

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -19,7 +19,7 @@ set -e
 hack_dir=$(dirname ${BASH_SOURCE})
 source ${hack_dir}/common.sh
 
-k8s_version=1.10.1
+k8s_version=1.13.1
 goarch=amd64
 goos="unknown"
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -107,18 +107,18 @@ type client struct {
 func (c *client) Create(ctx context.Context, obj runtime.Object, opts ...CreateOptionFunc) error {
 	_, ok := obj.(*unstructured.Unstructured)
 	if ok {
-		return c.unstructuredClient.Create(ctx, obj)
+		return c.unstructuredClient.Create(ctx, obj, opts...)
 	}
-	return c.typedClient.Create(ctx, obj)
+	return c.typedClient.Create(ctx, obj, opts...)
 }
 
 // Update implements client.Client
 func (c *client) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
 	_, ok := obj.(*unstructured.Unstructured)
 	if ok {
-		return c.unstructuredClient.Update(ctx, obj)
+		return c.unstructuredClient.Update(ctx, obj, opts...)
 	}
-	return c.typedClient.Update(ctx, obj)
+	return c.typedClient.Update(ctx, obj, opts...)
 }
 
 // Delete implements client.Client

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -104,7 +104,7 @@ type client struct {
 }
 
 // Create implements client.Client
-func (c *client) Create(ctx context.Context, obj runtime.Object) error {
+func (c *client) Create(ctx context.Context, obj runtime.Object, opts ...CreateOptionFunc) error {
 	_, ok := obj.(*unstructured.Unstructured)
 	if ok {
 		return c.unstructuredClient.Create(ctx, obj)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -113,7 +113,7 @@ func (c *client) Create(ctx context.Context, obj runtime.Object, opts ...CreateO
 }
 
 // Update implements client.Client
-func (c *client) Update(ctx context.Context, obj runtime.Object) error {
+func (c *client) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
 	_, ok := obj.(*unstructured.Unstructured)
 	if ok {
 		return c.unstructuredClient.Update(ctx, obj)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -255,6 +255,25 @@ var _ = Describe("Client", func() {
 				// TODO(seans3): implement these
 				// Example: ListOptions
 			})
+
+			Context("with the DryRun option", func() {
+				It("should not create a new object", func(done Done) {
+					cl, err := client.New(cfg, client.Options{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cl).NotTo(BeNil())
+
+					By("creating the object (with DryRun)")
+					err = cl.Create(context.TODO(), dep, client.CreateDryRunAll())
+					Expect(err).NotTo(HaveOccurred())
+
+					actual, err := clientset.AppsV1().Deployments(ns).Get(dep.Name, metav1.GetOptions{})
+					Expect(err).To(HaveOccurred())
+					Expect(errors.IsNotFound(err)).To(BeTrue())
+					Expect(actual).To(Equal(&appsv1.Deployment{}))
+
+					close(done)
+				})
+			})
 		})
 
 		Context("with unstructured objects", func() {
@@ -367,6 +386,33 @@ var _ = Describe("Client", func() {
 
 		})
 
+		Context("with the DryRun option", func() {
+			It("should not create a new object from a go struct", func(done Done) {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("encoding the deployment as unstructured")
+				u := &unstructured.Unstructured{}
+				scheme.Convert(dep, u, nil)
+				u.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "apps",
+					Kind:    "Deployment",
+					Version: "v1",
+				})
+
+				By("creating the object")
+				err = cl.Create(context.TODO(), u, client.CreateDryRunAll())
+				Expect(err).NotTo(HaveOccurred())
+
+				actual, err := clientset.AppsV1().Deployments(ns).Get(dep.Name, metav1.GetOptions{})
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+				Expect(actual).To(Equal(&appsv1.Deployment{}))
+
+				close(done)
+			})
+		})
 	})
 
 	Describe("Update", func() {
@@ -1722,6 +1768,22 @@ var _ = Describe("Client", func() {
 		})
 	})
 
+	Describe("CreateOptions", func() {
+		It("should allow setting DryRun to 'all'", func() {
+			co := &client.CreateOptions{}
+			client.CreateDryRunAll()(co)
+			all := []string{metav1.DryRunAll}
+			Expect(co.AsCreateOptions().DryRun).To(Equal(all))
+		})
+
+		It("should produce empty metav1.CreateOptions if nil", func() {
+			var co *client.CreateOptions
+			Expect(co.AsCreateOptions()).To(Equal(&metav1.CreateOptions{}))
+			co = &client.CreateOptions{}
+			Expect(co.AsCreateOptions()).To(Equal(&metav1.CreateOptions{}))
+		})
+	})
+
 	Describe("DeleteOptions", func() {
 		It("should allow setting GracePeriodSeconds", func() {
 			do := &client.DeleteOptions{}
@@ -1844,6 +1906,22 @@ var _ = Describe("Client", func() {
 			client.UseListOptions(newLo.InNamespace("test"))(lo)
 			Expect(lo).NotTo(BeNil())
 			Expect(lo.Namespace).To(Equal("test"))
+		})
+	})
+
+	Describe("UpdateOptions", func() {
+		It("should allow setting DryRun to 'all'", func() {
+			uo := &client.UpdateOptions{}
+			client.UpdateDryRunAll()(uo)
+			all := []string{metav1.DryRunAll}
+			Expect(uo.AsUpdateOptions().DryRun).To(Equal(all))
+		})
+
+		It("should produce empty metav1.UpdateOptions if nil", func() {
+			var co *client.UpdateOptions
+			Expect(co.AsUpdateOptions()).To(Equal(&metav1.UpdateOptions{}))
+			co = &client.UpdateOptions{}
+			Expect(co.AsUpdateOptions()).To(Equal(&metav1.UpdateOptions{}))
 		})
 	})
 })

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -138,7 +139,16 @@ func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...clien
 	return nil
 }
 
-func (c *fakeClient) Create(ctx context.Context, obj runtime.Object) error {
+func (c *fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOptionFunc) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
 	gvr, err := getGVRFromObject(obj, c.scheme)
 	if err != nil {
 		return err
@@ -163,7 +173,16 @@ func (c *fakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...cli
 	return c.tracker.Delete(gvr, accessor.GetNamespace(), accessor.GetName())
 }
 
-func (c *fakeClient) Update(ctx context.Context, obj runtime.Object) error {
+func (c *fakeClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOptionFunc) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
 	gvr, err := getGVRFromObject(obj, c.scheme)
 	if err != nil {
 		return err

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -30,31 +30,39 @@ type typedClient struct {
 }
 
 // Create implements client.Client
-func (c *typedClient) Create(ctx context.Context, obj runtime.Object) error {
+func (c *typedClient) Create(ctx context.Context, obj runtime.Object, opts ...CreateOptionFunc) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
+
+	createOpts := &CreateOptions{}
+	createOpts.ApplyOptions(opts)
 	return o.Post().
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Body(obj).
+		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
 		Context(ctx).
 		Do().
 		Into(obj)
 }
 
 // Update implements client.Client
-func (c *typedClient) Update(ctx context.Context, obj runtime.Object) error {
+func (c *typedClient) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
+
+	updateOpts := &UpdateOptions{}
+	updateOpts.ApplyOptions(opts)
 	return o.Put().
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.GetName()).
 		Body(obj).
+		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
 		Context(ctx).
 		Do().
 		Into(obj)

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -37,16 +37,18 @@ type unstructuredClient struct {
 }
 
 // Create implements client.Client
-func (uc *unstructuredClient) Create(_ context.Context, obj runtime.Object) error {
+func (uc *unstructuredClient) Create(_ context.Context, obj runtime.Object, opts ...CreateOptionFunc) error {
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
+	createOpts := CreateOptions{}
+	createOpts.ApplyOptions(opts)
 	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
 	if err != nil {
 		return err
 	}
-	i, err := r.Create(u, metav1.CreateOptions{})
+	i, err := r.Create(u, *createOpts.AsCreateOptions())
 	if err != nil {
 		return err
 	}
@@ -55,16 +57,18 @@ func (uc *unstructuredClient) Create(_ context.Context, obj runtime.Object) erro
 }
 
 // Update implements client.Client
-func (uc *unstructuredClient) Update(_ context.Context, obj runtime.Object) error {
+func (uc *unstructuredClient) Update(_ context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
+	updateOpts := UpdateOptions{}
+	updateOpts.ApplyOptions(opts)
 	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
 	if err != nil {
 		return err
 	}
-	i, err := r.Update(u, metav1.UpdateOptions{})
+	i, err := r.Update(u, *updateOpts.AsUpdateOptions())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds `CreateOptions` and `UpdateOptions` to the `Client` package to allow client users to set the `DryRun` option when creating and updating resources using the client. This should allow users to see the result of all Admission controllers before persisting changes.

I've attempted to match the patterns in `DeleteOptions` and `ListOptions` as much as possible but since the only valid value for `DryRun` is `all` (see [here](https://github.com/kubernetes/apimachinery/blob/dcb391cde5ca0298013d43336817d20b74650702/pkg/apis/meta/v1/types.go#L501-L507)) I've not made that configurable, but it could be easily changed. I've also had to name the two `OptionFuncs` `CreateDryRunAll` and `UpdateDryRunAll` which I don't particularly like, has anyway any better ideas for names for these?
