### PR TITLE
:sparkles: support custom negotiated serializer :bug:

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -66,10 +66,13 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 }
 
 // RESTClientForGVK constructs a new rest.Interface capable of accessing the resource associated
-// with the given GroupVersionKind.
+// with the given GroupVersionKind. The REST client will be configured to use the negotiated serializer from
+// baseConfig, if set, otherwise a default serializer will be set.
 func RESTClientForGVK(gvk schema.GroupVersionKind, baseConfig *rest.Config, codecs serializer.CodecFactory) (rest.Interface, error) {
 	cfg := createRestConfig(gvk, baseConfig)
-	cfg.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: codecs}
+	if cfg.NegotiatedSerializer == nil {
+		cfg.NegotiatedSerializer = serializer.DirectCodecFactory{CodecFactory: codecs}
+	}
 	return rest.RESTClientFor(cfg)
 }
 


### PR DESCRIPTION
The Kubernetes client allows for users to configure a serializer which
is used to encode and decode resources exchanged with the Kubernetes API
server.

This changeset modifies the controller-runtime client to only set the
default serializer if the NegotiatedSerializer option is nil.

Signed-off-by: Terin Stock <terin@cloudflare.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
