### PR TITLE
:bug: Fake client should fail with panic instead of log and exit

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -32,12 +31,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
-)
-
-var (
-	log = logf.RuntimeLog.WithName("fake-client")
 )
 
 type fakeClient struct {
@@ -63,9 +57,7 @@ func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.O
 	for _, obj := range initObjs {
 		err := tracker.Add(obj)
 		if err != nil {
-			log.Error(err, "failed to add object to fake client", "object", obj)
-			os.Exit(1)
-			return nil
+			panic(fmt.Errorf("failed to add object %v to fake client: %v", obj, err))
 		}
 	}
 	return &fakeClient{


### PR DESCRIPTION
Fake client should panic instead of log-then-exit when it fails to create.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/354
