### PR TITLE
:sparkles: Default QPS to a saner value in and out of tests

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -169,6 +169,9 @@ func (te *Environment) Start() (*rest.Config, error) {
 		// Create the *rest.Config for creating new clients
 		te.Config = &rest.Config{
 			Host: te.ControlPlane.APIURL().Host,
+			// gotta go fast during tests -- we don't really care about overwhelming our test API server
+			QPS:   1000.0,
+			Burst: 2000.0,
 		}
 	}
 


### PR DESCRIPTION
The default QPS on REST clients is 5 (with burst to 10), which is rather slow.  This is especially true when running a test server, since you want to run tests pretty quickly, and the test cluster is default.

For normal clients, we probably want to default to what the KCM defaults to (our situation isn't quite the same, since we actually share the client across controllers, so we should follow up dealing with that at some point).  This gives us 20 QPS with burst to 30.