### PR TITLE
 🐛 Add mutex to loggerPromise to prevent races

### DIFF
--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -17,6 +17,8 @@ limitations under the License.
 package log
 
 import (
+	"sync"
+
 	"github.com/go-logr/logr"
 )
 
@@ -25,6 +27,7 @@ import (
 type loggerPromise struct {
 	logger        *DelegatingLogger
 	childPromises []*loggerPromise
+	promisesLock  *sync.Mutex
 
 	name *string
 	tags []interface{}
@@ -33,9 +36,13 @@ type loggerPromise struct {
 // WithName provides a new Logger with the name appended
 func (p *loggerPromise) WithName(l *DelegatingLogger, name string) *loggerPromise {
 	res := &loggerPromise{
-		logger: l,
-		name:   &name,
+		logger:       l,
+		name:         &name,
+		promisesLock: &sync.Mutex{},
 	}
+
+	p.promisesLock.Lock()
+	defer p.promisesLock.Unlock()
 	p.childPromises = append(p.childPromises, res)
 	return res
 }
@@ -43,9 +50,13 @@ func (p *loggerPromise) WithName(l *DelegatingLogger, name string) *loggerPromis
 // WithValues provides a new Logger with the tags appended
 func (p *loggerPromise) WithValues(l *DelegatingLogger, tags ...interface{}) *loggerPromise {
 	res := &loggerPromise{
-		logger: l,
-		tags:   tags,
+		logger:       l,
+		tags:         tags,
+		promisesLock: &sync.Mutex{},
 	}
+
+	p.promisesLock.Lock()
+	defer p.promisesLock.Unlock()
 	p.childPromises = append(p.childPromises, res)
 	return res
 }
@@ -119,7 +130,7 @@ func (l *DelegatingLogger) Fulfill(actual logr.Logger) {
 func NewDelegatingLogger(initial logr.Logger) *DelegatingLogger {
 	l := &DelegatingLogger{
 		Logger:  initial,
-		promise: &loggerPromise{},
+		promise: &loggerPromise{promisesLock: &sync.Mutex{}},
 	}
 	l.promise.logger = l
 	return l

--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -27,7 +27,7 @@ import (
 type loggerPromise struct {
 	logger        *DelegatingLogger
 	childPromises []*loggerPromise
-	promisesLock  *sync.Mutex
+	promisesLock  sync.Mutex
 
 	name *string
 	tags []interface{}
@@ -38,7 +38,7 @@ func (p *loggerPromise) WithName(l *DelegatingLogger, name string) *loggerPromis
 	res := &loggerPromise{
 		logger:       l,
 		name:         &name,
-		promisesLock: &sync.Mutex{},
+		promisesLock: sync.Mutex{},
 	}
 
 	p.promisesLock.Lock()
@@ -52,7 +52,7 @@ func (p *loggerPromise) WithValues(l *DelegatingLogger, tags ...interface{}) *lo
 	res := &loggerPromise{
 		logger:       l,
 		tags:         tags,
-		promisesLock: &sync.Mutex{},
+		promisesLock: sync.Mutex{},
 	}
 
 	p.promisesLock.Lock()
@@ -130,7 +130,7 @@ func (l *DelegatingLogger) Fulfill(actual logr.Logger) {
 func NewDelegatingLogger(initial logr.Logger) *DelegatingLogger {
 	l := &DelegatingLogger{
 		Logger:  initial,
-		promise: &loggerPromise{promisesLock: &sync.Mutex{}},
+		promise: &loggerPromise{promisesLock: sync.Mutex{}},
 	}
 	l.promise.logger = l
 	return l


### PR DESCRIPTION
I was attempting to [add some logging](https://github.com/pusher/faros/pull/114) to our project Faros, but we run our tests with the `-race` flag and the tests failed while detecting a race in controller-runtime ([logs here](https://prow.pusher.com/view/gcs/pusher-ci-cluster-35535/pr-logs/pull/pusher_faros/114/pull-faros-test-ginkgo/1112733698010124288)).

I then created this branch, added a [commit](https://github.com/pusher/faros/pull/114/commits/db9851c02320c2fc7c7c7e50aca7f7ad2aab2333) to test the fix for the race and [my tests all passed](https://prow.pusher.com/view/gcs/pusher-ci-cluster-35535/pr-logs/pull/pusher_faros/114/pull-faros-test-ginkgo/1112736340442615808) 😄 
