### PR TITLE
:sparkles: [WIP] A fake client using client-go reactors

### DIFF
--- a/pkg/client/fake/reactor_client.go
+++ b/pkg/client/fake/reactor_client.go
@@ -1,0 +1,276 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
+)
+
+var (
+//log = logf.RuntimeLog.WithName("fake-client")
+)
+
+type fakeReactorClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+var _ client.Client = &fakeReactorClient{}
+
+// NewFakeReactorClient creates a new fake client for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+// Deprecated: use NewFakeReactorClientWithScheme.  You should always be
+// passing an explicit Scheme.
+func NewFakeReactorClient(initObjs ...runtime.Object) client.Client {
+	return NewFakeReactorClientWithScheme(scheme.Scheme, initObjs...)
+}
+
+// NewFakeReactorClientWithScheme creates a new fake client with the given scheme
+// for testing.
+// You can choose to initialize it with a slice of runtime.Object.
+func NewFakeReactorClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
+	tracker := testing.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
+	for _, obj := range initObjs {
+		if err := tracker.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	fc := &fakeReactorClient{scheme: clientScheme}
+	fc.AddReactor("*", "*", testing.ObjectReaction(tracker))
+	return fc
+}
+
+func (c *fakeReactorClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	// TODO Is the defaultObj necessary?
+	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
+	if err != nil {
+		return err
+	}
+	defaultObj, err := scheme.Scheme.New(gvk)
+	if err != nil {
+		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
+	}
+	o, err := c.Invokes(testing.NewGetAction(gvr, key.Namespace, key.Name), defaultObj)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeReactorClient) List(ctx context.Context, obj runtime.Object, opts ...client.ListOptionFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
+	}
+	// TODO Is the defaultObj necessary?
+	defaultObj, err := scheme.Scheme.New(gvk)
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	if err != nil {
+		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
+	}
+	o, err := c.Invokes(testing.NewListAction(gvr, gvk, listOpts.Namespace, *listOpts.AsListOptions()), defaultObj)
+	if err != nil {
+		return err
+	}
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	if err != nil {
+		return err
+	}
+
+	if listOpts.LabelSelector != nil {
+		objs, err := meta.ExtractList(obj)
+		if err != nil {
+			return err
+		}
+		filteredObjs, err := objectutil.FilterWithLabels(objs, listOpts.LabelSelector)
+		if err != nil {
+			return err
+		}
+		err = meta.SetList(obj, filteredObjs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *fakeReactorClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOptionFunc) error {
+	createOptions := &client.CreateOptions{}
+	createOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range createOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	// Is a nil defaultObj ok here?
+	_, err = c.Invokes(testing.NewCreateAction(gvr, accessor.GetNamespace(), obj), nil)
+	return err
+}
+
+func (c *fakeReactorClient) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOptionFunc) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	//TODO: implement propagation
+	// Is a nil defaultObj ok here?
+	_, err = c.Invokes(testing.NewDeleteAction(gvr, accessor.GetNamespace(), accessor.GetName()), nil)
+	return err
+}
+
+func (c *fakeReactorClient) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOptionFunc) error {
+	updateOptions := &client.UpdateOptions{}
+	updateOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range updateOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	// Is a nil defaultObj ok here?
+	_, err = c.Invokes(testing.NewUpdateAction(gvr, accessor.GetNamespace(), obj), nil)
+	return err
+}
+
+func (c *fakeReactorClient) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOptionFunc) error {
+	gvr, err := getGVRFromObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	// TODO Is the defaultObj necessary?
+	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
+	if err != nil {
+		return err
+	}
+	defaultObj, err := scheme.Scheme.New(gvk)
+	if err != nil {
+		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
+	}
+
+	o, err := c.Invokes(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data), defaultObj)
+
+	j, err := json.Marshal(o)
+	if err != nil {
+		return err
+	}
+	decoder := scheme.Codecs.UniversalDecoder()
+	_, _, err = decoder.Decode(j, nil, obj)
+	return err
+}
+
+func (c *fakeReactorClient) Status() client.StatusWriter {
+	return &fakeReactorStatusWriter{client: c}
+}
+
+// func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionResource, error) {
+// 	gvk, err := apiutil.GVKForObject(obj, scheme)
+// 	if err != nil {
+// 		return schema.GroupVersionResource{}, err
+// 	}
+// 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+// 	return gvr, nil
+// }
+
+type fakeReactorStatusWriter struct {
+	client *fakeReactorClient
+}
+
+func (sw *fakeReactorStatusWriter) Update(ctx context.Context, obj runtime.Object) error {
+	gvr, err := getGVRFromObject(obj, sw.client.scheme)
+	if err != nil {
+		return err
+	}
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	// Is a nil defaultObj ok here?
+	_, err = sw.client.Invokes(testing.NewUpdateSubresourceAction(gvr, "status", accessor.GetNamespace(), obj), nil)
+	return err
+}

--- a/pkg/client/fake/reactor_client.go
+++ b/pkg/client/fake/reactor_client.go
@@ -73,16 +73,8 @@ func (c *fakeReactorClient) Get(ctx context.Context, key client.ObjectKey, obj r
 	if err != nil {
 		return err
 	}
-	// TODO Is the defaultObj necessary?
-	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
-	if err != nil {
-		return err
-	}
-	defaultObj, err := scheme.Scheme.New(gvk)
-	if err != nil {
-		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
-	}
-	o, err := c.Invokes(testing.NewGetAction(gvr, key.Namespace, key.Name), defaultObj)
+
+	o, err := c.Invokes(testing.NewGetAction(gvr, key.Namespace, key.Name), nil)
 	if err != nil {
 		return err
 	}
@@ -104,8 +96,7 @@ func (c *fakeReactorClient) List(ctx context.Context, obj runtime.Object, opts .
 	if !strings.HasSuffix(gvk.Kind, "List") {
 		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
 	}
-	// TODO Is the defaultObj necessary?
-	defaultObj, err := scheme.Scheme.New(gvk)
+
 	// we need the non-list GVK, so chop off the "List" from the end of the kind
 	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 
@@ -114,10 +105,7 @@ func (c *fakeReactorClient) List(ctx context.Context, obj runtime.Object, opts .
 
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
-	if err != nil {
-		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
-	}
-	o, err := c.Invokes(testing.NewListAction(gvr, gvk, listOpts.Namespace, *listOpts.AsListOptions()), defaultObj)
+	o, err := c.Invokes(testing.NewListAction(gvr, gvk, listOpts.Namespace, *listOpts.AsListOptions()), nil)
 	if err != nil {
 		return err
 	}
@@ -223,17 +211,7 @@ func (c *fakeReactorClient) Patch(ctx context.Context, obj runtime.Object, patch
 		return err
 	}
 
-	// TODO Is the defaultObj necessary?
-	gvk, err := apiutil.GVKForObject(obj, scheme.Scheme)
-	if err != nil {
-		return err
-	}
-	defaultObj, err := scheme.Scheme.New(gvk)
-	if err != nil {
-		return fmt.Errorf("error creating a copy of %T: %v", obj, err)
-	}
-
-	o, err := c.Invokes(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data), defaultObj)
+	o, err := c.Invokes(testing.NewPatchAction(gvr, accessor.GetNamespace(), accessor.GetName(), patch.Type(), data), nil)
 
 	j, err := json.Marshal(o)
 	if err != nil {

--- a/pkg/client/fake/reactor_client_test.go
+++ b/pkg/client/fake/reactor_client_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Fake client", func() {
+	var dep *appsv1.Deployment
+	var dep2 *appsv1.Deployment
+	var cm *corev1.ConfigMap
+	var cl client.Client
+
+	BeforeEach(func() {
+		dep = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "ns1",
+			},
+		}
+		dep2 = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment-2",
+				Namespace: "ns1",
+				Labels: map[string]string{
+					"test-label": "label-value",
+				},
+			},
+		}
+		cm = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cm",
+				Namespace: "ns2",
+			},
+			Data: map[string]string{
+				"test-key": "test-value",
+			},
+		}
+	})
+
+	AssertClientBehavior := func() {
+		It("should be able to Get", func() {
+			By("Getting a deployment")
+			namespacedName := types.NamespacedName{
+				Name:      "test-deployment",
+				Namespace: "ns1",
+			}
+			obj := &appsv1.Deployment{}
+			err := cl.Get(nil, namespacedName, obj)
+			Expect(err).To(BeNil())
+			Expect(obj).To(Equal(dep))
+		})
+
+		It("should be able to List", func() {
+			By("Listing all deployments in a namespace")
+			list := &appsv1.DeploymentList{}
+			err := cl.List(nil, list, client.InNamespace("ns1"))
+			Expect(err).To(BeNil())
+			Expect(list.Items).To(HaveLen(2))
+			Expect(list.Items).To(ConsistOf(*dep, *dep2))
+		})
+
+		It("should support filtering by labels", func() {
+			By("Listing deployments with a particular label")
+			list := &appsv1.DeploymentList{}
+			err := cl.List(nil, list, client.InNamespace("ns1"),
+				client.MatchingLabels(map[string]string{
+					"test-label": "label-value",
+				}))
+			Expect(err).To(BeNil())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items).To(ConsistOf(*dep2))
+		})
+
+		It("should be able to Create", func() {
+			By("Creating a new configmap")
+			newcm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-test-cm",
+					Namespace: "ns2",
+				},
+			}
+			err := cl.Create(nil, newcm)
+			Expect(err).To(BeNil())
+
+			By("Getting the new configmap")
+			namespacedName := types.NamespacedName{
+				Name:      "new-test-cm",
+				Namespace: "ns2",
+			}
+			obj := &corev1.ConfigMap{}
+			err = cl.Get(nil, namespacedName, obj)
+			Expect(err).To(BeNil())
+			Expect(obj).To(Equal(newcm))
+		})
+
+		It("should be able to Update", func() {
+			By("Updating a new configmap")
+			newcm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cm",
+					Namespace: "ns2",
+				},
+				Data: map[string]string{
+					"test-key": "new-value",
+				},
+			}
+			err := cl.Update(nil, newcm)
+			Expect(err).To(BeNil())
+
+			By("Getting the new configmap")
+			namespacedName := types.NamespacedName{
+				Name:      "test-cm",
+				Namespace: "ns2",
+			}
+			obj := &corev1.ConfigMap{}
+			err = cl.Get(nil, namespacedName, obj)
+			Expect(err).To(BeNil())
+			Expect(obj).To(Equal(newcm))
+		})
+
+		It("should be able to Delete", func() {
+			By("Deleting a deployment")
+			err := cl.Delete(nil, dep)
+			Expect(err).To(BeNil())
+
+			By("Listing all deployments in the namespace")
+			list := &appsv1.DeploymentList{}
+			err = cl.List(nil, list, client.InNamespace("ns1"))
+			Expect(err).To(BeNil())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items).To(ConsistOf(*dep2))
+		})
+
+		Context("with the DryRun option", func() {
+			It("should not create a new object", func() {
+				By("Creating a new configmap with DryRun")
+				newcm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "new-test-cm",
+						Namespace: "ns2",
+					},
+				}
+				err := cl.Create(nil, newcm, client.CreateDryRunAll())
+				Expect(err).To(BeNil())
+
+				By("Getting the new configmap")
+				namespacedName := types.NamespacedName{
+					Name:      "new-test-cm",
+					Namespace: "ns2",
+				}
+				obj := &corev1.ConfigMap{}
+				err = cl.Get(nil, namespacedName, obj)
+				Expect(err).To(HaveOccurred())
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+				Expect(obj).NotTo(Equal(newcm))
+			})
+
+			It("should not Update the object", func() {
+				By("Updating a new configmap with DryRun")
+				newcm := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cm",
+						Namespace: "ns2",
+					},
+					Data: map[string]string{
+						"test-key": "new-value",
+					},
+				}
+				err := cl.Update(nil, newcm, client.UpdateDryRunAll())
+				Expect(err).To(BeNil())
+
+				By("Getting the new configmap")
+				namespacedName := types.NamespacedName{
+					Name:      "test-cm",
+					Namespace: "ns2",
+				}
+				obj := &corev1.ConfigMap{}
+				err = cl.Get(nil, namespacedName, obj)
+				Expect(err).To(BeNil())
+				Expect(obj).To(Equal(cm))
+			})
+		})
+
+		It("should be able to Patch", func() {
+			By("Patching a deployment")
+			mergePatch, err := json.Marshal(map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"annotations": map[string]interface{}{
+						"foo": "bar",
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			err = cl.Patch(nil, dep, client.ConstantPatch(types.StrategicMergePatchType, mergePatch))
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Getting the patched deployment")
+			namespacedName := types.NamespacedName{
+				Name:      "test-deployment",
+				Namespace: "ns1",
+			}
+			obj := &appsv1.Deployment{}
+			err = cl.Get(nil, namespacedName, obj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(obj.Annotations["foo"]).To(Equal("bar"))
+		})
+	}
+
+	AssertReactorBehavior := func() {
+
+	}
+
+	Context("with default scheme.Scheme", func() {
+		BeforeEach(func(done Done) {
+			cl = NewFakeReactorClient(dep, dep2, cm)
+			close(done)
+		})
+		AssertClientBehavior()
+		AssertReactorBehavior()
+	})
+
+	Context("with given scheme", func() {
+		BeforeEach(func(done Done) {
+			scheme := runtime.NewScheme()
+			corev1.AddToScheme(scheme)
+			appsv1.AddToScheme(scheme)
+			cl = NewFakeReactorClientWithScheme(scheme, dep, dep2, cm)
+			close(done)
+		})
+		AssertClientBehavior()
+		AssertReactorBehavior()
+	})
+})


### PR DESCRIPTION
This is an experiment in writing a fake client using the same reactor mechanism as the generated fake clients.

The `FakeReactorClient` does all the same things the `FakeClient` does, but it also adds all the `testing.Fake` reactor functions that make it possible to mock the response to do something abnormal for testing error conditions:

```go
cl.PrependReactor("get", "*", func(action testing.Action) (bool, runtime.Object, error) {
    return true, nil, fmt.Errorf("mocked %s: %s", action.GetVerb(), action.GetResource())
})
namespacedName := types.NamespacedName{
    Name:      "test-deployment",
    Namespace: "ns1",
}
obj := &appsv1.Deployment{}
err := cl.Get(nil, namespacedName, obj)
Expect(err).To(MatchError("mocked get: apps/v1, Resource=deployments"))
```

This is something we've missed in Knative. We built our own MockClient [here](https://github.com/knative/eventing/blob/4fcaf7e2568ae24bb3d77ce0d775c70cb17413aa/pkg/reconciler/testing/mock_client.go) but it might be easier if one was provided using the familiar reactor mechanisms.

WIP because I'm not sure if this is the right interface.