### PR TITLE
:warning: source: make the Informer source compatible with cache.Informer

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/source/internal"
 
-	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -243,8 +242,8 @@ func (cs *Channel) syncLoop() {
 
 // Informer is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create)
 type Informer struct {
-	// Informer is the generated client-go Informer
-	Informer toolscache.SharedIndexInformer
+	// Informer is the controller-runtime Informer
+	Informer cache.Informer
 }
 
 var _ Source = &Informer{}


### PR DESCRIPTION
Before fc804a41 (#267), the `cache.Informers` interface methods returned
`k8s.io/client-go/tools/cache.SharedIndexInformer`s which were by default
compatible with the built-in `source.Informer`. Users could create arbitrary
`cache.Cache` instances (or get them from the `Manager`) and then use
`controller.Watch` to drive a controller with a `source.Informer` from the
`cache.Cache`.

With fc804a41, the `cache.Informers` interface was changed to return
`cache.Informer` instances; however, `source.Informer` was not updated to accept
a `cache.Informer`, and so users can no longer use the built-in
`source.Informer` with `cache.Cache`.

The `cache.Informer` interface appears to satisfy the needs of
`source.Informer`. This commit broadens `source.Informer` to accept a
`cache.Informer`, restoring the prior capability while remaining compatible
with `SharedIndexInformer` use.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
