### PR TITLE
:bug: Populate GVK for listed objects

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -207,7 +207,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(listObj.Items).NotTo(BeEmpty())
 					Expect(listObj.Items).Should(HaveLen(3))
 					for _, p := range listObj.Items {
-						Expect(p.GroupVersionKind().Empty()).To(BeFalse())
+						Expect(p.GroupVersionKind()).To(Equal(kcorev1.SchemeGroupVersion.WithKind("Pod")))
 					}
 				})
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -200,13 +200,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 				It("should be able to list objects with GVK populated", func() {
 					By("listing pods")
-					listObj := &kcorev1.PodList{}
-					Expect(informerCache.List(context.Background(), listObj)).To(Succeed())
+					out := &kcorev1.PodList{}
+					Expect(informerCache.List(context.Background(), out)).To(Succeed())
 
 					By("verifying that the returned pods have GVK populated")
-					Expect(listObj.Items).NotTo(BeEmpty())
-					Expect(listObj.Items).Should(HaveLen(3))
-					for _, p := range listObj.Items {
+					Expect(out.Items).NotTo(BeEmpty())
+					Expect(out.Items).Should(SatisfyAny(HaveLen(3), HaveLen(4)))
+					for _, p := range out.Items {
 						Expect(p.GroupVersionKind()).To(Equal(kcorev1.SchemeGroupVersion.WithKind("Pod")))
 					}
 				})

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -198,6 +198,19 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 				})
 
+				It("should be able to list objects with GVK populated", func() {
+					By("listing pods")
+					listObj := &kcorev1.PodList{}
+					Expect(informerCache.List(context.Background(), listObj)).To(Succeed())
+
+					By("verifying that the returned pods have GVK populated")
+					Expect(listObj.Items).NotTo(BeEmpty())
+					Expect(listObj.Items).Should(HaveLen(3))
+					for _, p := range listObj.Items {
+						Expect(p.GroupVersionKind().Empty()).To(BeFalse())
+					}
+				})
+
 				It("should be able to list objects by namespace", func() {
 					By("listing pods in test-namespace-1")
 					listObj := &kcorev1.PodList{}

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -125,8 +125,9 @@ func (c *CacheReader) List(_ context.Context, out runtime.Object, opts ...client
 		if !isObj {
 			return fmt.Errorf("cache contained %T, which is not an Object", obj)
 		}
-		obj.GetObjectKind().SetGroupVersionKind(c.groupVersionKind)
-		runtimeObjs = append(runtimeObjs, obj)
+		outObj := obj.DeepCopyObject()
+		outObj.GetObjectKind().SetGroupVersionKind(c.groupVersionKind)
+		runtimeObjs = append(runtimeObjs, outObj)
 	}
 	filteredItems, err := objectutil.FilterWithLabels(runtimeObjs, labelSel)
 	if err != nil {

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -125,6 +125,7 @@ func (c *CacheReader) List(_ context.Context, out runtime.Object, opts ...client
 		if !isObj {
 			return fmt.Errorf("cache contained %T, which is not an Object", obj)
 		}
+		obj.GetObjectKind().SetGroupVersionKind(c.groupVersionKind)
 		runtimeObjs = append(runtimeObjs, obj)
 	}
 	filteredItems, err := objectutil.FilterWithLabels(runtimeObjs, labelSel)


### PR DESCRIPTION
Fixes #284. Populates GroupVersionKind for objects returned by the List method.

This supersedes #296. I've rebased the branch, fixed up the conflicts and found an issue where we seemed to not be deepcopying items out of the cache before returning.

I've maintained @liyinan926's ownership of the commits so they should still be credited for their work.

/CC @DirectXMan12 
