### PR TITLE
:running: support release notes on new version

### DIFF
--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -66,6 +66,52 @@ git::ensure-release-branch() {
     fi
 }
 
+# git::export-version-from-branch outputs the current version
+# for the given branch (as the argument) as exported variables
+# (${maj,min,patch}_ver, last_tag).
+git::export-version-from-branch() {
+    local target_branch=${1?must specify a branch}
+    local current_branch=$(git branch --show-current -q)
+
+    local expected_maj_ver
+    local expected_min_ver
+    if [[ ${target_branch} =~ release-0.([[:digit:]]+) ]]; then
+        expected_maj_ver=0
+        expected_min_ver=${BASH_REMATCH[1]}
+    elif [[ ${target_branch} =~ release-([[:digit:]]+) ]]; then
+        expected_maj_ver=${BASH_REMATCH[1]}
+    else
+        echo "branch ${target_branch} does not appear to be for a release -- it should be release-X or release-0.Y" >&2
+        exit 1
+    fi
+
+    local tag_pattern='v([[:digit:]]+).([[:digit:]]+).([[:digit:]]+)'
+
+    git checkout -q ${target_branch}
+
+    # make sure we've got a tag that matches *some* release
+    last_tag=$(git describe --tags --abbrev=0) # try to fetch just the "current" tag name
+    if [[ ! ${last_tag} =~ ${tag_pattern} ]]; then
+        # it's probably for a previous version
+        echo "tag ${last_tag} does not appear to be for a release -- it should be vX.Y.Z" >&2
+        git checkout -q ${current_branch}
+        exit 1
+    fi
+
+    export min_ver=${BASH_REMATCH[2]}
+    export patch_ver=${BASH_REMATCH[3]}
+    export maj_ver=${BASH_REMATCH[1]}
+    export last_tag=${last_tag}
+
+    if ${2:-1} && ([[ ${maj_ver} != ${expected_maj_ver} ]] || [[ ${maj_ver} == 0 && ${min_ver} != ${expected_min_ver} ]]); then
+        echo "tag ${last_tag} does not appear to be for a the right release (${target_branch})" >&2
+        git checkout ${current_branch}
+        exit 1
+    fi
+
+    git checkout -q ${current_branch}
+}
+
 # git::export-current-version outputs the current version
 # as exported variables (${maj,min,patch}_ver, last_tag) after
 # checking that we're on the right release branch.
@@ -75,25 +121,26 @@ git::export-current-version() {
 
     # deal with the release-0.1 branch, or similar
     local release_ver=${BASH_REMATCH[1]}
-    maj_ver=${release_ver}
-    local tag_pattern='v${maj_ver}.([[:digit:]]+).([[:digit]]+)'
-    if [[ ${maj_ver} =~ 0\.([[:digit:]]+) ]]; then
-        maj_ver=0
-        min_ver=${BASH_REMATCH[1]}
-        local tag_pattern="v0.(${min_ver}).([[:digit:]]+)"
+    local expected_maj_ver=${release_ver}
+    if [[ ${expected_maj_ver} =~ 0\.([[:digit:]]+) ]]; then
+        expected_maj_ver=0
+        local expected_min_ver=${BASH_REMATCH[1]}
     fi
 
-    # make sure we've got a tag that matches our release branch
-    last_tag=$(git describe --tags --abbrev=0) # try to fetch just the "current" tag name
-    if [[ ! ${last_tag} =~ ${tag_pattern} ]]; then
-        echo "tag ${last_tag} does not appear to be a release for this release (${release_ver})-- it should be v${maj_ver}.Y.Z" >&2
-        exit 1
+    git::export-version-from-branch "release-${release_ver}" false
+
+    local last_tag_branch=""
+    if [[ ${maj_ver} == "0" && ${min_ver} -eq $((expected_min_ver-1)) ]]; then
+        echo "most recent tag is a release behind (${last_tag}), checking previous release branch to be safe" >&2
+        last_tag_branch="release-0.${min_ver}"
+    elif [[ ${maj_ver} -eq $((expected_maj_ver-1)) ]]; then
+        echo "most recent tag is a release behind (${last_tag}), checking previous release branch to be safe" >&2
+        last_tag_branch="release-${maj_ver}"
     fi
 
-    export min_ver=${BASH_REMATCH[1]}
-    export patch_ver=${BASH_REMATCH[2]}
-    export maj_ver=${maj_ver}
-    export last_tag=${last_tag}
+    if [[ -n "${last_tag_branch}" ]]; then
+        git::export-version-from-branch ${last_tag_branch} true
+    fi
 }
 
 # git::next-version figures out the next version to tag

--- a/hack/release/release-notes.sh
+++ b/hack/release/release-notes.sh
@@ -64,8 +64,8 @@ done <<<$(git rev-list ${last_tag}..HEAD --merges --pretty=format:%B)
 
 # TODO: sort non merge commits with tags
 
-[[ -n "${breaking}" ]] && printf '\e[1;31mbreaking changes this version\e[0m' >&2
-[[ -n "${unknown}" ]] && printf '\e[1;35munknown changes in this release -- categorize manually\e[0m' >&2
+[[ -n "${breaking}" ]] && printf '\e[1;31mbreaking changes this version\e[0m\n' >&2
+[[ -n "${unknown}" ]] && printf '\e[1;35munknown changes in this release -- categorize manually\e[0m\n' >&2
 
 echo "" >&2
 echo "" >&2


### PR DESCRIPTION
This supports generating release notes when we cross "major" version
boundaries and need to create a new release branch.
