### PR TITLE
:bug: Fix typos in comment

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,7 +50,7 @@ type Controller interface {
 	//
 	// Watch may be provided one or more Predicates to filter events before
 	// they are given to the EventHandler.  Events will be passed to the
-	// EventHandler iff all provided Predicates evaluate to true.
+	// EventHandler if all provided Predicates evaluate to true.
 	Watch(src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
 
 	// Start starts the controller.  Start blocks until stop is closed or a

--- a/pkg/source/internal/eventsource.go
+++ b/pkg/source/internal/eventsource.go
@@ -42,7 +42,7 @@ type EventHandler struct {
 	Predicates   []predicate.Predicate
 }
 
-// OnAdd creates and CreateEvent and calls Create on EventHandler
+// OnAdd creates CreateEvent and calls Create on EventHandler
 func (e EventHandler) OnAdd(obj interface{}) {
 	c := event.CreateEvent{}
 
@@ -74,7 +74,7 @@ func (e EventHandler) OnAdd(obj interface{}) {
 	e.EventHandler.Create(c, e.Queue)
 }
 
-// OnUpdate creates and UpdateEvent and calls Update on EventHandler
+// OnUpdate creates UpdateEvent and calls Update on EventHandler
 func (e EventHandler) OnUpdate(oldObj, newObj interface{}) {
 	u := event.UpdateEvent{}
 
@@ -124,7 +124,7 @@ func (e EventHandler) OnUpdate(oldObj, newObj interface{}) {
 	e.EventHandler.Update(u, e.Queue)
 }
 
-// OnDelete creates and DeleteEvent and calls Delete on EventHandler
+// OnDelete creates DeleteEvent and calls Delete on EventHandler
 func (e EventHandler) OnDelete(obj interface{}) {
 	d := event.DeleteEvent{}
 


### PR DESCRIPTION
Fix some typos in comment.
- iff -> if
- remove unnecessary "and"

