### PR TITLE
:bug: Remove redundant check

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -180,11 +180,6 @@ func (c *Controller) processNextWorkItem() bool {
 	}()
 
 	obj, shutdown := c.Queue.Get()
-	if obj == nil {
-		// Sometimes the Queue gives us nil items when it starts up
-		c.Queue.Forget(obj)
-	}
-
 	if shutdown {
 		// Stop working
 		return false


### PR DESCRIPTION
[This check](https://github.com/kubernetes-sigs/controller-runtime/blob/e4c40bc20113bec130047ba0a42cec39ca0d6476/pkg/internal/controller/controller.go#L202) covers the case obj equals nil.