### PR TITLE
:sparkles: [WIP] Structured Errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -482,6 +482,18 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:cc5c2ca087db25b6dcae0e2e2714582bc900f0b711acc42f8bc10c5e2bc5a159"
+  name = "golang.org/x/exp"
+  packages = [
+    "errors",
+    "errors/fmt",
+    "errors/internal",
+  ]
+  pruneopts = "UT"
+  revision = "a1d7652674e8f269b17d9be90d3c4c1d0e8830e8"
+
+[[projects]]
+  branch = "master"
   digest = "1:ff58bc124488348ba2ca02f62de899d07ba3e7dce51da02557bfc9a8052608db"
   name = "golang.org/x/net"
   packages = [
@@ -944,6 +956,8 @@
     "go.uber.org/zap",
     "go.uber.org/zap/buffer",
     "go.uber.org/zap/zapcore",
+    "golang.org/x/exp/errors",
+    "golang.org/x/exp/errors/fmt",
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/apps/v1",
     "k8s.io/api/autoscaling/v1",

--- a/example/controller.go
+++ b/example/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/erreur"
 )
 
 // reconcileReplicaSet reconciles ReplicaSets
@@ -51,7 +52,7 @@ func (r *reconcileReplicaSet) Reconcile(request reconcile.Request) (reconcile.Re
 
 	if err != nil {
 		log.Error(err, "Could not fetch ReplicaSet")
-		return reconcile.Result{}, err
+		return reconcile.Result{}, erreur.WithValues("could not find ReplicaSet", "replicaset", request.NamespacedName).CausedBy(err)
 	}
 
 	// Print the ReplicaSet

--- a/pkg/erreur/README.md
+++ b/pkg/erreur/README.md
@@ -1,0 +1,4 @@
+Erreur: Fancy Errors
+====================
+
+

--- a/pkg/erreur/base.go
+++ b/pkg/erreur/base.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package erreur defines structured errors.
+//
+// The API is designed to feel very similar to logr,
+// and all erreur errors will automatically inject their
+// structured data into logs when using logr.
+//
+// All erreur errors also implement the prototype Go 2 error
+// interfaces from golang.org/x/exp/errors
+package erreur
+
+// ValueReceiver is some sink that knows how to receive key-value
+// pairs (e.g. from an Error).  It can be used to receive all key-value
+// pairs from an Error for logging, to print all key-value pairs, etc.
+type ValueReceiver interface {
+	Pair(key string, val interface{})
+}
+
+// Error is an error with structured data attached.
+type Error interface {
+	error
+	Structured
+}
+
+// Structured contains structured key-value pairs, and knows
+// how to dump them into a ValueReceiver.
+type Structured interface {
+	ValuesInto(ValueReceiver)
+}

--- a/pkg/erreur/doc.go
+++ b/pkg/erreur/doc.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package erreur defines structured errors.
+//
+// The API is designed to feel very similar to logr,
+// and is designed to be easy to handle by structured
+// logging implementations (like zapr).
+//
+// All erreur errors produced by the helpers in this package
+// also implement the prototype Go 2 error interfaces from
+// golang.org/x/exp/errors (Formatter, Wrapper).
+//
+// If the CAPTURE_STACK_TRACES environment variable is set to
+// `true` or `1`, it will automatically capture stack traces
+// unless otherwise explicitly disabled.
+package erreur

--- a/pkg/erreur/easy.go
+++ b/pkg/erreur/easy.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package erreur
+
+import (
+	"golang.org/x/exp/errors"
+)
+
+// CauseSetter is some error that can have a cause set.
+// It's like the opposite of errors.Wrapper.
+type CauseSetter interface {
+	// CausedBy marks that this error is caused by the given
+	// error.  It always returns itself for convinience.
+	CausedBy(err error) error
+}
+
+// ErrorWithCause is an Error whose cause can be set (i.e.
+// also a CauseSetter).
+type ErrorWithCause interface {
+	Error
+	CauseSetter
+}
+
+// easyError is similar to errorImpl, except that it directly
+// takes the set of pairs to save (meaning one less allocation
+// per new error).
+type easyError struct {
+	errorMixin
+	pairs []interface{}
+}
+
+func (e *easyError) ValuesInto(out ValueReceiver) {
+	for i := 0; i < len(e.pairs); i+=2 {
+		out.Pair(e.pairs[i].(string), e.pairs[i+1])
+	}
+
+	if e.wrapped == nil {
+		return
+	}
+
+	next, isStructured := e.wrapped.(Structured)
+	if !isStructured {
+		return
+	}
+
+	next.ValuesInto(out)
+}
+
+func (e *easyError) FormatError(p errors.Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	e.ValuesInto(PrintingReceiver{Printer: p})
+	return e.wrapped
+}
+
+// WithValues returns a new Error with the given message and key-value
+// pairs (like logr).  Wrap with CausedBy(cause, thisError) to set a cause.
+func WithValues(msg string, keysAndValues ...interface{}) ErrorWithCause {
+	// don't just call from base b/c we'd need an extra caller skip
+	return &easyError{
+		errorMixin: errorMixin{
+			msg: msg,
+			frame: maybeTrace(),
+		},
+		pairs: keysAndValues,
+	}
+}
+
+// CausedBy sets the cause of the first error to the second error,
+// if the first error is a CauseSetter.  It always returns the first
+// error.
+func CausedBy(newError, cause error) error {
+	if setter, canSet := newError.(CauseSetter); canSet {
+		setter.CausedBy(cause)
+		return newError
+	}
+	
+	return newError
+}

--- a/pkg/erreur/easy_bench_test.go
+++ b/pkg/erreur/easy_bench_test.go
@@ -1,0 +1,62 @@
+package erreur_test
+
+import (
+	oldfmt "fmt"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/erreur"
+	rzap "go.uber.org/zap"
+	"golang.org/x/exp/errors/fmt"
+)
+
+func init() {
+	out, _, err := rzap.Open()
+	if err != nil {
+		panic(err)
+	}
+	log.SetLogger(zap.LoggerTo(out, false))
+}
+
+func TestWithErreur(t *testing.T) {
+	printErreurError()
+}
+
+func printErreurError() {
+	cause := erreur.WithValues("something went wrong", "borked", "subsystem")
+	err := erreur.WithValues("there was a problem", "problem", "in the manifolds").CausedBy(cause)
+	log.Log.Error(err, "couldn't do the thing")
+}
+
+func BenchmarkWithErreur(b *testing.B) {
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		printErreurError()
+	}
+}
+
+func printExpError() {
+	cause := fmt.Errorf("something went wrong -- borked: %s", "subsystem")
+	err := fmt.Errorf("there was a problem -- problem: %s -- %v", "in the manifolds", cause)
+	log.Log.Error(err, "couldn't do the thing")
+}
+
+func BenchmarkExpError(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		printExpError()
+	}
+}
+
+func printFmtError() {
+	cause := oldfmt.Errorf("something went wrong -- borked: %s", "subsystem")
+	err := oldfmt.Errorf("there was a problem -- problem: %s -- %v", "in the manifolds", cause)
+	log.Log.Error(err, "couldn't do the thing")
+}
+
+func BenchmarkPlainFmt(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		printFmtError()
+	}
+}

--- a/pkg/erreur/impl.go
+++ b/pkg/erreur/impl.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package erreur
+
+import (
+	"golang.org/x/exp/errors"
+)
+
+// HasCaller is an error with a stack trace attached
+type HasCaller interface {
+	Caller() errors.Frame
+}
+
+// errorMixin is the base functionality shared by easyError and errorImpl.
+// It contains implementations of methods having to do with message, error wrapping,
+// and stack trace capturing.
+type errorMixin struct {
+	msg string
+	wrapped error
+	frame errors.Frame
+}
+func (e *errorMixin) Unwrap() error {
+	return e.wrapped
+}
+func (e *errorMixin) Error() string {
+	return e.msg
+}
+func (e *errorMixin) Caller() errors.Frame {
+	return e.frame
+}
+func (e *errorMixin) CausedBy(err error) error {
+	e.wrapped = err
+	return e
+}
+
+// errorImpl is a wrapper that implements Error from some
+// base primitives (Structured, plus potentially a message, caller, etc)
+type errorImpl struct {
+	structured Structured
+	errorMixin
+}
+
+func (e *errorImpl) ValuesInto(out ValueReceiver) {
+	e.structured.ValuesInto(out)
+	if e.wrapped == nil {
+		return
+	}
+
+	next, isStructured := e.wrapped.(Structured)
+	if !isStructured {
+		return
+	}
+
+	next.ValuesInto(out)
+}
+
+func (e *errorImpl) FormatError(p errors.Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	e.ValuesInto(PrintingReceiver{Printer: p})
+	return e.wrapped
+}
+
+// WithStructured returns a new Error with the given message and structured
+// data provided by keysAndValues.  Use this is you have some static
+// data structure representing your error.
+func WithStructured(msg string, keysAndValues Structured) ErrorWithCause {
+	return &errorImpl{
+		structured: keysAndValues,
+		errorMixin: errorMixin{
+			msg: msg,
+			frame: maybeTrace(),
+		},
+	}
+}

--- a/pkg/erreur/receivers.go
+++ b/pkg/erreur/receivers.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package erreur
+
+import (
+	"golang.org/x/exp/errors"
+)
+
+// PrintingReceiver receives values, and prints them using the given printer.
+type PrintingReceiver struct {
+	errors.Printer
+}
+func (r PrintingReceiver) Pair(key string, val interface{}) {
+	if r.Detail() {
+		r.Printf("%s: %+v", key, val)
+	}
+}

--- a/pkg/erreur/trace.go
+++ b/pkg/erreur/trace.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package erreur
+
+import (
+	"os"
+	"sync/atomic"
+
+	"golang.org/x/exp/errors"
+)
+
+var (
+	// captureTrace is effectively an "atomic bool"
+	captureTrace uint32
+	// traceEnvVar is the environment variable that controls
+	// stack trace capturing on start-up.
+	traceEnvVar = "CAPTURE_STACK_TRACES"
+)
+
+func init() {
+	envVarVal := os.Getenv(traceEnvVar)
+	if envVarVal == "true" || envVarVal == "1" {
+		CaptureStackTraces()
+	}
+}
+
+func CaptureStackTraces() {
+	atomic.StoreUint32(&captureTrace, 1)
+}
+
+func DontCaptureStackTraces() {
+	atomic.StoreUint32(&captureTrace, 0)
+}
+
+func maybeTrace() errors.Frame {
+	if atomic.LoadUint32(&captureTrace) == 0 {
+		return errors.Frame{}
+	}
+
+	return errors.Caller(2)
+}

--- a/pkg/log/zap/erreur_helpers.go
+++ b/pkg/log/zap/erreur_helpers.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package zap
+
+import (
+	"bytes"
+	"fmt"
+
+	"go.uber.org/zap/buffer"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/erreur"
+	"golang.org/x/exp/errors"
+)
+
+// ErreurAwareEncoder is an structured-error-aware Zap Encoder.  It adds
+// structure as extra fields, and sets the stack if available.  Instead of
+// trying to force Erreur errors objects to implement ObjectMarshaller, we just
+// implement a wrapper Encoder that checks for pkg/erreur types.
+type ErreurAwareEncoder struct {
+	// Encoder is the zapcore.Encoder that this encoder delegates to
+	zapcore.Encoder
+
+	// Verbose indicates if stack traces should be printed.
+	Verbose bool
+}
+
+// NB(directxman12): can't just override AddReflected, since the encoder calls AddReflected on itself directly
+
+// Clone implements zapcore.Encoder
+func (k *ErreurAwareEncoder) Clone() zapcore.Encoder {
+	return &ErreurAwareEncoder{
+		Encoder: k.Encoder.Clone(),
+	}
+}
+
+// EncodeEntry implements zapcore.Encoder
+func (k *ErreurAwareEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Field) (*buffer.Buffer, error) {
+	for i, field := range fields {
+		if field.Type != zapcore.ErrorType {
+			continue
+		}
+
+		structured, isStructured := field.Interface.(erreur.Structured)
+		if !isStructured {
+			continue
+		}
+		// NB: commented-out code is a slightly less efficient way of doing things,
+		// but closer to what zap normally looks like
+		/*valRecv := &fieldValRecv{fields: fields}
+		structured.ValuesInto(valRecv)
+		fields = valRecv.fields*/
+		fields[i] = zap.Object(field.Key, structuredMarshaller{err: field.Interface.(error), structured: structured, unwrappable: field.Interface.(errors.Wrapper)})
+
+		/*if unwrappable, canUnwrap := field.Interface.(errors.Wrapper); canUnwrap && unwrappable.Unwrap() != nil {
+			fields = append(fields, zap.Array("errorCauses", causeArrayMarshaller{wrapped: unwrappable}))
+		}*/
+
+		// TODO(directxman12): do we really want to override the stack like this?
+		withTrace, hasTrace := field.Interface.(erreur.HasCaller)
+		if !hasTrace {
+			continue
+		}
+		trace := withTrace.Caller()
+		if trace == (errors.Frame{}) {
+			continue
+		}
+		traceOut := bufferPrinter{
+			detail: k.Verbose,
+		}
+		trace.Format(&traceOut)
+		entry.Stack = traceOut.Buffer.String()
+	}
+
+	return k.Encoder.EncodeEntry(entry, fields)
+}
+
+// fieldValRecv is an erreur.ValueReceiver that appends zapcore.Fields.
+type fieldValRecv struct {
+	fields []zapcore.Field
+}
+
+func (r *fieldValRecv) Pair(key string, val interface{}) {
+	r.fields = append(r.fields, zap.Any(key, val))
+}
+
+type bufferPrinter struct{
+	bytes.Buffer
+	detail bool
+}
+func (p *bufferPrinter) Print(args ...interface{}) {
+	fmt.Fprint(&p.Buffer, args...)
+}
+func (p *bufferPrinter) Printf(format string, args ...interface{}) {
+	fmt.Fprintf(&p.Buffer, format, args...)
+}
+func (p *bufferPrinter) Detail() bool {
+	return p.detail
+}
+
+// causeArrayMarshaller fakes multi-error support using the same key Zap does,
+// but without requiring allocations, etc.
+type causeArrayMarshaller struct {
+	wrapped errors.Wrapper
+}
+func (c causeArrayMarshaller) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	next := c.wrapped.Unwrap()
+	for next != nil {
+		enc.AppendString(next.Error())
+		unwrappable, canUnwrap := next.(errors.Wrapper)
+		if !canUnwrap {
+			next = nil
+			continue
+		}
+		next = unwrappable.Unwrap()
+	}
+
+	return nil
+}
+
+type structuredMarshaller struct {
+	err error
+	structured erreur.Structured
+	unwrappable errors.Wrapper
+}
+
+func (s structuredMarshaller) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("message", s.err.Error())
+	s.structured.ValuesInto(encValRecv{enc: enc})
+	if s.unwrappable != nil && s.unwrappable.Unwrap() != nil {
+		if err := enc.AddArray("causes", causeArrayMarshaller{wrapped: s.unwrappable}); err != nil {
+			return nil
+		}
+	}
+	return nil
+}
+
+type encValRecv struct {
+	enc zapcore.ObjectEncoder
+}
+func (e encValRecv) Pair(key string, val interface{}) {
+	e.enc.AddReflected(key, val)
+}

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -67,7 +67,10 @@ func RawLoggerTo(destWriter io.Writer, development bool, opts ...zap.Option) *za
 			}))
 	}
 	opts = append(opts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
-	log := zap.New(zapcore.NewCore(&KubeAwareEncoder{Encoder: enc, Verbose: development}, sink, lvl))
+	log := zap.New(zapcore.NewCore(&ErreurAwareEncoder{
+		Encoder: &KubeAwareEncoder{Encoder: enc, Verbose: development},
+		Verbose: true,
+	}, sink, lvl))
 	log = log.WithOptions(opts...)
 	return log
 }

--- a/vendor/golang.org/x/exp/AUTHORS
+++ b/vendor/golang.org/x/exp/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/exp/CONTRIBUTORS
+++ b/vendor/golang.org/x/exp/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/exp/LICENSE
+++ b/vendor/golang.org/x/exp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/exp/PATENTS
+++ b/vendor/golang.org/x/exp/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/exp/errors/errors.go
+++ b/vendor/golang.org/x/exp/errors/errors.go
@@ -1,0 +1,35 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errors implements functions to manipulate errors.
+//
+// This package implements the Go 2 draft designs for error inspection and printing:
+//   https://go.googlesource.com/proposal/+/master/design/go2draft.md
+//
+// This is an EXPERIMENTAL package, and may change in arbitrary ways without notice.
+package errors
+
+// errorString is a trivial implementation of error.
+type errorString struct {
+	s     string
+	frame Frame
+}
+
+// New returns an error that formats as the given text.
+//
+// The returned error embeds a Frame set to the caller's location and implements
+// Formatter to show this information when printed with details.
+func New(text string) error {
+	return &errorString{text, Caller(1)}
+}
+
+func (e *errorString) Error() string {
+	return e.s
+}
+
+func (e *errorString) FormatError(p Printer) (next error) {
+	p.Print(e.s)
+	e.frame.Format(p)
+	return nil
+}

--- a/vendor/golang.org/x/exp/errors/fmt/adaptor.go
+++ b/vendor/golang.org/x/exp/errors/fmt/adaptor.go
@@ -1,0 +1,31 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import "golang.org/x/exp/errors"
+
+// The functionality in this file is to provide adaptors only. It will not
+// be included in the standard library.
+
+// FormatError calls the FormatError method of err with a errors.Printer
+// configured according to s and verb and writes the result to s.
+func FormatError(s State, verb rune, err errors.Formatter) {
+	// Assuming this function is only called from the Format method, and given
+	// that FormatError takes precedence over Format, it cannot be called from
+	// any package that supports errors.Formatter. It is therefore safe to
+	// disregard that State may be a specific printer implementation and use one
+	// of our choice instead.
+	p := newPrinter()
+	if verb == 'v' {
+		if s.Flag('#') {
+			p.fmt.sharpV = true
+		}
+		if s.Flag('+') {
+			p.fmt.plusV = true
+		}
+	}
+	fmtError(p, verb, err)
+	s.Write(p.buf)
+}

--- a/vendor/golang.org/x/exp/errors/fmt/doc.go
+++ b/vendor/golang.org/x/exp/errors/fmt/doc.go
@@ -1,0 +1,346 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+	Package fmt implements formatted I/O with functions analogous
+	to C's printf and scanf.  The format 'verbs' are derived from C's but
+	are simpler.
+
+
+	Printing
+
+	The verbs:
+
+	General:
+		%v	the value in a default format
+			when printing structs, the plus flag (%+v) adds field names
+		%#v	a Go-syntax representation of the value
+		%T	a Go-syntax representation of the type of the value
+		%%	a literal percent sign; consumes no value
+
+	Boolean:
+		%t	the word true or false
+	Integer:
+		%b	base 2
+		%c	the character represented by the corresponding Unicode code point
+		%d	base 10
+		%o	base 8
+		%q	a single-quoted character literal safely escaped with Go syntax.
+		%x	base 16, with lower-case letters for a-f
+		%X	base 16, with upper-case letters for A-F
+		%U	Unicode format: U+1234; same as "U+%04X"
+	Floating-point and complex constituents:
+		%b	decimalless scientific notation with exponent a power of two,
+			in the manner of strconv.FormatFloat with the 'b' format,
+			e.g. -123456p-78
+		%e	scientific notation, e.g. -1.234456e+78
+		%E	scientific notation, e.g. -1.234456E+78
+		%f	decimal point but no exponent, e.g. 123.456
+		%F	synonym for %f
+		%g	%e for large exponents, %f otherwise. Precision is discussed below.
+		%G	%E for large exponents, %F otherwise
+	String and slice of bytes (treated equivalently with these verbs):
+		%s	the uninterpreted bytes of the string or slice
+		%q	a double-quoted string safely escaped with Go syntax
+		%x	base 16, lower-case, two characters per byte
+		%X	base 16, upper-case, two characters per byte
+	Slice:
+		%p	address of 0th element in base 16 notation, with leading 0x
+	Pointer:
+		%p	base 16 notation, with leading 0x
+		The %b, %d, %o, %x and %X verbs also work with pointers,
+		formatting the value exactly as if it were an integer.
+
+	The default format for %v is:
+		bool:                    %t
+		int, int8 etc.:          %d
+		uint, uint8 etc.:        %d, %#x if printed with %#v
+		float32, complex64, etc: %g
+		string:                  %s
+		chan:                    %p
+		pointer:                 %p
+	For compound objects, the elements are printed using these rules, recursively,
+	laid out like this:
+		struct:             {field0 field1 ...}
+		array, slice:       [elem0 elem1 ...]
+		maps:               map[key1:value1 key2:value2 ...]
+		pointer to above:   &{}, &[], &map[]
+
+	Width is specified by an optional decimal number immediately preceding the verb.
+	If absent, the width is whatever is necessary to represent the value.
+	Precision is specified after the (optional) width by a period followed by a
+	decimal number. If no period is present, a default precision is used.
+	A period with no following number specifies a precision of zero.
+	Examples:
+		%f     default width, default precision
+		%9f    width 9, default precision
+		%.2f   default width, precision 2
+		%9.2f  width 9, precision 2
+		%9.f   width 9, precision 0
+
+	Width and precision are measured in units of Unicode code points,
+	that is, runes. (This differs from C's printf where the
+	units are always measured in bytes.) Either or both of the flags
+	may be replaced with the character '*', causing their values to be
+	obtained from the next operand (preceding the one to format),
+	which must be of type int.
+
+	For most values, width is the minimum number of runes to output,
+	padding the formatted form with spaces if necessary.
+
+	For strings, byte slices and byte arrays, however, precision
+	limits the length of the input to be formatted (not the size of
+	the output), truncating if necessary. Normally it is measured in
+	runes, but for these types when formatted with the %x or %X format
+	it is measured in bytes.
+
+	For floating-point values, width sets the minimum width of the field and
+	precision sets the number of places after the decimal, if appropriate,
+	except that for %g/%G precision sets the maximum number of significant
+	digits (trailing zeros are removed). For example, given 12.345 the format
+	%6.3f prints 12.345 while %.3g prints 12.3. The default precision for %e, %f
+	and %#g is 6; for %g it is the smallest number of digits necessary to identify
+	the value uniquely.
+
+	For complex numbers, the width and precision apply to the two
+	components independently and the result is parenthesized, so %f applied
+	to 1.2+3.4i produces (1.200000+3.400000i).
+
+	Other flags:
+		+	always print a sign for numeric values;
+			guarantee ASCII-only output for %q (%+q)
+		-	pad with spaces on the right rather than the left (left-justify the field)
+		#	alternate format: add leading 0 for octal (%#o), 0x for hex (%#x);
+			0X for hex (%#X); suppress 0x for %p (%#p);
+			for %q, print a raw (backquoted) string if strconv.CanBackquote
+			returns true;
+			always print a decimal point for %e, %E, %f, %F, %g and %G;
+			do not remove trailing zeros for %g and %G;
+			write e.g. U+0078 'x' if the character is printable for %U (%#U).
+		' '	(space) leave a space for elided sign in numbers (% d);
+			put spaces between bytes printing strings or slices in hex (% x, % X)
+		0	pad with leading zeros rather than spaces;
+			for numbers, this moves the padding after the sign
+
+	Flags are ignored by verbs that do not expect them.
+	For example there is no alternate decimal format, so %#d and %d
+	behave identically.
+
+	For each Printf-like function, there is also a Print function
+	that takes no format and is equivalent to saying %v for every
+	operand.  Another variant Println inserts blanks between
+	operands and appends a newline.
+
+	Regardless of the verb, if an operand is an interface value,
+	the internal concrete value is used, not the interface itself.
+	Thus:
+		var i interface{} = 23
+		fmt.Printf("%v\n", i)
+	will print 23.
+
+	Except when printed using the verbs %T and %p, special
+	formatting considerations apply for operands that implement
+	certain interfaces. In order of application:
+
+	1. If the operand is a reflect.Value, the operand is replaced by the
+	concrete value that it holds, and printing continues with the next rule.
+
+	2. If an operand implements the Formatter interface, and not
+	errors.Formatter, it will be invoked. Formatter provides fine
+	control of formatting.
+
+	3. If the %v verb is used with the # flag (%#v) and the operand
+	implements the GoStringer interface, that will be invoked.
+
+	If the format (which is implicitly %v for Println etc.) is valid
+	for a string (%s %q %v %x %X), the following three rules apply:
+
+	4. If an operand implements errors.Formatter, the FormatError
+	method will be invoked with an errors.Printer to print the error.
+	If the %v flag is used with the + flag (%+v), the Detail method
+	of the Printer will return true and the error will be formatted
+	as a detailed error message. Otherwise the printed string will
+	be formatted as required by the verb (if any).
+
+	5. If an operand implements the error interface, the Error method
+	will be invoked to convert the object to a string, which will then
+	be formatted as required by the verb (if any).
+
+	6. If an operand implements method String() string, that method
+	will be invoked to convert the object to a string, which will then
+	be formatted as required by the verb (if any).
+
+	For compound operands such as slices and structs, the format
+	applies to the elements of each operand, recursively, not to the
+	operand as a whole. Thus %q will quote each element of a slice
+	of strings, and %6.2f will control formatting for each element
+	of a floating-point array.
+
+	However, when printing a byte slice with a string-like verb
+	(%s %q %x %X), it is treated identically to a string, as a single item.
+
+	To avoid recursion in cases such as
+		type X string
+		func (x X) String() string { return Sprintf("<%s>", x) }
+	convert the value before recurring:
+		func (x X) String() string { return Sprintf("<%s>", string(x)) }
+	Infinite recursion can also be triggered by self-referential data
+	structures, such as a slice that contains itself as an element, if
+	that type has a String method. Such pathologies are rare, however,
+	and the package does not protect against them.
+
+	When printing a struct, fmt cannot and therefore does not invoke
+	formatting methods such as Error or String on unexported fields.
+
+	Explicit argument indexes:
+
+	In Printf, Sprintf, and Fprintf, the default behavior is for each
+	formatting verb to format successive arguments passed in the call.
+	However, the notation [n] immediately before the verb indicates that the
+	nth one-indexed argument is to be formatted instead. The same notation
+	before a '*' for a width or precision selects the argument index holding
+	the value. After processing a bracketed expression [n], subsequent verbs
+	will use arguments n+1, n+2, etc. unless otherwise directed.
+
+	For example,
+		fmt.Sprintf("%[2]d %[1]d\n", 11, 22)
+	will yield "22 11", while
+		fmt.Sprintf("%[3]*.[2]*[1]f", 12.0, 2, 6)
+	equivalent to
+		fmt.Sprintf("%6.2f", 12.0)
+	will yield " 12.00". Because an explicit index affects subsequent verbs,
+	this notation can be used to print the same values multiple times
+	by resetting the index for the first argument to be repeated:
+		fmt.Sprintf("%d %d %#[1]x %#x", 16, 17)
+	will yield "16 17 0x10 0x11".
+
+	Format errors:
+
+	If an invalid argument is given for a verb, such as providing
+	a string to %d, the generated string will contain a
+	description of the problem, as in these examples:
+
+		Wrong type or unknown verb: %!verb(type=value)
+			Printf("%d", hi):          %!d(string=hi)
+		Too many arguments: %!(EXTRA type=value)
+			Printf("hi", "guys"):      hi%!(EXTRA string=guys)
+		Too few arguments: %!verb(MISSING)
+			Printf("hi%d"):            hi%!d(MISSING)
+		Non-int for width or precision: %!(BADWIDTH) or %!(BADPREC)
+			Printf("%*s", 4.5, "hi"):  %!(BADWIDTH)hi
+			Printf("%.*s", 4.5, "hi"): %!(BADPREC)hi
+		Invalid or invalid use of argument index: %!(BADINDEX)
+			Printf("%*[2]d", 7):       %!d(BADINDEX)
+			Printf("%.[2]d", 7):       %!d(BADINDEX)
+
+	All errors begin with the string "%!" followed sometimes
+	by a single character (the verb) and end with a parenthesized
+	description.
+
+	If an Error or String method triggers a panic when called by a
+	print routine, the fmt package reformats the error message
+	from the panic, decorating it with an indication that it came
+	through the fmt package.  For example, if a String method
+	calls panic("bad"), the resulting formatted message will look
+	like
+		%!s(PANIC=bad)
+
+	The %!s just shows the print verb in use when the failure
+	occurred. If the panic is caused by a nil receiver to an Error
+	or String method, however, the output is the undecorated
+	string, "<nil>".
+
+	Scanning
+
+	An analogous set of functions scans formatted text to yield
+	values.  Scan, Scanf and Scanln read from os.Stdin; Fscan,
+	Fscanf and Fscanln read from a specified io.Reader; Sscan,
+	Sscanf and Sscanln read from an argument string.
+
+	Scan, Fscan, Sscan treat newlines in the input as spaces.
+
+	Scanln, Fscanln and Sscanln stop scanning at a newline and
+	require that the items be followed by a newline or EOF.
+
+	Scanf, Fscanf, and Sscanf parse the arguments according to a
+	format string, analogous to that of Printf. In the text that
+	follows, 'space' means any Unicode whitespace character
+	except newline.
+
+	In the format string, a verb introduced by the % character
+	consumes and parses input; these verbs are described in more
+	detail below. A character other than %, space, or newline in
+	the format consumes exactly that input character, which must
+	be present. A newline with zero or more spaces before it in
+	the format string consumes zero or more spaces in the input
+	followed by a single newline or the end of the input. A space
+	following a newline in the format string consumes zero or more
+	spaces in the input. Otherwise, any run of one or more spaces
+	in the format string consumes as many spaces as possible in
+	the input. Unless the run of spaces in the format string
+	appears adjacent to a newline, the run must consume at least
+	one space from the input or find the end of the input.
+
+	The handling of spaces and newlines differs from that of C's
+	scanf family: in C, newlines are treated as any other space,
+	and it is never an error when a run of spaces in the format
+	string finds no spaces to consume in the input.
+
+	The verbs behave analogously to those of Printf.
+	For example, %x will scan an integer as a hexadecimal number,
+	and %v will scan the default representation format for the value.
+	The Printf verbs %p and %T and the flags # and + are not implemented.
+	The verbs %e %E %f %F %g and %G are all equivalent and scan any
+	floating-point or complex value. For float and complex literals in
+	scientific notation, both the decimal (e) and binary (p) exponent
+	formats are supported (for example: "2.3e+7" and "4.5p-8").
+
+	Input processed by verbs is implicitly space-delimited: the
+	implementation of every verb except %c starts by discarding
+	leading spaces from the remaining input, and the %s verb
+	(and %v reading into a string) stops consuming input at the first
+	space or newline character.
+
+	The familiar base-setting prefixes 0 (octal) and 0x
+	(hexadecimal) are accepted when scanning integers without
+	a format or with the %v verb.
+
+	Width is interpreted in the input text but there is no
+	syntax for scanning with a precision (no %5.2f, just %5f).
+	If width is provided, it applies after leading spaces are
+	trimmed and specifies the maximum number of runes to read
+	to satisfy the verb. For example,
+	   Sscanf(" 1234567 ", "%5s%d", &s, &i)
+	will set s to "12345" and i to 67 while
+	   Sscanf(" 12 34 567 ", "%5s%d", &s, &i)
+	will set s to "12" and i to 34.
+
+	In all the scanning functions, a carriage return followed
+	immediately by a newline is treated as a plain newline
+	(\r\n means the same as \n).
+
+	In all the scanning functions, if an operand implements method
+	Scan (that is, it implements the Scanner interface) that
+	method will be used to scan the text for that operand.  Also,
+	if the number of arguments scanned is less than the number of
+	arguments provided, an error is returned.
+
+	All arguments to be scanned must be either pointers to basic
+	types or implementations of the Scanner interface.
+
+	Like Scanf and Fscanf, Sscanf need not consume its entire input.
+	There is no way to recover how much of the input string Sscanf used.
+
+	Note: Fscan etc. can read one character (rune) past the input
+	they return, which means that a loop calling a scan routine
+	may skip some of the input.  This is usually a problem only
+	when there is no space between input values.  If the reader
+	provided to Fscan implements ReadRune, that method will be used
+	to read characters.  If the reader also implements UnreadRune,
+	that method will be used to save the character and successive
+	calls will not lose data.  To attach ReadRune and UnreadRune
+	methods to a reader without that capability, use
+	bufio.NewReader.
+*/
+package fmt

--- a/vendor/golang.org/x/exp/errors/fmt/errors.go
+++ b/vendor/golang.org/x/exp/errors/fmt/errors.go
@@ -1,0 +1,245 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/exp/errors"
+	"golang.org/x/exp/errors/internal"
+)
+
+// Errorf formats according to a format specifier and returns the string as a
+// value that satisfies error.
+//
+// The returned error includes the file and line number of the caller when
+// formatted with additional detail enabled. If the last argument is an error
+// the returned error's Format method will return it if the format string ends
+// with ": %s", ": %v", or ": %w". If the last argument is an error and the
+// format string ends with ": %w", the returned error implements errors.Wrapper
+// with an Unwrap method returning it.
+func Errorf(format string, a ...interface{}) error {
+	err, wrap := lastError(format, a)
+	if err == nil {
+		return &noWrapError{Sprintf(format, a...), nil, errors.Caller(1)}
+	}
+
+	// TODO: this is not entirely correct. The error value could be
+	// printed elsewhere in format if it mixes numbered with unnumbered
+	// substitutions. With relatively small changes to doPrintf we can
+	// have it optionally ignore extra arguments and pass the argument
+	// list in its entirety.
+	msg := Sprintf(format[:len(format)-len(": %s")], a[:len(a)-1]...)
+	frame := errors.Frame{}
+	if internal.EnableTrace {
+		frame = errors.Caller(1)
+	}
+	if wrap {
+		return &wrapError{msg, err, frame}
+	}
+	return &noWrapError{msg, err, frame}
+}
+
+func lastError(format string, a []interface{}) (err error, wrap bool) {
+	wrap = strings.HasSuffix(format, ": %w")
+	if !wrap &&
+		!strings.HasSuffix(format, ": %s") &&
+		!strings.HasSuffix(format, ": %v") {
+		return nil, false
+	}
+
+	if len(a) == 0 {
+		return nil, false
+	}
+
+	err, ok := a[len(a)-1].(error)
+	if !ok {
+		return nil, false
+	}
+
+	return err, wrap
+}
+
+type noWrapError struct {
+	msg   string
+	err   error
+	frame errors.Frame
+}
+
+func (e *noWrapError) Error() string {
+	return Sprint(e)
+}
+
+func (e *noWrapError) FormatError(p errors.Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+type wrapError struct {
+	msg   string
+	err   error
+	frame errors.Frame
+}
+
+func (e *wrapError) Error() string {
+	return Sprint(e)
+}
+
+func (e *wrapError) FormatError(p errors.Printer) (next error) {
+	p.Print(e.msg)
+	e.frame.Format(p)
+	return e.err
+}
+
+func (e *wrapError) Unwrap() error {
+	return e.err
+}
+
+func fmtError(p *pp, verb rune, err error) (handled bool) {
+	var (
+		sep = " " // separator before next error
+		w   = p   // print buffer where error text is written
+	)
+	switch {
+	// Note that this switch must match the preference order
+	// for ordinary string printing (%#v before %+v, and so on).
+
+	case p.fmt.sharpV:
+		if stringer, ok := p.arg.(GoStringer); ok {
+			// Print the result of GoString unadorned.
+			p.fmt.fmtS(stringer.GoString())
+			return true
+		}
+		return false
+
+	case p.fmt.plusV:
+		sep = "\n  - "
+		w.fmt.fmtFlags = fmtFlags{plusV: p.fmt.plusV} // only keep detail flag
+
+		// The width or precision of a detailed view could be the number of
+		// errors to print from a list.
+
+	default:
+		// Use an intermediate buffer in the rare cases that precision,
+		// truncation, or one of the alternative verbs (q, x, and X) are
+		// specified.
+		switch verb {
+		case 's', 'v':
+			if (!w.fmt.widPresent || w.fmt.wid == 0) && !w.fmt.precPresent {
+				break
+			}
+			fallthrough
+		case 'q', 'x', 'X':
+			w = newPrinter()
+			defer w.free()
+		default:
+			w.badVerb(verb)
+			return true
+		}
+	}
+
+loop:
+	for {
+		w.fmt.inDetail = false
+		switch v := err.(type) {
+		case errors.Formatter:
+			err = v.FormatError((*errPP)(w))
+		case Formatter:
+			if w.fmt.plusV {
+				v.Format((*errPPState)(w), 'v') // indent new lines
+			} else {
+				v.Format(w, 'v') // do not indent new lines
+			}
+			break loop
+		default:
+			w.fmtString(v.Error(), 's')
+			break loop
+		}
+		if err == nil {
+			break
+		}
+		if !w.fmt.inDetail || !p.fmt.plusV {
+			w.buf.WriteByte(':')
+		}
+		// Strip last newline of detail.
+		if bytes.HasSuffix([]byte(w.buf), detailSep) {
+			w.buf = w.buf[:len(w.buf)-len(detailSep)]
+		}
+		w.buf.WriteString(sep)
+		w.fmt.inDetail = false
+	}
+
+	if w != p {
+		p.fmtString(string(w.buf), verb)
+	}
+	return true
+}
+
+var detailSep = []byte("\n    ")
+
+// errPPState wraps a pp to implement State with indentation. It is used
+// for errors implementing fmt.Formatter.
+type errPPState pp
+
+func (p *errPPState) Width() (wid int, ok bool)      { return (*pp)(p).Width() }
+func (p *errPPState) Precision() (prec int, ok bool) { return (*pp)(p).Precision() }
+func (p *errPPState) Flag(c int) bool                { return (*pp)(p).Flag(c) }
+
+func (p *errPPState) Write(b []byte) (n int, err error) {
+	if !p.fmt.inDetail || p.fmt.plusV {
+		if len(b) == 0 {
+			return 0, nil
+		}
+		if p.fmt.inDetail && p.fmt.needNewline {
+			p.fmt.needNewline = false
+			p.buf.WriteByte(':')
+			p.buf.Write(detailSep)
+			if b[0] == '\n' {
+				b = b[1:]
+			}
+		}
+		k := 0
+		for i, c := range b {
+			if c == '\n' {
+				p.buf.Write(b[k:i])
+				p.buf.Write(detailSep)
+				k = i + 1
+			}
+		}
+		p.buf.Write(b[k:])
+		p.fmt.needNewline = !p.fmt.inDetail
+	}
+	return len(b), nil
+}
+
+// errPP wraps a pp to implement an errors.Printer.
+type errPP pp
+
+func (p *errPP) Print(args ...interface{}) {
+	if !p.fmt.inDetail || p.fmt.plusV {
+		if p.fmt.plusV {
+			Fprint((*errPPState)(p), args...)
+		} else {
+			(*pp)(p).doPrint(args)
+		}
+	}
+}
+
+func (p *errPP) Printf(format string, args ...interface{}) {
+	if !p.fmt.inDetail || p.fmt.plusV {
+		if p.fmt.plusV {
+			Fprintf((*errPPState)(p), format, args...)
+		} else {
+			(*pp)(p).doPrintf(format, args)
+		}
+	}
+}
+
+func (p *errPP) Detail() bool {
+	p.fmt.inDetail = true
+	return p.fmt.plusV
+}

--- a/vendor/golang.org/x/exp/errors/fmt/format.go
+++ b/vendor/golang.org/x/exp/errors/fmt/format.go
@@ -1,0 +1,542 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	"strconv"
+	"unicode/utf8"
+)
+
+const (
+	ldigits = "0123456789abcdefx"
+	udigits = "0123456789ABCDEFX"
+)
+
+const (
+	signed   = true
+	unsigned = false
+)
+
+// flags placed in a separate struct for easy clearing.
+type fmtFlags struct {
+	widPresent  bool
+	precPresent bool
+	minus       bool
+	plus        bool
+	sharp       bool
+	space       bool
+	zero        bool
+
+	// For the formats %+v %#v, we set the plusV/sharpV flags
+	// and clear the plus/sharp flags since %+v and %#v are in effect
+	// different, flagless formats set at the top level.
+	plusV  bool
+	sharpV bool
+
+	// error-related flags.
+	inDetail    bool
+	needNewline bool
+}
+
+// A fmt is the raw formatter used by Printf etc.
+// It prints into a buffer that must be set up separately.
+type fmt struct {
+	buf *buffer
+
+	fmtFlags
+
+	wid  int // width
+	prec int // precision
+
+	// intbuf is large enough to store %b of an int64 with a sign and
+	// avoids padding at the end of the struct on 32 bit architectures.
+	intbuf [68]byte
+}
+
+func (f *fmt) clearflags() {
+	f.fmtFlags = fmtFlags{}
+}
+
+func (f *fmt) init(buf *buffer) {
+	f.buf = buf
+	f.clearflags()
+}
+
+// writePadding generates n bytes of padding.
+func (f *fmt) writePadding(n int) {
+	if n <= 0 { // No padding bytes needed.
+		return
+	}
+	buf := *f.buf
+	oldLen := len(buf)
+	newLen := oldLen + n
+	// Make enough room for padding.
+	if newLen > cap(buf) {
+		buf = make(buffer, cap(buf)*2+n)
+		copy(buf, *f.buf)
+	}
+	// Decide which byte the padding should be filled with.
+	padByte := byte(' ')
+	if f.zero {
+		padByte = byte('0')
+	}
+	// Fill padding with padByte.
+	padding := buf[oldLen:newLen]
+	for i := range padding {
+		padding[i] = padByte
+	}
+	*f.buf = buf[:newLen]
+}
+
+// pad appends b to f.buf, padded on left (!f.minus) or right (f.minus).
+func (f *fmt) pad(b []byte) {
+	if !f.widPresent || f.wid == 0 {
+		f.buf.Write(b)
+		return
+	}
+	width := f.wid - utf8.RuneCount(b)
+	if !f.minus {
+		// left padding
+		f.writePadding(width)
+		f.buf.Write(b)
+	} else {
+		// right padding
+		f.buf.Write(b)
+		f.writePadding(width)
+	}
+}
+
+// padString appends s to f.buf, padded on left (!f.minus) or right (f.minus).
+func (f *fmt) padString(s string) {
+	if !f.widPresent || f.wid == 0 {
+		f.buf.WriteString(s)
+		return
+	}
+	width := f.wid - utf8.RuneCountInString(s)
+	if !f.minus {
+		// left padding
+		f.writePadding(width)
+		f.buf.WriteString(s)
+	} else {
+		// right padding
+		f.buf.WriteString(s)
+		f.writePadding(width)
+	}
+}
+
+// fmtBoolean formats a boolean.
+func (f *fmt) fmtBoolean(v bool) {
+	if v {
+		f.padString("true")
+	} else {
+		f.padString("false")
+	}
+}
+
+// fmtUnicode formats a uint64 as "U+0078" or with f.sharp set as "U+0078 'x'".
+func (f *fmt) fmtUnicode(u uint64) {
+	buf := f.intbuf[0:]
+
+	// With default precision set the maximum needed buf length is 18
+	// for formatting -1 with %#U ("U+FFFFFFFFFFFFFFFF") which fits
+	// into the already allocated intbuf with a capacity of 68 bytes.
+	prec := 4
+	if f.precPresent && f.prec > 4 {
+		prec = f.prec
+		// Compute space needed for "U+" , number, " '", character, "'".
+		width := 2 + prec + 2 + utf8.UTFMax + 1
+		if width > len(buf) {
+			buf = make([]byte, width)
+		}
+	}
+
+	// Format into buf, ending at buf[i]. Formatting numbers is easier right-to-left.
+	i := len(buf)
+
+	// For %#U we want to add a space and a quoted character at the end of the buffer.
+	if f.sharp && u <= utf8.MaxRune && strconv.IsPrint(rune(u)) {
+		i--
+		buf[i] = '\''
+		i -= utf8.RuneLen(rune(u))
+		utf8.EncodeRune(buf[i:], rune(u))
+		i--
+		buf[i] = '\''
+		i--
+		buf[i] = ' '
+	}
+	// Format the Unicode code point u as a hexadecimal number.
+	for u >= 16 {
+		i--
+		buf[i] = udigits[u&0xF]
+		prec--
+		u >>= 4
+	}
+	i--
+	buf[i] = udigits[u]
+	prec--
+	// Add zeros in front of the number until requested precision is reached.
+	for prec > 0 {
+		i--
+		buf[i] = '0'
+		prec--
+	}
+	// Add a leading "U+".
+	i--
+	buf[i] = '+'
+	i--
+	buf[i] = 'U'
+
+	oldZero := f.zero
+	f.zero = false
+	f.pad(buf[i:])
+	f.zero = oldZero
+}
+
+// fmtInteger formats signed and unsigned integers.
+func (f *fmt) fmtInteger(u uint64, base int, isSigned bool, digits string) {
+	negative := isSigned && int64(u) < 0
+	if negative {
+		u = -u
+	}
+
+	buf := f.intbuf[0:]
+	// The already allocated f.intbuf with a capacity of 68 bytes
+	// is large enough for integer formatting when no precision or width is set.
+	if f.widPresent || f.precPresent {
+		// Account 3 extra bytes for possible addition of a sign and "0x".
+		width := 3 + f.wid + f.prec // wid and prec are always positive.
+		if width > len(buf) {
+			// We're going to need a bigger boat.
+			buf = make([]byte, width)
+		}
+	}
+
+	// Two ways to ask for extra leading zero digits: %.3d or %03d.
+	// If both are specified the f.zero flag is ignored and
+	// padding with spaces is used instead.
+	prec := 0
+	if f.precPresent {
+		prec = f.prec
+		// Precision of 0 and value of 0 means "print nothing" but padding.
+		if prec == 0 && u == 0 {
+			oldZero := f.zero
+			f.zero = false
+			f.writePadding(f.wid)
+			f.zero = oldZero
+			return
+		}
+	} else if f.zero && f.widPresent {
+		prec = f.wid
+		if negative || f.plus || f.space {
+			prec-- // leave room for sign
+		}
+	}
+
+	// Because printing is easier right-to-left: format u into buf, ending at buf[i].
+	// We could make things marginally faster by splitting the 32-bit case out
+	// into a separate block but it's not worth the duplication, so u has 64 bits.
+	i := len(buf)
+	// Use constants for the division and modulo for more efficient code.
+	// Switch cases ordered by popularity.
+	switch base {
+	case 10:
+		for u >= 10 {
+			i--
+			next := u / 10
+			buf[i] = byte('0' + u - next*10)
+			u = next
+		}
+	case 16:
+		for u >= 16 {
+			i--
+			buf[i] = digits[u&0xF]
+			u >>= 4
+		}
+	case 8:
+		for u >= 8 {
+			i--
+			buf[i] = byte('0' + u&7)
+			u >>= 3
+		}
+	case 2:
+		for u >= 2 {
+			i--
+			buf[i] = byte('0' + u&1)
+			u >>= 1
+		}
+	default:
+		panic("fmt: unknown base; can't happen")
+	}
+	i--
+	buf[i] = digits[u]
+	for i > 0 && prec > len(buf)-i {
+		i--
+		buf[i] = '0'
+	}
+
+	// Various prefixes: 0x, -, etc.
+	if f.sharp {
+		switch base {
+		case 8:
+			if buf[i] != '0' {
+				i--
+				buf[i] = '0'
+			}
+		case 16:
+			// Add a leading 0x or 0X.
+			i--
+			buf[i] = digits[16]
+			i--
+			buf[i] = '0'
+		}
+	}
+
+	if negative {
+		i--
+		buf[i] = '-'
+	} else if f.plus {
+		i--
+		buf[i] = '+'
+	} else if f.space {
+		i--
+		buf[i] = ' '
+	}
+
+	// Left padding with zeros has already been handled like precision earlier
+	// or the f.zero flag is ignored due to an explicitly set precision.
+	oldZero := f.zero
+	f.zero = false
+	f.pad(buf[i:])
+	f.zero = oldZero
+}
+
+// truncate truncates the string to the specified precision, if present.
+func (f *fmt) truncate(s string) string {
+	if f.precPresent {
+		n := f.prec
+		for i := range s {
+			n--
+			if n < 0 {
+				return s[:i]
+			}
+		}
+	}
+	return s
+}
+
+// fmtS formats a string.
+func (f *fmt) fmtS(s string) {
+	s = f.truncate(s)
+	f.padString(s)
+}
+
+// fmtSbx formats a string or byte slice as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtSbx(s string, b []byte, digits string) {
+	length := len(b)
+	if b == nil {
+		// No byte slice present. Assume string s should be encoded.
+		length = len(s)
+	}
+	// Set length to not process more bytes than the precision demands.
+	if f.precPresent && f.prec < length {
+		length = f.prec
+	}
+	// Compute width of the encoding taking into account the f.sharp and f.space flag.
+	width := 2 * length
+	if width > 0 {
+		if f.space {
+			// Each element encoded by two hexadecimals will get a leading 0x or 0X.
+			if f.sharp {
+				width *= 2
+			}
+			// Elements will be separated by a space.
+			width += length - 1
+		} else if f.sharp {
+			// Only a leading 0x or 0X will be added for the whole string.
+			width += 2
+		}
+	} else { // The byte slice or string that should be encoded is empty.
+		if f.widPresent {
+			f.writePadding(f.wid)
+		}
+		return
+	}
+	// Handle padding to the left.
+	if f.widPresent && f.wid > width && !f.minus {
+		f.writePadding(f.wid - width)
+	}
+	// Write the encoding directly into the output buffer.
+	buf := *f.buf
+	if f.sharp {
+		// Add leading 0x or 0X.
+		buf = append(buf, '0', digits[16])
+	}
+	var c byte
+	for i := 0; i < length; i++ {
+		if f.space && i > 0 {
+			// Separate elements with a space.
+			buf = append(buf, ' ')
+			if f.sharp {
+				// Add leading 0x or 0X for each element.
+				buf = append(buf, '0', digits[16])
+			}
+		}
+		if b != nil {
+			c = b[i] // Take a byte from the input byte slice.
+		} else {
+			c = s[i] // Take a byte from the input string.
+		}
+		// Encode each byte as two hexadecimal digits.
+		buf = append(buf, digits[c>>4], digits[c&0xF])
+	}
+	*f.buf = buf
+	// Handle padding to the right.
+	if f.widPresent && f.wid > width && f.minus {
+		f.writePadding(f.wid - width)
+	}
+}
+
+// fmtSx formats a string as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtSx(s, digits string) {
+	f.fmtSbx(s, nil, digits)
+}
+
+// fmtBx formats a byte slice as a hexadecimal encoding of its bytes.
+func (f *fmt) fmtBx(b []byte, digits string) {
+	f.fmtSbx("", b, digits)
+}
+
+// fmtQ formats a string as a double-quoted, escaped Go string constant.
+// If f.sharp is set a raw (backquoted) string may be returned instead
+// if the string does not contain any control characters other than tab.
+func (f *fmt) fmtQ(s string) {
+	s = f.truncate(s)
+	if f.sharp && strconv.CanBackquote(s) {
+		f.padString("`" + s + "`")
+		return
+	}
+	buf := f.intbuf[:0]
+	if f.plus {
+		f.pad(strconv.AppendQuoteToASCII(buf, s))
+	} else {
+		f.pad(strconv.AppendQuote(buf, s))
+	}
+}
+
+// fmtC formats an integer as a Unicode character.
+// If the character is not valid Unicode, it will print '\ufffd'.
+func (f *fmt) fmtC(c uint64) {
+	r := rune(c)
+	if c > utf8.MaxRune {
+		r = utf8.RuneError
+	}
+	buf := f.intbuf[:0]
+	w := utf8.EncodeRune(buf[:utf8.UTFMax], r)
+	f.pad(buf[:w])
+}
+
+// fmtQc formats an integer as a single-quoted, escaped Go character constant.
+// If the character is not valid Unicode, it will print '\ufffd'.
+func (f *fmt) fmtQc(c uint64) {
+	r := rune(c)
+	if c > utf8.MaxRune {
+		r = utf8.RuneError
+	}
+	buf := f.intbuf[:0]
+	if f.plus {
+		f.pad(strconv.AppendQuoteRuneToASCII(buf, r))
+	} else {
+		f.pad(strconv.AppendQuoteRune(buf, r))
+	}
+}
+
+// fmtFloat formats a float64. It assumes that verb is a valid format specifier
+// for strconv.AppendFloat and therefore fits into a byte.
+func (f *fmt) fmtFloat(v float64, size int, verb rune, prec int) {
+	// Explicit precision in format specifier overrules default precision.
+	if f.precPresent {
+		prec = f.prec
+	}
+	// Format number, reserving space for leading + sign if needed.
+	num := strconv.AppendFloat(f.intbuf[:1], v, byte(verb), prec, size)
+	if num[1] == '-' || num[1] == '+' {
+		num = num[1:]
+	} else {
+		num[0] = '+'
+	}
+	// f.space means to add a leading space instead of a "+" sign unless
+	// the sign is explicitly asked for by f.plus.
+	if f.space && num[0] == '+' && !f.plus {
+		num[0] = ' '
+	}
+	// Special handling for infinities and NaN,
+	// which don't look like a number so shouldn't be padded with zeros.
+	if num[1] == 'I' || num[1] == 'N' {
+		oldZero := f.zero
+		f.zero = false
+		// Remove sign before NaN if not asked for.
+		if num[1] == 'N' && !f.space && !f.plus {
+			num = num[1:]
+		}
+		f.pad(num)
+		f.zero = oldZero
+		return
+	}
+	// The sharp flag forces printing a decimal point for non-binary formats
+	// and retains trailing zeros, which we may need to restore.
+	if f.sharp && verb != 'b' {
+		digits := 0
+		switch verb {
+		case 'v', 'g', 'G':
+			digits = prec
+			// If no precision is set explicitly use a precision of 6.
+			if digits == -1 {
+				digits = 6
+			}
+		}
+
+		// Buffer pre-allocated with enough room for
+		// exponent notations of the form "e+123".
+		var tailBuf [5]byte
+		tail := tailBuf[:0]
+
+		hasDecimalPoint := false
+		// Starting from i = 1 to skip sign at num[0].
+		for i := 1; i < len(num); i++ {
+			switch num[i] {
+			case '.':
+				hasDecimalPoint = true
+			case 'e', 'E':
+				tail = append(tail, num[i:]...)
+				num = num[:i]
+			default:
+				digits--
+			}
+		}
+		if !hasDecimalPoint {
+			num = append(num, '.')
+		}
+		for digits > 0 {
+			num = append(num, '0')
+			digits--
+		}
+		num = append(num, tail...)
+	}
+	// We want a sign if asked for and if the sign is not positive.
+	if f.plus || num[0] != '+' {
+		// If we're zero padding to the left we want the sign before the leading zeros.
+		// Achieve this by writing the sign out and then padding the unsigned number.
+		if f.zero && f.widPresent && f.wid > len(num) {
+			f.buf.WriteByte(num[0])
+			f.writePadding(f.wid - len(num))
+			f.buf.Write(num[1:])
+			return
+		}
+		f.pad(num)
+		return
+	}
+	// No sign to show and the number is positive; just print the unsigned number.
+	f.pad(num[1:])
+}

--- a/vendor/golang.org/x/exp/errors/fmt/print.go
+++ b/vendor/golang.org/x/exp/errors/fmt/print.go
@@ -1,0 +1,1131 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	gofmt "fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+	"unicode/utf8"
+
+	"golang.org/x/exp/errors"
+)
+
+// Strings for use with buffer.WriteString.
+// This is less overhead than using buffer.Write with byte arrays.
+const (
+	commaSpaceString  = ", "
+	nilAngleString    = "<nil>"
+	nilParenString    = "(nil)"
+	nilString         = "nil"
+	mapString         = "map["
+	percentBangString = "%!"
+	missingString     = "(MISSING)"
+	badIndexString    = "(BADINDEX)"
+	panicString       = "(PANIC="
+	extraString       = "%!(EXTRA "
+	badWidthString    = "%!(BADWIDTH)"
+	badPrecString     = "%!(BADPREC)"
+	noVerbString      = "%!(NOVERB)"
+	invReflectString  = "<invalid reflect.Value>"
+)
+
+// These interface need to be aliases so that implementations can be used
+// for different implementations.
+
+// State represents the printer state passed to custom formatters.
+// It provides access to the io.Writer interface plus information about
+// the flags and options for the operand's format specifier.
+type State = gofmt.State
+
+// Formatter is the interface implemented by values with a custom formatter.
+// The implementation of Format may call Sprint(f) or Fprint(f) etc.
+// to generate its output.
+type Formatter = gofmt.Formatter
+
+// Stringer is implemented by any value that has a String method,
+// which defines the ``native'' format for that value.
+// The String method is used to print values passed as an operand
+// to any format that accepts a string or to an unformatted printer
+// such as Print.
+type Stringer = gofmt.Stringer
+
+// GoStringer is implemented by any value that has a GoString method,
+// which defines the Go syntax for that value.
+// The GoString method is used to print values passed as an operand
+// to a %#v format.
+type GoStringer = gofmt.GoStringer
+
+// Use simple []byte instead of bytes.Buffer to avoid large dependency.
+type buffer []byte
+
+func (b *buffer) Write(p []byte) {
+	*b = append(*b, p...)
+}
+
+func (b *buffer) WriteString(s string) {
+	*b = append(*b, s...)
+}
+
+func (b *buffer) WriteByte(c byte) {
+	*b = append(*b, c)
+}
+
+func (bp *buffer) WriteRune(r rune) {
+	if r < utf8.RuneSelf {
+		*bp = append(*bp, byte(r))
+		return
+	}
+
+	b := *bp
+	n := len(b)
+	for n+utf8.UTFMax > cap(b) {
+		b = append(b, 0)
+	}
+	w := utf8.EncodeRune(b[n:n+utf8.UTFMax], r)
+	*bp = b[:n+w]
+}
+
+// pp is used to store a printer's state and is reused with sync.Pool to avoid allocations.
+type pp struct {
+	buf buffer
+
+	// arg holds the current item, as an interface{}.
+	arg interface{}
+
+	// value is used instead of arg for reflect values.
+	value reflect.Value
+
+	// fmt is used to format basic items such as integers or strings.
+	fmt fmt
+
+	// reordered records whether the format string used argument reordering.
+	reordered bool
+	// goodArgNum records whether the most recent reordering directive was valid.
+	goodArgNum bool
+	// panicking is set by catchPanic to avoid infinite panic, recover, panic, ... recursion.
+	panicking bool
+	// erroring is set when printing an error string to guard against calling handleMethods.
+	erroring bool
+}
+
+var ppFree = sync.Pool{
+	New: func() interface{} { return new(pp) },
+}
+
+// newPrinter allocates a new pp struct or grabs a cached one.
+func newPrinter() *pp {
+	p := ppFree.Get().(*pp)
+	p.panicking = false
+	p.erroring = false
+	p.fmt.init(&p.buf)
+	return p
+}
+
+// free saves used pp structs in ppFree; avoids an allocation per invocation.
+func (p *pp) free() {
+	p.buf = p.buf[:0]
+	p.arg = nil
+	p.value = reflect.Value{}
+	ppFree.Put(p)
+}
+
+func (p *pp) Width() (wid int, ok bool) { return p.fmt.wid, p.fmt.widPresent }
+
+func (p *pp) Precision() (prec int, ok bool) { return p.fmt.prec, p.fmt.precPresent }
+
+func (p *pp) Flag(b int) bool {
+	switch b {
+	case '-':
+		return p.fmt.minus
+	case '+':
+		return p.fmt.plus || p.fmt.plusV
+	case '#':
+		return p.fmt.sharp || p.fmt.sharpV
+	case ' ':
+		return p.fmt.space
+	case '0':
+		return p.fmt.zero
+	}
+	return false
+}
+
+// Implement Write so we can call Fprintf on a pp (through State), for
+// recursive use in custom verbs.
+func (p *pp) Write(b []byte) (ret int, err error) {
+	p.buf.Write(b)
+	return len(b), nil
+}
+
+// Implement WriteString so that we can call io.WriteString
+// on a pp (through state), for efficiency.
+func (p *pp) WriteString(s string) (ret int, err error) {
+	p.buf.WriteString(s)
+	return len(s), nil
+}
+
+// These routines end in 'f' and take a format string.
+
+// Fprintf formats according to a format specifier and writes to w.
+// It returns the number of bytes written and any write error encountered.
+func Fprintf(w io.Writer, format string, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Printf formats according to a format specifier and writes to standard output.
+// It returns the number of bytes written and any write error encountered.
+func Printf(format string, a ...interface{}) (n int, err error) {
+	return Fprintf(os.Stdout, format, a...)
+}
+
+// Sprintf formats according to a format specifier and returns the resulting string.
+func Sprintf(format string, a ...interface{}) string {
+	p := newPrinter()
+	p.doPrintf(format, a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// These routines do not take a format string
+
+// Fprint formats using the default formats for its operands and writes to w.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Fprint(w io.Writer, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrint(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Print formats using the default formats for its operands and writes to standard output.
+// Spaces are added between operands when neither is a string.
+// It returns the number of bytes written and any write error encountered.
+func Print(a ...interface{}) (n int, err error) {
+	return Fprint(os.Stdout, a...)
+}
+
+// Sprint formats using the default formats for its operands and returns the resulting string.
+// Spaces are added between operands when neither is a string.
+func Sprint(a ...interface{}) string {
+	p := newPrinter()
+	p.doPrint(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// These routines end in 'ln', do not take a format string,
+// always add spaces between operands, and add a newline
+// after the last operand.
+
+// Fprintln formats using the default formats for its operands and writes to w.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Fprintln(w io.Writer, a ...interface{}) (n int, err error) {
+	p := newPrinter()
+	p.doPrintln(a)
+	n, err = w.Write(p.buf)
+	p.free()
+	return
+}
+
+// Println formats using the default formats for its operands and writes to standard output.
+// Spaces are always added between operands and a newline is appended.
+// It returns the number of bytes written and any write error encountered.
+func Println(a ...interface{}) (n int, err error) {
+	return Fprintln(os.Stdout, a...)
+}
+
+// Sprintln formats using the default formats for its operands and returns the resulting string.
+// Spaces are always added between operands and a newline is appended.
+func Sprintln(a ...interface{}) string {
+	p := newPrinter()
+	p.doPrintln(a)
+	s := string(p.buf)
+	p.free()
+	return s
+}
+
+// getField gets the i'th field of the struct value.
+// If the field is itself is an interface, return a value for
+// the thing inside the interface, not the interface itself.
+func getField(v reflect.Value, i int) reflect.Value {
+	val := v.Field(i)
+	if val.Kind() == reflect.Interface && !val.IsNil() {
+		val = val.Elem()
+	}
+	return val
+}
+
+// tooLarge reports whether the magnitude of the integer is
+// too large to be used as a formatting width or precision.
+func tooLarge(x int) bool {
+	const max int = 1e6
+	return x > max || x < -max
+}
+
+// parsenum converts ASCII to integer.  num is 0 (and isnum is false) if no number present.
+func parsenum(s string, start, end int) (num int, isnum bool, newi int) {
+	if start >= end {
+		return 0, false, end
+	}
+	for newi = start; newi < end && '0' <= s[newi] && s[newi] <= '9'; newi++ {
+		if tooLarge(num) {
+			return 0, false, end // Overflow; crazy long number most likely.
+		}
+		num = num*10 + int(s[newi]-'0')
+		isnum = true
+	}
+	return
+}
+
+func (p *pp) unknownType(v reflect.Value) {
+	if !v.IsValid() {
+		p.buf.WriteString(nilAngleString)
+		return
+	}
+	p.buf.WriteByte('?')
+	p.buf.WriteString(v.Type().String())
+	p.buf.WriteByte('?')
+}
+
+func (p *pp) badVerb(verb rune) {
+	p.erroring = true
+	p.buf.WriteString(percentBangString)
+	p.buf.WriteRune(verb)
+	p.buf.WriteByte('(')
+	switch {
+	case p.arg != nil:
+		p.buf.WriteString(reflect.TypeOf(p.arg).String())
+		p.buf.WriteByte('=')
+		p.printArg(p.arg, 'v')
+	case p.value.IsValid():
+		p.buf.WriteString(p.value.Type().String())
+		p.buf.WriteByte('=')
+		p.printValue(p.value, 'v', 0)
+	default:
+		p.buf.WriteString(nilAngleString)
+	}
+	p.buf.WriteByte(')')
+	p.erroring = false
+}
+
+func (p *pp) fmtBool(v bool, verb rune) {
+	switch verb {
+	case 't', 'v':
+		p.fmt.fmtBoolean(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmt0x64 formats a uint64 in hexadecimal and prefixes it with 0x or
+// not, as requested, by temporarily setting the sharp flag.
+func (p *pp) fmt0x64(v uint64, leading0x bool) {
+	sharp := p.fmt.sharp
+	p.fmt.sharp = leading0x
+	p.fmt.fmtInteger(v, 16, unsigned, ldigits)
+	p.fmt.sharp = sharp
+}
+
+// fmtInteger formats a signed or unsigned integer.
+func (p *pp) fmtInteger(v uint64, isSigned bool, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV && !isSigned {
+			p.fmt0x64(v, true)
+		} else {
+			p.fmt.fmtInteger(v, 10, isSigned, ldigits)
+		}
+	case 'd':
+		p.fmt.fmtInteger(v, 10, isSigned, ldigits)
+	case 'b':
+		p.fmt.fmtInteger(v, 2, isSigned, ldigits)
+	case 'o':
+		p.fmt.fmtInteger(v, 8, isSigned, ldigits)
+	case 'x':
+		p.fmt.fmtInteger(v, 16, isSigned, ldigits)
+	case 'X':
+		p.fmt.fmtInteger(v, 16, isSigned, udigits)
+	case 'c':
+		p.fmt.fmtC(v)
+	case 'q':
+		if v <= utf8.MaxRune {
+			p.fmt.fmtQc(v)
+		} else {
+			p.badVerb(verb)
+		}
+	case 'U':
+		p.fmt.fmtUnicode(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtFloat formats a float. The default precision for each verb
+// is specified as last argument in the call to fmt_float.
+func (p *pp) fmtFloat(v float64, size int, verb rune) {
+	switch verb {
+	case 'v':
+		p.fmt.fmtFloat(v, size, 'g', -1)
+	case 'b', 'g', 'G':
+		p.fmt.fmtFloat(v, size, verb, -1)
+	case 'f', 'e', 'E':
+		p.fmt.fmtFloat(v, size, verb, 6)
+	case 'F':
+		p.fmt.fmtFloat(v, size, 'f', 6)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+// fmtComplex formats a complex number v with
+// r = real(v) and j = imag(v) as (r+ji) using
+// fmtFloat for r and j formatting.
+func (p *pp) fmtComplex(v complex128, size int, verb rune) {
+	// Make sure any unsupported verbs are found before the
+	// calls to fmtFloat to not generate an incorrect error string.
+	switch verb {
+	case 'v', 'b', 'g', 'G', 'f', 'F', 'e', 'E':
+		oldPlus := p.fmt.plus
+		p.buf.WriteByte('(')
+		p.fmtFloat(real(v), size/2, verb)
+		// Imaginary part always has a sign.
+		p.fmt.plus = true
+		p.fmtFloat(imag(v), size/2, verb)
+		p.buf.WriteString("i)")
+		p.fmt.plus = oldPlus
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtString(v string, verb rune) {
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.fmt.fmtQ(v)
+		} else {
+			p.fmt.fmtS(v)
+		}
+	case 's':
+		p.fmt.fmtS(v)
+	case 'x':
+		p.fmt.fmtSx(v, ldigits)
+	case 'X':
+		p.fmt.fmtSx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(v)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) fmtBytes(v []byte, verb rune, typeString string) {
+	switch verb {
+	case 'v', 'd':
+		if p.fmt.sharpV {
+			p.buf.WriteString(typeString)
+			if v == nil {
+				p.buf.WriteString(nilParenString)
+				return
+			}
+			p.buf.WriteByte('{')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.WriteString(commaSpaceString)
+				}
+				p.fmt0x64(uint64(c), true)
+			}
+			p.buf.WriteByte('}')
+		} else {
+			p.buf.WriteByte('[')
+			for i, c := range v {
+				if i > 0 {
+					p.buf.WriteByte(' ')
+				}
+				p.fmt.fmtInteger(uint64(c), 10, unsigned, ldigits)
+			}
+			p.buf.WriteByte(']')
+		}
+	case 's':
+		p.fmt.fmtS(string(v))
+	case 'x':
+		p.fmt.fmtBx(v, ldigits)
+	case 'X':
+		p.fmt.fmtBx(v, udigits)
+	case 'q':
+		p.fmt.fmtQ(string(v))
+	default:
+		p.printValue(reflect.ValueOf(v), verb, 0)
+	}
+}
+
+func (p *pp) fmtPointer(value reflect.Value, verb rune) {
+	var u uintptr
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Map, reflect.Ptr, reflect.Slice, reflect.UnsafePointer:
+		u = value.Pointer()
+	default:
+		p.badVerb(verb)
+		return
+	}
+
+	switch verb {
+	case 'v':
+		if p.fmt.sharpV {
+			p.buf.WriteByte('(')
+			p.buf.WriteString(value.Type().String())
+			p.buf.WriteString(")(")
+			if u == 0 {
+				p.buf.WriteString(nilString)
+			} else {
+				p.fmt0x64(uint64(u), true)
+			}
+			p.buf.WriteByte(')')
+		} else {
+			if u == 0 {
+				p.fmt.padString(nilAngleString)
+			} else {
+				p.fmt0x64(uint64(u), !p.fmt.sharp)
+			}
+		}
+	case 'p':
+		p.fmt0x64(uint64(u), !p.fmt.sharp)
+	case 'b', 'o', 'd', 'x', 'X':
+		p.fmtInteger(uint64(u), unsigned, verb)
+	default:
+		p.badVerb(verb)
+	}
+}
+
+func (p *pp) catchPanic(arg interface{}, verb rune) {
+	if err := recover(); err != nil {
+		// If it's a nil pointer, just say "<nil>". The likeliest causes are a
+		// Stringer that fails to guard against nil or a nil pointer for a
+		// value receiver, and in either case, "<nil>" is a nice result.
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Ptr && v.IsNil() {
+			p.buf.WriteString(nilAngleString)
+			return
+		}
+		// Otherwise print a concise panic message. Most of the time the panic
+		// value will print itself nicely.
+		if p.panicking {
+			// Nested panics; the recursion in printArg cannot succeed.
+			panic(err)
+		}
+
+		oldFlags := p.fmt.fmtFlags
+		// For this output we want default behavior.
+		p.fmt.clearflags()
+
+		p.buf.WriteString(percentBangString)
+		p.buf.WriteRune(verb)
+		p.buf.WriteString(panicString)
+		p.panicking = true
+		p.printArg(err, 'v')
+		p.panicking = false
+		p.buf.WriteByte(')')
+
+		p.fmt.fmtFlags = oldFlags
+	}
+}
+
+func (p *pp) handleMethods(verb rune) (handled bool) {
+	if p.erroring {
+		return
+	}
+	switch x := p.arg.(type) {
+	case errors.Formatter:
+		handled = true
+		defer p.catchPanic(p.arg, verb)
+		return fmtError(p, verb, x)
+
+	case Formatter:
+		handled = true
+		defer p.catchPanic(p.arg, verb)
+		x.Format(p, verb)
+		return
+
+	case error:
+		handled = true
+		defer p.catchPanic(p.arg, verb)
+		return fmtError(p, verb, x)
+	}
+
+	// If we're doing Go syntax and the argument knows how to supply it, take care of it now.
+	if p.fmt.sharpV {
+		if stringer, ok := p.arg.(GoStringer); ok {
+			handled = true
+			defer p.catchPanic(p.arg, verb)
+			// Print the result of GoString unadorned.
+			p.fmt.fmtS(stringer.GoString())
+			return
+		}
+	} else {
+		// If a string is acceptable according to the format, see if
+		// the value satisfies one of the string-valued interfaces.
+		// Println etc. set verb to %v, which is "stringable".
+		switch verb {
+		case 'v', 's', 'x', 'X', 'q':
+			if v, ok := p.arg.(Stringer); ok {
+				handled = true
+				defer p.catchPanic(p.arg, verb)
+				p.fmtString(v.String(), verb)
+				return
+			}
+		}
+	}
+	return false
+}
+
+func (p *pp) printArg(arg interface{}, verb rune) {
+	p.arg = arg
+	p.value = reflect.Value{}
+
+	if arg == nil {
+		switch verb {
+		case 'T', 'v':
+			p.fmt.padString(nilAngleString)
+		default:
+			p.badVerb(verb)
+		}
+		return
+	}
+
+	// Special processing considerations.
+	// %T (the value's type) and %p (its address) are special; we always do them first.
+	switch verb {
+	case 'T':
+		p.fmt.fmtS(reflect.TypeOf(arg).String())
+		return
+	case 'p':
+		p.fmtPointer(reflect.ValueOf(arg), 'p')
+		return
+	}
+
+	// Some types can be done without reflection.
+	switch f := arg.(type) {
+	case bool:
+		p.fmtBool(f, verb)
+	case float32:
+		p.fmtFloat(float64(f), 32, verb)
+	case float64:
+		p.fmtFloat(f, 64, verb)
+	case complex64:
+		p.fmtComplex(complex128(f), 64, verb)
+	case complex128:
+		p.fmtComplex(f, 128, verb)
+	case int:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int8:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int16:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int32:
+		p.fmtInteger(uint64(f), signed, verb)
+	case int64:
+		p.fmtInteger(uint64(f), signed, verb)
+	case uint:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint8:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint16:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint32:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case uint64:
+		p.fmtInteger(f, unsigned, verb)
+	case uintptr:
+		p.fmtInteger(uint64(f), unsigned, verb)
+	case string:
+		p.fmtString(f, verb)
+	case []byte:
+		p.fmtBytes(f, verb, "[]byte")
+	case reflect.Value:
+		// Handle extractable values with special methods
+		// since printValue does not handle them at depth 0.
+		if f.IsValid() && f.CanInterface() {
+			p.arg = f.Interface()
+			if p.handleMethods(verb) {
+				return
+			}
+		}
+		p.printValue(f, verb, 0)
+	default:
+		// If the type is not simple, it might have methods.
+		if !p.handleMethods(verb) {
+			// Need to use reflection, since the type had no
+			// interface methods that could be used for formatting.
+			p.printValue(reflect.ValueOf(f), verb, 0)
+		}
+	}
+}
+
+// printValue is similar to printArg but starts with a reflect value, not an interface{} value.
+// It does not handle 'p' and 'T' verbs because these should have been already handled by printArg.
+func (p *pp) printValue(value reflect.Value, verb rune, depth int) {
+	// Handle values with special methods if not already handled by printArg (depth == 0).
+	if depth > 0 && value.IsValid() && value.CanInterface() {
+		p.arg = value.Interface()
+		if p.handleMethods(verb) {
+			return
+		}
+	}
+	p.arg = nil
+	p.value = value
+
+	switch f := value; value.Kind() {
+	case reflect.Invalid:
+		if depth == 0 {
+			p.buf.WriteString(invReflectString)
+		} else {
+			switch verb {
+			case 'v':
+				p.buf.WriteString(nilAngleString)
+			default:
+				p.badVerb(verb)
+			}
+		}
+	case reflect.Bool:
+		p.fmtBool(f.Bool(), verb)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		p.fmtInteger(uint64(f.Int()), signed, verb)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		p.fmtInteger(f.Uint(), unsigned, verb)
+	case reflect.Float32:
+		p.fmtFloat(f.Float(), 32, verb)
+	case reflect.Float64:
+		p.fmtFloat(f.Float(), 64, verb)
+	case reflect.Complex64:
+		p.fmtComplex(f.Complex(), 64, verb)
+	case reflect.Complex128:
+		p.fmtComplex(f.Complex(), 128, verb)
+	case reflect.String:
+		p.fmtString(f.String(), verb)
+	case reflect.Map:
+		if p.fmt.sharpV {
+			p.buf.WriteString(f.Type().String())
+			if f.IsNil() {
+				p.buf.WriteString(nilParenString)
+				return
+			}
+			p.buf.WriteByte('{')
+		} else {
+			p.buf.WriteString(mapString)
+		}
+		keys := f.MapKeys()
+		for i, key := range keys {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.WriteString(commaSpaceString)
+				} else {
+					p.buf.WriteByte(' ')
+				}
+			}
+			p.printValue(key, verb, depth+1)
+			p.buf.WriteByte(':')
+			p.printValue(f.MapIndex(key), verb, depth+1)
+		}
+		if p.fmt.sharpV {
+			p.buf.WriteByte('}')
+		} else {
+			p.buf.WriteByte(']')
+		}
+	case reflect.Struct:
+		if p.fmt.sharpV {
+			p.buf.WriteString(f.Type().String())
+		}
+		p.buf.WriteByte('{')
+		for i := 0; i < f.NumField(); i++ {
+			if i > 0 {
+				if p.fmt.sharpV {
+					p.buf.WriteString(commaSpaceString)
+				} else {
+					p.buf.WriteByte(' ')
+				}
+			}
+			if p.fmt.plusV || p.fmt.sharpV {
+				if name := f.Type().Field(i).Name; name != "" {
+					p.buf.WriteString(name)
+					p.buf.WriteByte(':')
+				}
+			}
+			p.printValue(getField(f, i), verb, depth+1)
+		}
+		p.buf.WriteByte('}')
+	case reflect.Interface:
+		value := f.Elem()
+		if !value.IsValid() {
+			if p.fmt.sharpV {
+				p.buf.WriteString(f.Type().String())
+				p.buf.WriteString(nilParenString)
+			} else {
+				p.buf.WriteString(nilAngleString)
+			}
+		} else {
+			p.printValue(value, verb, depth+1)
+		}
+	case reflect.Array, reflect.Slice:
+		switch verb {
+		case 's', 'q', 'x', 'X':
+			// Handle byte and uint8 slices and arrays special for the above verbs.
+			t := f.Type()
+			if t.Elem().Kind() == reflect.Uint8 {
+				var bytes []byte
+				if f.Kind() == reflect.Slice {
+					bytes = f.Bytes()
+				} else if f.CanAddr() {
+					bytes = f.Slice(0, f.Len()).Bytes()
+				} else {
+					// We have an array, but we cannot Slice() a non-addressable array,
+					// so we build a slice by hand. This is a rare case but it would be nice
+					// if reflection could help a little more.
+					bytes = make([]byte, f.Len())
+					for i := range bytes {
+						bytes[i] = byte(f.Index(i).Uint())
+					}
+				}
+				p.fmtBytes(bytes, verb, t.String())
+				return
+			}
+		}
+		if p.fmt.sharpV {
+			p.buf.WriteString(f.Type().String())
+			if f.Kind() == reflect.Slice && f.IsNil() {
+				p.buf.WriteString(nilParenString)
+				return
+			}
+			p.buf.WriteByte('{')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.WriteString(commaSpaceString)
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.WriteByte('}')
+		} else {
+			p.buf.WriteByte('[')
+			for i := 0; i < f.Len(); i++ {
+				if i > 0 {
+					p.buf.WriteByte(' ')
+				}
+				p.printValue(f.Index(i), verb, depth+1)
+			}
+			p.buf.WriteByte(']')
+		}
+	case reflect.Ptr:
+		// pointer to array or slice or struct? ok at top level
+		// but not embedded (avoid loops)
+		if depth == 0 && f.Pointer() != 0 {
+			switch a := f.Elem(); a.Kind() {
+			case reflect.Array, reflect.Slice, reflect.Struct, reflect.Map:
+				p.buf.WriteByte('&')
+				p.printValue(a, verb, depth+1)
+				return
+			}
+		}
+		fallthrough
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
+		p.fmtPointer(f, verb)
+	default:
+		p.unknownType(f)
+	}
+}
+
+// intFromArg gets the argNumth element of a. On return, isInt reports whether the argument has integer type.
+func intFromArg(a []interface{}, argNum int) (num int, isInt bool, newArgNum int) {
+	newArgNum = argNum
+	if argNum < len(a) {
+		num, isInt = a[argNum].(int) // Almost always OK.
+		if !isInt {
+			// Work harder.
+			switch v := reflect.ValueOf(a[argNum]); v.Kind() {
+			case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+				n := v.Int()
+				if int64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+				n := v.Uint()
+				if int64(n) >= 0 && uint64(int(n)) == n {
+					num = int(n)
+					isInt = true
+				}
+			default:
+				// Already 0, false.
+			}
+		}
+		newArgNum = argNum + 1
+		if tooLarge(num) {
+			num = 0
+			isInt = false
+		}
+	}
+	return
+}
+
+// parseArgNumber returns the value of the bracketed number, minus 1
+// (explicit argument numbers are one-indexed but we want zero-indexed).
+// The opening bracket is known to be present at format[0].
+// The returned values are the index, the number of bytes to consume
+// up to the closing paren, if present, and whether the number parsed
+// ok. The bytes to consume will be 1 if no closing paren is present.
+func parseArgNumber(format string) (index int, wid int, ok bool) {
+	// There must be at least 3 bytes: [n].
+	if len(format) < 3 {
+		return 0, 1, false
+	}
+
+	// Find closing bracket.
+	for i := 1; i < len(format); i++ {
+		if format[i] == ']' {
+			width, ok, newi := parsenum(format, 1, i)
+			if !ok || newi != i {
+				return 0, i + 1, false
+			}
+			return width - 1, i + 1, true // arg numbers are one-indexed and skip paren.
+		}
+	}
+	return 0, 1, false
+}
+
+// argNumber returns the next argument to evaluate, which is either the value of the passed-in
+// argNum or the value of the bracketed integer that begins format[i:]. It also returns
+// the new value of i, that is, the index of the next byte of the format to process.
+func (p *pp) argNumber(argNum int, format string, i int, numArgs int) (newArgNum, newi int, found bool) {
+	if len(format) <= i || format[i] != '[' {
+		return argNum, i, false
+	}
+	p.reordered = true
+	index, wid, ok := parseArgNumber(format[i:])
+	if ok && 0 <= index && index < numArgs {
+		return index, i + wid, true
+	}
+	p.goodArgNum = false
+	return argNum, i + wid, ok
+}
+
+func (p *pp) badArgNum(verb rune) {
+	p.buf.WriteString(percentBangString)
+	p.buf.WriteRune(verb)
+	p.buf.WriteString(badIndexString)
+}
+
+func (p *pp) missingArg(verb rune) {
+	p.buf.WriteString(percentBangString)
+	p.buf.WriteRune(verb)
+	p.buf.WriteString(missingString)
+}
+
+func (p *pp) doPrintf(format string, a []interface{}) {
+	end := len(format)
+	argNum := 0         // we process one argument per non-trivial format
+	afterIndex := false // previous item in format was an index like [3].
+	p.reordered = false
+formatLoop:
+	for i := 0; i < end; {
+		p.goodArgNum = true
+		lasti := i
+		for i < end && format[i] != '%' {
+			i++
+		}
+		if i > lasti {
+			p.buf.WriteString(format[lasti:i])
+		}
+		if i >= end {
+			// done processing format string
+			break
+		}
+
+		// Process one verb
+		i++
+
+		// Do we have flags?
+		p.fmt.clearflags()
+	simpleFormat:
+		for ; i < end; i++ {
+			c := format[i]
+			switch c {
+			case '#':
+				p.fmt.sharp = true
+			case '0':
+				p.fmt.zero = !p.fmt.minus // Only allow zero padding to the left.
+			case '+':
+				p.fmt.plus = true
+			case '-':
+				p.fmt.minus = true
+				p.fmt.zero = false // Do not pad with zeros to the right.
+			case ' ':
+				p.fmt.space = true
+			default:
+				// Fast path for common case of ascii lower case simple verbs
+				// without precision or width or argument indices.
+				if 'a' <= c && c <= 'z' && argNum < len(a) {
+					if c == 'v' {
+						// Go syntax
+						p.fmt.sharpV = p.fmt.sharp
+						p.fmt.sharp = false
+						// Struct-field syntax
+						p.fmt.plusV = p.fmt.plus
+						p.fmt.plus = false
+					}
+					p.printArg(a[argNum], rune(c))
+					argNum++
+					i++
+					continue formatLoop
+				}
+				// Format is more complex than simple flags and a verb or is malformed.
+				break simpleFormat
+			}
+		}
+
+		// Do we have an explicit argument index?
+		argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+
+		// Do we have width?
+		if i < end && format[i] == '*' {
+			i++
+			p.fmt.wid, p.fmt.widPresent, argNum = intFromArg(a, argNum)
+
+			if !p.fmt.widPresent {
+				p.buf.WriteString(badWidthString)
+			}
+
+			// We have a negative width, so take its value and ensure
+			// that the minus flag is set
+			if p.fmt.wid < 0 {
+				p.fmt.wid = -p.fmt.wid
+				p.fmt.minus = true
+				p.fmt.zero = false // Do not pad with zeros to the right.
+			}
+			afterIndex = false
+		} else {
+			p.fmt.wid, p.fmt.widPresent, i = parsenum(format, i, end)
+			if afterIndex && p.fmt.widPresent { // "%[3]2d"
+				p.goodArgNum = false
+			}
+		}
+
+		// Do we have precision?
+		if i+1 < end && format[i] == '.' {
+			i++
+			if afterIndex { // "%[3].2d"
+				p.goodArgNum = false
+			}
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+			if i < end && format[i] == '*' {
+				i++
+				p.fmt.prec, p.fmt.precPresent, argNum = intFromArg(a, argNum)
+				// Negative precision arguments don't make sense
+				if p.fmt.prec < 0 {
+					p.fmt.prec = 0
+					p.fmt.precPresent = false
+				}
+				if !p.fmt.precPresent {
+					p.buf.WriteString(badPrecString)
+				}
+				afterIndex = false
+			} else {
+				p.fmt.prec, p.fmt.precPresent, i = parsenum(format, i, end)
+				if !p.fmt.precPresent {
+					p.fmt.prec = 0
+					p.fmt.precPresent = true
+				}
+			}
+		}
+
+		if !afterIndex {
+			argNum, i, afterIndex = p.argNumber(argNum, format, i, len(a))
+		}
+
+		if i >= end {
+			p.buf.WriteString(noVerbString)
+			break
+		}
+
+		verb, size := rune(format[i]), 1
+		if verb >= utf8.RuneSelf {
+			verb, size = utf8.DecodeRuneInString(format[i:])
+		}
+		i += size
+
+		switch {
+		case verb == '%': // Percent does not absorb operands and ignores f.wid and f.prec.
+			p.buf.WriteByte('%')
+		case !p.goodArgNum:
+			p.badArgNum(verb)
+		case argNum >= len(a): // No argument left over to print for the current verb.
+			p.missingArg(verb)
+		case verb == 'v':
+			// Go syntax
+			p.fmt.sharpV = p.fmt.sharp
+			p.fmt.sharp = false
+			// Struct-field syntax
+			p.fmt.plusV = p.fmt.plus
+			p.fmt.plus = false
+			fallthrough
+		default:
+			p.printArg(a[argNum], verb)
+			argNum++
+		}
+	}
+
+	// Check for extra arguments unless the call accessed the arguments
+	// out of order, in which case it's too expensive to detect if they've all
+	// been used and arguably OK if they're not.
+	if !p.reordered && argNum < len(a) {
+		p.fmt.clearflags()
+		p.buf.WriteString(extraString)
+		for i, arg := range a[argNum:] {
+			if i > 0 {
+				p.buf.WriteString(commaSpaceString)
+			}
+			if arg == nil {
+				p.buf.WriteString(nilAngleString)
+			} else {
+				p.buf.WriteString(reflect.TypeOf(arg).String())
+				p.buf.WriteByte('=')
+				p.printArg(arg, 'v')
+			}
+		}
+		p.buf.WriteByte(')')
+	}
+}
+
+func (p *pp) doPrint(a []interface{}) {
+	prevString := false
+	for argNum, arg := range a {
+		isString := arg != nil && reflect.TypeOf(arg).Kind() == reflect.String
+		// Add a space between two non-string arguments.
+		if argNum > 0 && !isString && !prevString {
+			p.buf.WriteByte(' ')
+		}
+		p.printArg(arg, 'v')
+		prevString = isString
+	}
+}
+
+// doPrintln is like doPrint but always adds a space between arguments
+// and a newline after the last argument.
+func (p *pp) doPrintln(a []interface{}) {
+	for argNum, arg := range a {
+		if argNum > 0 {
+			p.buf.WriteByte(' ')
+		}
+		p.printArg(arg, 'v')
+	}
+	p.buf.WriteByte('\n')
+}

--- a/vendor/golang.org/x/exp/errors/fmt/scan.go
+++ b/vendor/golang.org/x/exp/errors/fmt/scan.go
@@ -1,0 +1,1201 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fmt
+
+import (
+	"errors"
+	"io"
+	"math"
+	"os"
+	"reflect"
+	"strconv"
+	"sync"
+	"unicode/utf8"
+)
+
+// ScanState represents the scanner state passed to custom scanners.
+// Scanners may do rune-at-a-time scanning or ask the ScanState
+// to discover the next space-delimited token.
+type ScanState interface {
+	// ReadRune reads the next rune (Unicode code point) from the input.
+	// If invoked during Scanln, Fscanln, or Sscanln, ReadRune() will
+	// return EOF after returning the first '\n' or when reading beyond
+	// the specified width.
+	ReadRune() (r rune, size int, err error)
+	// UnreadRune causes the next call to ReadRune to return the same rune.
+	UnreadRune() error
+	// SkipSpace skips space in the input. Newlines are treated appropriately
+	// for the operation being performed; see the package documentation
+	// for more information.
+	SkipSpace()
+	// Token skips space in the input if skipSpace is true, then returns the
+	// run of Unicode code points c satisfying f(c).  If f is nil,
+	// !unicode.IsSpace(c) is used; that is, the token will hold non-space
+	// characters. Newlines are treated appropriately for the operation being
+	// performed; see the package documentation for more information.
+	// The returned slice points to shared data that may be overwritten
+	// by the next call to Token, a call to a Scan function using the ScanState
+	// as input, or when the calling Scan method returns.
+	Token(skipSpace bool, f func(rune) bool) (token []byte, err error)
+	// Width returns the value of the width option and whether it has been set.
+	// The unit is Unicode code points.
+	Width() (wid int, ok bool)
+	// Because ReadRune is implemented by the interface, Read should never be
+	// called by the scanning routines and a valid implementation of
+	// ScanState may choose always to return an error from Read.
+	Read(buf []byte) (n int, err error)
+}
+
+// Scanner is implemented by any value that has a Scan method, which scans
+// the input for the representation of a value and stores the result in the
+// receiver, which must be a pointer to be useful. The Scan method is called
+// for any argument to Scan, Scanf, or Scanln that implements it.
+type Scanner interface {
+	Scan(state ScanState, verb rune) error
+}
+
+// Scan scans text read from standard input, storing successive
+// space-separated values into successive arguments. Newlines count
+// as space. It returns the number of items successfully scanned.
+// If that is less than the number of arguments, err will report why.
+func Scan(a ...interface{}) (n int, err error) {
+	return Fscan(os.Stdin, a...)
+}
+
+// Scanln is similar to Scan, but stops scanning at a newline and
+// after the final item there must be a newline or EOF.
+func Scanln(a ...interface{}) (n int, err error) {
+	return Fscanln(os.Stdin, a...)
+}
+
+// Scanf scans text read from standard input, storing successive
+// space-separated values into successive arguments as determined by
+// the format. It returns the number of items successfully scanned.
+// If that is less than the number of arguments, err will report why.
+// Newlines in the input must match newlines in the format.
+// The one exception: the verb %c always scans the next rune in the
+// input, even if it is a space (or tab etc.) or newline.
+func Scanf(format string, a ...interface{}) (n int, err error) {
+	return Fscanf(os.Stdin, format, a...)
+}
+
+type stringReader string
+
+func (r *stringReader) Read(b []byte) (n int, err error) {
+	n = copy(b, *r)
+	*r = (*r)[n:]
+	if n == 0 {
+		err = io.EOF
+	}
+	return
+}
+
+// Sscan scans the argument string, storing successive space-separated
+// values into successive arguments. Newlines count as space. It
+// returns the number of items successfully scanned. If that is less
+// than the number of arguments, err will report why.
+func Sscan(str string, a ...interface{}) (n int, err error) {
+	return Fscan((*stringReader)(&str), a...)
+}
+
+// Sscanln is similar to Sscan, but stops scanning at a newline and
+// after the final item there must be a newline or EOF.
+func Sscanln(str string, a ...interface{}) (n int, err error) {
+	return Fscanln((*stringReader)(&str), a...)
+}
+
+// Sscanf scans the argument string, storing successive space-separated
+// values into successive arguments as determined by the format. It
+// returns the number of items successfully parsed.
+// Newlines in the input must match newlines in the format.
+func Sscanf(str string, format string, a ...interface{}) (n int, err error) {
+	return Fscanf((*stringReader)(&str), format, a...)
+}
+
+// Fscan scans text read from r, storing successive space-separated
+// values into successive arguments. Newlines count as space. It
+// returns the number of items successfully scanned. If that is less
+// than the number of arguments, err will report why.
+func Fscan(r io.Reader, a ...interface{}) (n int, err error) {
+	s, old := newScanState(r, true, false)
+	n, err = s.doScan(a)
+	s.free(old)
+	return
+}
+
+// Fscanln is similar to Fscan, but stops scanning at a newline and
+// after the final item there must be a newline or EOF.
+func Fscanln(r io.Reader, a ...interface{}) (n int, err error) {
+	s, old := newScanState(r, false, true)
+	n, err = s.doScan(a)
+	s.free(old)
+	return
+}
+
+// Fscanf scans text read from r, storing successive space-separated
+// values into successive arguments as determined by the format. It
+// returns the number of items successfully parsed.
+// Newlines in the input must match newlines in the format.
+func Fscanf(r io.Reader, format string, a ...interface{}) (n int, err error) {
+	s, old := newScanState(r, false, false)
+	n, err = s.doScanf(format, a)
+	s.free(old)
+	return
+}
+
+// scanError represents an error generated by the scanning software.
+// It's used as a unique signature to identify such errors when recovering.
+type scanError struct {
+	err error
+}
+
+const eof = -1
+
+// ss is the internal implementation of ScanState.
+type ss struct {
+	rs    io.RuneScanner // where to read input
+	buf   buffer         // token accumulator
+	count int            // runes consumed so far.
+	atEOF bool           // already read EOF
+	ssave
+}
+
+// ssave holds the parts of ss that need to be
+// saved and restored on recursive scans.
+type ssave struct {
+	validSave bool // is or was a part of an actual ss.
+	nlIsEnd   bool // whether newline terminates scan
+	nlIsSpace bool // whether newline counts as white space
+	argLimit  int  // max value of ss.count for this arg; argLimit <= limit
+	limit     int  // max value of ss.count.
+	maxWid    int  // width of this arg.
+}
+
+// The Read method is only in ScanState so that ScanState
+// satisfies io.Reader. It will never be called when used as
+// intended, so there is no need to make it actually work.
+func (s *ss) Read(buf []byte) (n int, err error) {
+	return 0, errors.New("ScanState's Read should not be called. Use ReadRune")
+}
+
+func (s *ss) ReadRune() (r rune, size int, err error) {
+	if s.atEOF || s.count >= s.argLimit {
+		err = io.EOF
+		return
+	}
+
+	r, size, err = s.rs.ReadRune()
+	if err == nil {
+		s.count++
+		if s.nlIsEnd && r == '\n' {
+			s.atEOF = true
+		}
+	} else if err == io.EOF {
+		s.atEOF = true
+	}
+	return
+}
+
+func (s *ss) Width() (wid int, ok bool) {
+	if s.maxWid == hugeWid {
+		return 0, false
+	}
+	return s.maxWid, true
+}
+
+// The public method returns an error; this private one panics.
+// If getRune reaches EOF, the return value is EOF (-1).
+func (s *ss) getRune() (r rune) {
+	r, _, err := s.ReadRune()
+	if err != nil {
+		if err == io.EOF {
+			return eof
+		}
+		s.error(err)
+	}
+	return
+}
+
+// mustReadRune turns io.EOF into a panic(io.ErrUnexpectedEOF).
+// It is called in cases such as string scanning where an EOF is a
+// syntax error.
+func (s *ss) mustReadRune() (r rune) {
+	r = s.getRune()
+	if r == eof {
+		s.error(io.ErrUnexpectedEOF)
+	}
+	return
+}
+
+func (s *ss) UnreadRune() error {
+	s.rs.UnreadRune()
+	s.atEOF = false
+	s.count--
+	return nil
+}
+
+func (s *ss) error(err error) {
+	panic(scanError{err})
+}
+
+func (s *ss) errorString(err string) {
+	panic(scanError{errors.New(err)})
+}
+
+func (s *ss) Token(skipSpace bool, f func(rune) bool) (tok []byte, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			if se, ok := e.(scanError); ok {
+				err = se.err
+			} else {
+				panic(e)
+			}
+		}
+	}()
+	if f == nil {
+		f = notSpace
+	}
+	s.buf = s.buf[:0]
+	tok = s.token(skipSpace, f)
+	return
+}
+
+// space is a copy of the unicode.White_Space ranges,
+// to avoid depending on package unicode.
+var space = [][2]uint16{
+	{0x0009, 0x000d},
+	{0x0020, 0x0020},
+	{0x0085, 0x0085},
+	{0x00a0, 0x00a0},
+	{0x1680, 0x1680},
+	{0x2000, 0x200a},
+	{0x2028, 0x2029},
+	{0x202f, 0x202f},
+	{0x205f, 0x205f},
+	{0x3000, 0x3000},
+}
+
+func isSpace(r rune) bool {
+	if r >= 1<<16 {
+		return false
+	}
+	rx := uint16(r)
+	for _, rng := range space {
+		if rx < rng[0] {
+			return false
+		}
+		if rx <= rng[1] {
+			return true
+		}
+	}
+	return false
+}
+
+// notSpace is the default scanning function used in Token.
+func notSpace(r rune) bool {
+	return !isSpace(r)
+}
+
+// readRune is a structure to enable reading UTF-8 encoded code points
+// from an io.Reader. It is used if the Reader given to the scanner does
+// not already implement io.RuneScanner.
+type readRune struct {
+	reader   io.Reader
+	buf      [utf8.UTFMax]byte // used only inside ReadRune
+	pending  int               // number of bytes in pendBuf; only >0 for bad UTF-8
+	pendBuf  [utf8.UTFMax]byte // bytes left over
+	peekRune rune              // if >=0 next rune; when <0 is ^(previous Rune)
+}
+
+// readByte returns the next byte from the input, which may be
+// left over from a previous read if the UTF-8 was ill-formed.
+func (r *readRune) readByte() (b byte, err error) {
+	if r.pending > 0 {
+		b = r.pendBuf[0]
+		copy(r.pendBuf[0:], r.pendBuf[1:])
+		r.pending--
+		return
+	}
+	n, err := io.ReadFull(r.reader, r.pendBuf[:1])
+	if n != 1 {
+		return 0, err
+	}
+	return r.pendBuf[0], err
+}
+
+// ReadRune returns the next UTF-8 encoded code point from the
+// io.Reader inside r.
+func (r *readRune) ReadRune() (rr rune, size int, err error) {
+	if r.peekRune >= 0 {
+		rr = r.peekRune
+		r.peekRune = ^r.peekRune
+		size = utf8.RuneLen(rr)
+		return
+	}
+	r.buf[0], err = r.readByte()
+	if err != nil {
+		return
+	}
+	if r.buf[0] < utf8.RuneSelf { // fast check for common ASCII case
+		rr = rune(r.buf[0])
+		size = 1 // Known to be 1.
+		// Flip the bits of the rune so it's available to UnreadRune.
+		r.peekRune = ^rr
+		return
+	}
+	var n int
+	for n = 1; !utf8.FullRune(r.buf[:n]); n++ {
+		r.buf[n], err = r.readByte()
+		if err != nil {
+			if err == io.EOF {
+				err = nil
+				break
+			}
+			return
+		}
+	}
+	rr, size = utf8.DecodeRune(r.buf[:n])
+	if size < n { // an error, save the bytes for the next read
+		copy(r.pendBuf[r.pending:], r.buf[size:n])
+		r.pending += n - size
+	}
+	// Flip the bits of the rune so it's available to UnreadRune.
+	r.peekRune = ^rr
+	return
+}
+
+func (r *readRune) UnreadRune() error {
+	if r.peekRune >= 0 {
+		return errors.New("fmt: scanning called UnreadRune with no rune available")
+	}
+	// Reverse bit flip of previously read rune to obtain valid >=0 state.
+	r.peekRune = ^r.peekRune
+	return nil
+}
+
+var ssFree = sync.Pool{
+	New: func() interface{} { return new(ss) },
+}
+
+// newScanState allocates a new ss struct or grab a cached one.
+func newScanState(r io.Reader, nlIsSpace, nlIsEnd bool) (s *ss, old ssave) {
+	s = ssFree.Get().(*ss)
+	if rs, ok := r.(io.RuneScanner); ok {
+		s.rs = rs
+	} else {
+		s.rs = &readRune{reader: r, peekRune: -1}
+	}
+	s.nlIsSpace = nlIsSpace
+	s.nlIsEnd = nlIsEnd
+	s.atEOF = false
+	s.limit = hugeWid
+	s.argLimit = hugeWid
+	s.maxWid = hugeWid
+	s.validSave = true
+	s.count = 0
+	return
+}
+
+// free saves used ss structs in ssFree; avoid an allocation per invocation.
+func (s *ss) free(old ssave) {
+	// If it was used recursively, just restore the old state.
+	if old.validSave {
+		s.ssave = old
+		return
+	}
+	// Don't hold on to ss structs with large buffers.
+	if cap(s.buf) > 1024 {
+		return
+	}
+	s.buf = s.buf[:0]
+	s.rs = nil
+	ssFree.Put(s)
+}
+
+// SkipSpace provides Scan methods the ability to skip space and newline
+// characters in keeping with the current scanning mode set by format strings
+// and Scan/Scanln.
+func (s *ss) SkipSpace() {
+	for {
+		r := s.getRune()
+		if r == eof {
+			return
+		}
+		if r == '\r' && s.peek("\n") {
+			continue
+		}
+		if r == '\n' {
+			if s.nlIsSpace {
+				continue
+			}
+			s.errorString("unexpected newline")
+			return
+		}
+		if !isSpace(r) {
+			s.UnreadRune()
+			break
+		}
+	}
+}
+
+// token returns the next space-delimited string from the input. It
+// skips white space. For Scanln, it stops at newlines. For Scan,
+// newlines are treated as spaces.
+func (s *ss) token(skipSpace bool, f func(rune) bool) []byte {
+	if skipSpace {
+		s.SkipSpace()
+	}
+	// read until white space or newline
+	for {
+		r := s.getRune()
+		if r == eof {
+			break
+		}
+		if !f(r) {
+			s.UnreadRune()
+			break
+		}
+		s.buf.WriteRune(r)
+	}
+	return s.buf
+}
+
+var complexError = errors.New("syntax error scanning complex number")
+var boolError = errors.New("syntax error scanning boolean")
+
+func indexRune(s string, r rune) int {
+	for i, c := range s {
+		if c == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// consume reads the next rune in the input and reports whether it is in the ok string.
+// If accept is true, it puts the character into the input token.
+func (s *ss) consume(ok string, accept bool) bool {
+	r := s.getRune()
+	if r == eof {
+		return false
+	}
+	if indexRune(ok, r) >= 0 {
+		if accept {
+			s.buf.WriteRune(r)
+		}
+		return true
+	}
+	if r != eof && accept {
+		s.UnreadRune()
+	}
+	return false
+}
+
+// peek reports whether the next character is in the ok string, without consuming it.
+func (s *ss) peek(ok string) bool {
+	r := s.getRune()
+	if r != eof {
+		s.UnreadRune()
+	}
+	return indexRune(ok, r) >= 0
+}
+
+func (s *ss) notEOF() {
+	// Guarantee there is data to be read.
+	if r := s.getRune(); r == eof {
+		panic(io.EOF)
+	}
+	s.UnreadRune()
+}
+
+// accept checks the next rune in the input. If it's a byte (sic) in the string, it puts it in the
+// buffer and returns true. Otherwise it return false.
+func (s *ss) accept(ok string) bool {
+	return s.consume(ok, true)
+}
+
+// okVerb verifies that the verb is present in the list, setting s.err appropriately if not.
+func (s *ss) okVerb(verb rune, okVerbs, typ string) bool {
+	for _, v := range okVerbs {
+		if v == verb {
+			return true
+		}
+	}
+	s.errorString("bad verb '%" + string(verb) + "' for " + typ)
+	return false
+}
+
+// scanBool returns the value of the boolean represented by the next token.
+func (s *ss) scanBool(verb rune) bool {
+	s.SkipSpace()
+	s.notEOF()
+	if !s.okVerb(verb, "tv", "boolean") {
+		return false
+	}
+	// Syntax-checking a boolean is annoying. We're not fastidious about case.
+	switch s.getRune() {
+	case '0':
+		return false
+	case '1':
+		return true
+	case 't', 'T':
+		if s.accept("rR") && (!s.accept("uU") || !s.accept("eE")) {
+			s.error(boolError)
+		}
+		return true
+	case 'f', 'F':
+		if s.accept("aA") && (!s.accept("lL") || !s.accept("sS") || !s.accept("eE")) {
+			s.error(boolError)
+		}
+		return false
+	}
+	return false
+}
+
+// Numerical elements
+const (
+	binaryDigits      = "01"
+	octalDigits       = "01234567"
+	decimalDigits     = "0123456789"
+	hexadecimalDigits = "0123456789aAbBcCdDeEfF"
+	sign              = "+-"
+	period            = "."
+	exponent          = "eEp"
+)
+
+// getBase returns the numeric base represented by the verb and its digit string.
+func (s *ss) getBase(verb rune) (base int, digits string) {
+	s.okVerb(verb, "bdoUxXv", "integer") // sets s.err
+	base = 10
+	digits = decimalDigits
+	switch verb {
+	case 'b':
+		base = 2
+		digits = binaryDigits
+	case 'o':
+		base = 8
+		digits = octalDigits
+	case 'x', 'X', 'U':
+		base = 16
+		digits = hexadecimalDigits
+	}
+	return
+}
+
+// scanNumber returns the numerical string with specified digits starting here.
+func (s *ss) scanNumber(digits string, haveDigits bool) string {
+	if !haveDigits {
+		s.notEOF()
+		if !s.accept(digits) {
+			s.errorString("expected integer")
+		}
+	}
+	for s.accept(digits) {
+	}
+	return string(s.buf)
+}
+
+// scanRune returns the next rune value in the input.
+func (s *ss) scanRune(bitSize int) int64 {
+	s.notEOF()
+	r := int64(s.getRune())
+	n := uint(bitSize)
+	x := (r << (64 - n)) >> (64 - n)
+	if x != r {
+		s.errorString("overflow on character value " + string(r))
+	}
+	return r
+}
+
+// scanBasePrefix reports whether the integer begins with a 0 or 0x,
+// and returns the base, digit string, and whether a zero was found.
+// It is called only if the verb is %v.
+func (s *ss) scanBasePrefix() (base int, digits string, found bool) {
+	if !s.peek("0") {
+		return 10, decimalDigits, false
+	}
+	s.accept("0")
+	found = true // We've put a digit into the token buffer.
+	// Special cases for '0' && '0x'
+	base, digits = 8, octalDigits
+	if s.peek("xX") {
+		s.consume("xX", false)
+		base, digits = 16, hexadecimalDigits
+	}
+	return
+}
+
+// scanInt returns the value of the integer represented by the next
+// token, checking for overflow. Any error is stored in s.err.
+func (s *ss) scanInt(verb rune, bitSize int) int64 {
+	if verb == 'c' {
+		return s.scanRune(bitSize)
+	}
+	s.SkipSpace()
+	s.notEOF()
+	base, digits := s.getBase(verb)
+	haveDigits := false
+	if verb == 'U' {
+		if !s.consume("U", false) || !s.consume("+", false) {
+			s.errorString("bad unicode format ")
+		}
+	} else {
+		s.accept(sign) // If there's a sign, it will be left in the token buffer.
+		if verb == 'v' {
+			base, digits, haveDigits = s.scanBasePrefix()
+		}
+	}
+	tok := s.scanNumber(digits, haveDigits)
+	i, err := strconv.ParseInt(tok, base, 64)
+	if err != nil {
+		s.error(err)
+	}
+	n := uint(bitSize)
+	x := (i << (64 - n)) >> (64 - n)
+	if x != i {
+		s.errorString("integer overflow on token " + tok)
+	}
+	return i
+}
+
+// scanUint returns the value of the unsigned integer represented
+// by the next token, checking for overflow. Any error is stored in s.err.
+func (s *ss) scanUint(verb rune, bitSize int) uint64 {
+	if verb == 'c' {
+		return uint64(s.scanRune(bitSize))
+	}
+	s.SkipSpace()
+	s.notEOF()
+	base, digits := s.getBase(verb)
+	haveDigits := false
+	if verb == 'U' {
+		if !s.consume("U", false) || !s.consume("+", false) {
+			s.errorString("bad unicode format ")
+		}
+	} else if verb == 'v' {
+		base, digits, haveDigits = s.scanBasePrefix()
+	}
+	tok := s.scanNumber(digits, haveDigits)
+	i, err := strconv.ParseUint(tok, base, 64)
+	if err != nil {
+		s.error(err)
+	}
+	n := uint(bitSize)
+	x := (i << (64 - n)) >> (64 - n)
+	if x != i {
+		s.errorString("unsigned integer overflow on token " + tok)
+	}
+	return i
+}
+
+// floatToken returns the floating-point number starting here, no longer than swid
+// if the width is specified. It's not rigorous about syntax because it doesn't check that
+// we have at least some digits, but Atof will do that.
+func (s *ss) floatToken() string {
+	s.buf = s.buf[:0]
+	// NaN?
+	if s.accept("nN") && s.accept("aA") && s.accept("nN") {
+		return string(s.buf)
+	}
+	// leading sign?
+	s.accept(sign)
+	// Inf?
+	if s.accept("iI") && s.accept("nN") && s.accept("fF") {
+		return string(s.buf)
+	}
+	// digits?
+	for s.accept(decimalDigits) {
+	}
+	// decimal point?
+	if s.accept(period) {
+		// fraction?
+		for s.accept(decimalDigits) {
+		}
+	}
+	// exponent?
+	if s.accept(exponent) {
+		// leading sign?
+		s.accept(sign)
+		// digits?
+		for s.accept(decimalDigits) {
+		}
+	}
+	return string(s.buf)
+}
+
+// complexTokens returns the real and imaginary parts of the complex number starting here.
+// The number might be parenthesized and has the format (N+Ni) where N is a floating-point
+// number and there are no spaces within.
+func (s *ss) complexTokens() (real, imag string) {
+	// TODO: accept N and Ni independently?
+	parens := s.accept("(")
+	real = s.floatToken()
+	s.buf = s.buf[:0]
+	// Must now have a sign.
+	if !s.accept("+-") {
+		s.error(complexError)
+	}
+	// Sign is now in buffer
+	imagSign := string(s.buf)
+	imag = s.floatToken()
+	if !s.accept("i") {
+		s.error(complexError)
+	}
+	if parens && !s.accept(")") {
+		s.error(complexError)
+	}
+	return real, imagSign + imag
+}
+
+// convertFloat converts the string to a float64value.
+func (s *ss) convertFloat(str string, n int) float64 {
+	if p := indexRune(str, 'p'); p >= 0 {
+		// Atof doesn't handle power-of-2 exponents,
+		// but they're easy to evaluate.
+		f, err := strconv.ParseFloat(str[:p], n)
+		if err != nil {
+			// Put full string into error.
+			if e, ok := err.(*strconv.NumError); ok {
+				e.Num = str
+			}
+			s.error(err)
+		}
+		m, err := strconv.Atoi(str[p+1:])
+		if err != nil {
+			// Put full string into error.
+			if e, ok := err.(*strconv.NumError); ok {
+				e.Num = str
+			}
+			s.error(err)
+		}
+		return math.Ldexp(f, m)
+	}
+	f, err := strconv.ParseFloat(str, n)
+	if err != nil {
+		s.error(err)
+	}
+	return f
+}
+
+// convertComplex converts the next token to a complex128 value.
+// The atof argument is a type-specific reader for the underlying type.
+// If we're reading complex64, atof will parse float32s and convert them
+// to float64's to avoid reproducing this code for each complex type.
+func (s *ss) scanComplex(verb rune, n int) complex128 {
+	if !s.okVerb(verb, floatVerbs, "complex") {
+		return 0
+	}
+	s.SkipSpace()
+	s.notEOF()
+	sreal, simag := s.complexTokens()
+	real := s.convertFloat(sreal, n/2)
+	imag := s.convertFloat(simag, n/2)
+	return complex(real, imag)
+}
+
+// convertString returns the string represented by the next input characters.
+// The format of the input is determined by the verb.
+func (s *ss) convertString(verb rune) (str string) {
+	if !s.okVerb(verb, "svqxX", "string") {
+		return ""
+	}
+	s.SkipSpace()
+	s.notEOF()
+	switch verb {
+	case 'q':
+		str = s.quotedString()
+	case 'x', 'X':
+		str = s.hexString()
+	default:
+		str = string(s.token(true, notSpace)) // %s and %v just return the next word
+	}
+	return
+}
+
+// quotedString returns the double- or back-quoted string represented by the next input characters.
+func (s *ss) quotedString() string {
+	s.notEOF()
+	quote := s.getRune()
+	switch quote {
+	case '`':
+		// Back-quoted: Anything goes until EOF or back quote.
+		for {
+			r := s.mustReadRune()
+			if r == quote {
+				break
+			}
+			s.buf.WriteRune(r)
+		}
+		return string(s.buf)
+	case '"':
+		// Double-quoted: Include the quotes and let strconv.Unquote do the backslash escapes.
+		s.buf.WriteByte('"')
+		for {
+			r := s.mustReadRune()
+			s.buf.WriteRune(r)
+			if r == '\\' {
+				// In a legal backslash escape, no matter how long, only the character
+				// immediately after the escape can itself be a backslash or quote.
+				// Thus we only need to protect the first character after the backslash.
+				s.buf.WriteRune(s.mustReadRune())
+			} else if r == '"' {
+				break
+			}
+		}
+		result, err := strconv.Unquote(string(s.buf))
+		if err != nil {
+			s.error(err)
+		}
+		return result
+	default:
+		s.errorString("expected quoted string")
+	}
+	return ""
+}
+
+// hexDigit returns the value of the hexadecimal digit.
+func hexDigit(d rune) (int, bool) {
+	digit := int(d)
+	switch digit {
+	case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+		return digit - '0', true
+	case 'a', 'b', 'c', 'd', 'e', 'f':
+		return 10 + digit - 'a', true
+	case 'A', 'B', 'C', 'D', 'E', 'F':
+		return 10 + digit - 'A', true
+	}
+	return -1, false
+}
+
+// hexByte returns the next hex-encoded (two-character) byte from the input.
+// It returns ok==false if the next bytes in the input do not encode a hex byte.
+// If the first byte is hex and the second is not, processing stops.
+func (s *ss) hexByte() (b byte, ok bool) {
+	rune1 := s.getRune()
+	if rune1 == eof {
+		return
+	}
+	value1, ok := hexDigit(rune1)
+	if !ok {
+		s.UnreadRune()
+		return
+	}
+	value2, ok := hexDigit(s.mustReadRune())
+	if !ok {
+		s.errorString("illegal hex digit")
+		return
+	}
+	return byte(value1<<4 | value2), true
+}
+
+// hexString returns the space-delimited hexpair-encoded string.
+func (s *ss) hexString() string {
+	s.notEOF()
+	for {
+		b, ok := s.hexByte()
+		if !ok {
+			break
+		}
+		s.buf.WriteByte(b)
+	}
+	if len(s.buf) == 0 {
+		s.errorString("no hex data for %x string")
+		return ""
+	}
+	return string(s.buf)
+}
+
+const (
+	floatVerbs = "beEfFgGv"
+
+	hugeWid = 1 << 30
+
+	intBits     = 32 << (^uint(0) >> 63)
+	uintptrBits = 32 << (^uintptr(0) >> 63)
+)
+
+// scanOne scans a single value, deriving the scanner from the type of the argument.
+func (s *ss) scanOne(verb rune, arg interface{}) {
+	s.buf = s.buf[:0]
+	var err error
+	// If the parameter has its own Scan method, use that.
+	if v, ok := arg.(Scanner); ok {
+		err = v.Scan(s, verb)
+		if err != nil {
+			if err == io.EOF {
+				err = io.ErrUnexpectedEOF
+			}
+			s.error(err)
+		}
+		return
+	}
+
+	switch v := arg.(type) {
+	case *bool:
+		*v = s.scanBool(verb)
+	case *complex64:
+		*v = complex64(s.scanComplex(verb, 64))
+	case *complex128:
+		*v = s.scanComplex(verb, 128)
+	case *int:
+		*v = int(s.scanInt(verb, intBits))
+	case *int8:
+		*v = int8(s.scanInt(verb, 8))
+	case *int16:
+		*v = int16(s.scanInt(verb, 16))
+	case *int32:
+		*v = int32(s.scanInt(verb, 32))
+	case *int64:
+		*v = s.scanInt(verb, 64)
+	case *uint:
+		*v = uint(s.scanUint(verb, intBits))
+	case *uint8:
+		*v = uint8(s.scanUint(verb, 8))
+	case *uint16:
+		*v = uint16(s.scanUint(verb, 16))
+	case *uint32:
+		*v = uint32(s.scanUint(verb, 32))
+	case *uint64:
+		*v = s.scanUint(verb, 64)
+	case *uintptr:
+		*v = uintptr(s.scanUint(verb, uintptrBits))
+	// Floats are tricky because you want to scan in the precision of the result, not
+	// scan in high precision and convert, in order to preserve the correct error condition.
+	case *float32:
+		if s.okVerb(verb, floatVerbs, "float32") {
+			s.SkipSpace()
+			s.notEOF()
+			*v = float32(s.convertFloat(s.floatToken(), 32))
+		}
+	case *float64:
+		if s.okVerb(verb, floatVerbs, "float64") {
+			s.SkipSpace()
+			s.notEOF()
+			*v = s.convertFloat(s.floatToken(), 64)
+		}
+	case *string:
+		*v = s.convertString(verb)
+	case *[]byte:
+		// We scan to string and convert so we get a copy of the data.
+		// If we scanned to bytes, the slice would point at the buffer.
+		*v = []byte(s.convertString(verb))
+	default:
+		val := reflect.ValueOf(v)
+		ptr := val
+		if ptr.Kind() != reflect.Ptr {
+			s.errorString("type not a pointer: " + val.Type().String())
+			return
+		}
+		switch v := ptr.Elem(); v.Kind() {
+		case reflect.Bool:
+			v.SetBool(s.scanBool(verb))
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v.SetInt(s.scanInt(verb, v.Type().Bits()))
+		case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+			v.SetUint(s.scanUint(verb, v.Type().Bits()))
+		case reflect.String:
+			v.SetString(s.convertString(verb))
+		case reflect.Slice:
+			// For now, can only handle (renamed) []byte.
+			typ := v.Type()
+			if typ.Elem().Kind() != reflect.Uint8 {
+				s.errorString("can't scan type: " + val.Type().String())
+			}
+			str := s.convertString(verb)
+			v.Set(reflect.MakeSlice(typ, len(str), len(str)))
+			for i := 0; i < len(str); i++ {
+				v.Index(i).SetUint(uint64(str[i]))
+			}
+		case reflect.Float32, reflect.Float64:
+			s.SkipSpace()
+			s.notEOF()
+			v.SetFloat(s.convertFloat(s.floatToken(), v.Type().Bits()))
+		case reflect.Complex64, reflect.Complex128:
+			v.SetComplex(s.scanComplex(verb, v.Type().Bits()))
+		default:
+			s.errorString("can't scan type: " + val.Type().String())
+		}
+	}
+}
+
+// errorHandler turns local panics into error returns.
+func errorHandler(errp *error) {
+	if e := recover(); e != nil {
+		if se, ok := e.(scanError); ok { // catch local error
+			*errp = se.err
+		} else if eof, ok := e.(error); ok && eof == io.EOF { // out of input
+			*errp = eof
+		} else {
+			panic(e)
+		}
+	}
+}
+
+// doScan does the real work for scanning without a format string.
+func (s *ss) doScan(a []interface{}) (numProcessed int, err error) {
+	defer errorHandler(&err)
+	for _, arg := range a {
+		s.scanOne('v', arg)
+		numProcessed++
+	}
+	// Check for newline (or EOF) if required (Scanln etc.).
+	if s.nlIsEnd {
+		for {
+			r := s.getRune()
+			if r == '\n' || r == eof {
+				break
+			}
+			if !isSpace(r) {
+				s.errorString("expected newline")
+				break
+			}
+		}
+	}
+	return
+}
+
+// advance determines whether the next characters in the input match
+// those of the format. It returns the number of bytes (sic) consumed
+// in the format. All runs of space characters in either input or
+// format behave as a single space. Newlines are special, though:
+// newlines in the format must match those in the input and vice versa.
+// This routine also handles the %% case. If the return value is zero,
+// either format starts with a % (with no following %) or the input
+// is empty. If it is negative, the input did not match the string.
+func (s *ss) advance(format string) (i int) {
+	for i < len(format) {
+		fmtc, w := utf8.DecodeRuneInString(format[i:])
+
+		// Space processing.
+		// In the rest of this comment "space" means spaces other than newline.
+		// Newline in the format matches input of zero or more spaces and then newline or end-of-input.
+		// Spaces in the format before the newline are collapsed into the newline.
+		// Spaces in the format after the newline match zero or more spaces after the corresponding input newline.
+		// Other spaces in the format match input of one or more spaces or end-of-input.
+		if isSpace(fmtc) {
+			newlines := 0
+			trailingSpace := false
+			for isSpace(fmtc) && i < len(format) {
+				if fmtc == '\n' {
+					newlines++
+					trailingSpace = false
+				} else {
+					trailingSpace = true
+				}
+				i += w
+				fmtc, w = utf8.DecodeRuneInString(format[i:])
+			}
+			for j := 0; j < newlines; j++ {
+				inputc := s.getRune()
+				for isSpace(inputc) && inputc != '\n' {
+					inputc = s.getRune()
+				}
+				if inputc != '\n' && inputc != eof {
+					s.errorString("newline in format does not match input")
+				}
+			}
+			if trailingSpace {
+				inputc := s.getRune()
+				if newlines == 0 {
+					// If the trailing space stood alone (did not follow a newline),
+					// it must find at least one space to consume.
+					if !isSpace(inputc) && inputc != eof {
+						s.errorString("expected space in input to match format")
+					}
+					if inputc == '\n' {
+						s.errorString("newline in input does not match format")
+					}
+				}
+				for isSpace(inputc) && inputc != '\n' {
+					inputc = s.getRune()
+				}
+				if inputc != eof {
+					s.UnreadRune()
+				}
+			}
+			continue
+		}
+
+		// Verbs.
+		if fmtc == '%' {
+			// % at end of string is an error.
+			if i+w == len(format) {
+				s.errorString("missing verb: % at end of format string")
+			}
+			// %% acts like a real percent
+			nextc, _ := utf8.DecodeRuneInString(format[i+w:]) // will not match % if string is empty
+			if nextc != '%' {
+				return
+			}
+			i += w // skip the first %
+		}
+
+		// Literals.
+		inputc := s.mustReadRune()
+		if fmtc != inputc {
+			s.UnreadRune()
+			return -1
+		}
+		i += w
+	}
+	return
+}
+
+// doScanf does the real work when scanning with a format string.
+// At the moment, it handles only pointers to basic types.
+func (s *ss) doScanf(format string, a []interface{}) (numProcessed int, err error) {
+	defer errorHandler(&err)
+	end := len(format) - 1
+	// We process one item per non-trivial format
+	for i := 0; i <= end; {
+		w := s.advance(format[i:])
+		if w > 0 {
+			i += w
+			continue
+		}
+		// Either we failed to advance, we have a percent character, or we ran out of input.
+		if format[i] != '%' {
+			// Can't advance format. Why not?
+			if w < 0 {
+				s.errorString("input does not match format")
+			}
+			// Otherwise at EOF; "too many operands" error handled below
+			break
+		}
+		i++ // % is one byte
+
+		// do we have 20 (width)?
+		var widPresent bool
+		s.maxWid, widPresent, i = parsenum(format, i, end)
+		if !widPresent {
+			s.maxWid = hugeWid
+		}
+
+		c, w := utf8.DecodeRuneInString(format[i:])
+		i += w
+
+		if c != 'c' {
+			s.SkipSpace()
+		}
+		s.argLimit = s.limit
+		if f := s.count + s.maxWid; f < s.argLimit {
+			s.argLimit = f
+		}
+
+		if numProcessed >= len(a) { // out of operands
+			s.errorString("too few operands for format '%" + format[i-w:] + "'")
+			break
+		}
+		arg := a[numProcessed]
+
+		s.scanOne(c, arg)
+		numProcessed++
+		s.argLimit = s.limit
+	}
+	if numProcessed < len(a) {
+		s.errorString("too many operands")
+	}
+	return
+}

--- a/vendor/golang.org/x/exp/errors/format.go
+++ b/vendor/golang.org/x/exp/errors/format.go
@@ -1,0 +1,34 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package errors
+
+// A Formatter formats error messages.
+type Formatter interface {
+	error
+
+	// FormatError prints the receiver's first error and returns the next error in
+	// the error chain, if any.
+	FormatError(p Printer) (next error)
+}
+
+// A Printer formats error messages.
+//
+// The most common implementation of Printer is the one provided by package fmt
+// during Printf. Localization packages such as golang.org/x/text/message
+// typically provide their own implementations.
+type Printer interface {
+	// Print appends args to the message output.
+	Print(args ...interface{})
+
+	// Printf writes a formatted string.
+	Printf(format string, args ...interface{})
+
+	// Detail reports whether error detail is requested.
+	// After the first call to Detail, all text written to the Printer
+	// is formatted as additional detail, or ignored when
+	// detail has not been requested.
+	// If Detail returns false, the caller can avoid printing the detail at all.
+	Detail() bool
+}

--- a/vendor/golang.org/x/exp/errors/frame.go
+++ b/vendor/golang.org/x/exp/errors/frame.go
@@ -1,0 +1,56 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package errors
+
+import (
+	"runtime"
+)
+
+// A Frame contains part of a call stack.
+type Frame struct {
+	// Make room for three PCs: the one we were asked for, what it called,
+	// and possibly a PC for skipPleaseUseCallersFrames. See:
+	// https://go.googlesource.com/go/+/032678e0fb/src/runtime/extern.go#169
+	frames [3]uintptr
+}
+
+// Caller returns a Frame that describes a frame on the caller's stack.
+// The argument skip is the number of frames to skip over.
+// Caller(0) returns the frame for the caller of Caller.
+func Caller(skip int) Frame {
+	var s Frame
+	runtime.Callers(skip+1, s.frames[:])
+	return s
+}
+
+// location reports the file, line, and function of a frame.
+//
+// The returned function may be "" even if file and line are not.
+func (f Frame) location() (function, file string, line int) {
+	frames := runtime.CallersFrames(f.frames[:])
+	if _, ok := frames.Next(); !ok {
+		return "", "", 0
+	}
+	fr, ok := frames.Next()
+	if !ok {
+		return "", "", 0
+	}
+	return fr.Function, fr.File, fr.Line
+}
+
+// Format prints the stack as error detail.
+// It should be called from an error's Format implementation,
+// before printing any other error detail.
+func (f Frame) Format(p Printer) {
+	if p.Detail() {
+		function, file, line := f.location()
+		if function != "" {
+			p.Printf("%s\n    ", function)
+		}
+		if file != "" {
+			p.Printf("%s:%d\n", file, line)
+		}
+	}
+}

--- a/vendor/golang.org/x/exp/errors/go.mod
+++ b/vendor/golang.org/x/exp/errors/go.mod
@@ -1,0 +1,1 @@
+module golang.org/x/exp/errors

--- a/vendor/golang.org/x/exp/errors/internal/internal.go
+++ b/vendor/golang.org/x/exp/errors/internal/internal.go
@@ -1,0 +1,8 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package internal
+
+// EnableTrace indicates whether stack information should be recorded in errors.
+var EnableTrace = true

--- a/vendor/golang.org/x/exp/errors/wrap.go
+++ b/vendor/golang.org/x/exp/errors/wrap.go
@@ -1,0 +1,98 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package errors
+
+import (
+	"reflect"
+)
+
+// An Wrapper provides context around another error.
+type Wrapper interface {
+	// Unwrap returns the next error in the error chain.
+	// If there is no next error, Unwrap returns nil.
+	Unwrap() error
+}
+
+// Opaque returns an error with the same error formatting as err
+// but that does not match err and cannot be unwrapped.
+func Opaque(err error) error {
+	return noWrapper{err}
+}
+
+type noWrapper struct {
+	error
+}
+
+func (e noWrapper) FormatError(p Printer) (next error) {
+	if f, ok := e.error.(Formatter); ok {
+		return f.FormatError(p)
+	}
+	p.Print(e.error)
+	return nil
+}
+
+// Unwrap returns the next error in err's chain.
+// If there is no next error, Unwrap returns nil.
+func Unwrap(err error) error {
+	u, ok := err.(Wrapper)
+	if !ok {
+		return nil
+	}
+	return u.Unwrap()
+}
+
+// Is returns true if any error in err's chain matches target.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements an Is method such that Is(target) returns true.
+func Is(err, target error) bool {
+	if target == nil {
+		return err == target
+	}
+	for {
+		if err == target {
+			return true
+		}
+		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+			return true
+		}
+		// TODO: consider supporing target.Is(err). This would allow
+		// user-definable predicates, but also may allow for coping with sloppy
+		// APIs, thereby making it easier to get away with them.
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}
+
+// As finds the first error in err's chain that matches a type to which target
+// points, and if so, sets the target to its value and reports success. An error
+// matches a type if it is of the same type, or if it has an As method such that
+// As(target) returns true. As will panic if target is nil or not a pointer.
+//
+// The As method should set the target to its value and report success if err
+// matches the type to which target points and report success.
+func As(err error, target interface{}) bool {
+	if target == nil {
+		panic("errors: target cannot be nil")
+	}
+	typ := reflect.TypeOf(target)
+	if typ.Kind() != reflect.Ptr {
+		panic("errors: target must be a pointer")
+	}
+	targetType := typ.Elem()
+	for {
+		if reflect.TypeOf(err) == targetType {
+			reflect.ValueOf(target).Elem().Set(reflect.ValueOf(err))
+			return true
+		}
+		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+			return true
+		}
+		if err = Unwrap(err); err == nil {
+			return false
+		}
+	}
+}


### PR DESCRIPTION
This is a sketch of what structured error collection could look like.
With stack tracing enabled, it's slower than current format.Errorf, but
still faster than the Go 2 error prototype.  With stack traces disabled,
it's actually faster than fmt.Errorf, with the same number of
allocations, but slightly more bytes.
