### PR TITLE
Add back http2 support :bug:

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -140,6 +140,7 @@ func (s *Server) Start(stop <-chan struct{}) error {
 
 	cfg := &tls.Config{
 		Certificates: []tls.Certificate{cert},
+		NextProtos:   []string{"h2"},
 	}
 
 	listener, err := tls.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(int(s.Port))), cfg)


### PR DESCRIPTION
Add back support for serving HTTP2 from the webhook server.
Fixes #408 