### PR TITLE
🐛Pass appropriate context to leaderelector.Run

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -309,7 +309,16 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 		return err
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		select {
+		case <-cm.internalStop:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	// Start the leader elector process
-	go l.Run(context.Background())
+	go l.Run(ctx)
 	return nil
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Closing of internalStop channel should be propagated to a context that is passed to leaderelector.Run.