### PR TITLE
:bug: Enable labels list options in fake client

### DIFF
--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -116,19 +116,30 @@ func (c *CacheReader) List(_ context.Context, opts *client.ListOptions, out runt
 		labelSel = opts.LabelSelector
 	}
 
+	filteredItems, err := c.filterListItems(objs, labelSel)
+	if err != nil {
+		return err
+	}
+
+	return apimeta.SetList(out, filteredItems)
+}
+
+func (c *CacheReader) filterListItems(objs []interface{}, labelSel labels.Selector) ([]runtime.Object, error) {
 	runtimeObjs := make([]runtime.Object, 0, len(objs))
 	for _, item := range objs {
 		obj, isObj := item.(runtime.Object)
 		if !isObj {
-			return fmt.Errorf("cache contained %T, which is not an Object", obj)
+			return nil, fmt.Errorf("cache contained %T, which is not an Object", obj)
 		}
 		runtimeObjs = append(runtimeObjs, obj)
 	}
+
 	filteredItems, err := objectutil.FilterWithLabels(runtimeObjs, labelSel)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return apimeta.SetList(out, filteredItems)
+
+	return filteredItems, nil
 }
 
 // objectKeyToStorageKey converts an object key to store key.

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
 )
 
 // CacheReader is a CacheReader
@@ -115,33 +116,19 @@ func (c *CacheReader) List(_ context.Context, opts *client.ListOptions, out runt
 		labelSel = opts.LabelSelector
 	}
 
-	outItems, err := c.getListItems(objs, labelSel)
-	if err != nil {
-		return err
-	}
-	return apimeta.SetList(out, outItems)
-}
-
-func (c *CacheReader) getListItems(objs []interface{}, labelSel labels.Selector) ([]runtime.Object, error) {
-	outItems := make([]runtime.Object, 0, len(objs))
+	runtimeObjs := make([]runtime.Object, 0, len(objs))
 	for _, item := range objs {
 		obj, isObj := item.(runtime.Object)
 		if !isObj {
-			return nil, fmt.Errorf("cache contained %T, which is not an Object", obj)
+			return fmt.Errorf("cache contained %T, which is not an Object", obj)
 		}
-		meta, err := apimeta.Accessor(obj)
-		if err != nil {
-			return nil, err
-		}
-		if labelSel != nil {
-			lbls := labels.Set(meta.GetLabels())
-			if !labelSel.Matches(lbls) {
-				continue
-			}
-		}
-		outItems = append(outItems, obj.DeepCopyObject())
+		runtimeObjs = append(runtimeObjs, obj)
 	}
-	return outItems, nil
+	filteredItems, err := objectutil.FilterWithLabels(runtimeObjs, labelSel)
+	if err != nil {
+		return err
+	}
+	return apimeta.SetList(out, filteredItems)
 }
 
 // objectKeyToStorageKey converts an object key to store key.

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -116,18 +117,23 @@ func (c *fakeClient) List(ctx context.Context, opts *client.ListOptions, list ru
 	}
 
 	if opts.LabelSelector != nil {
-		objs, err := meta.ExtractList(list)
-		if err != nil {
-			return err
-		}
-		filteredObjs, err := objectutil.FilterWithLabels(objs, opts.LabelSelector)
-		if err != nil {
-			return err
-		}
-		err = meta.SetList(list, filteredObjs)
-		if err != nil {
-			return err
-		}
+		return filterListItems(list, opts.LabelSelector)
+	}
+	return nil
+}
+
+func filterListItems(list runtime.Object, labSel labels.Selector) error {
+	objs, err := meta.ExtractList(list)
+	if err != nil {
+		return err
+	}
+	filteredObjs, err := objectutil.FilterWithLabels(objs, labSel)
+	if err != nil {
+		return err
+	}
+	err = meta.SetList(list, filteredObjs)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/internal/objectutil/filter.go
+++ b/pkg/internal/objectutil/filter.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package objectutil
+
+import (
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// FilterWithLabels returns a copy of the items in objs matching labelSel
+func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtime.Object, error) {
+	outItems := make([]runtime.Object, 0, len(objs))
+	for _, obj := range objs {
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		if labelSel != nil {
+			lbls := labels.Set(meta.GetLabels())
+			if !labelSel.Matches(lbls) {
+				continue
+			}
+		}
+		outItems = append(outItems, obj.DeepCopyObject())
+	}
+	return outItems, nil
+}


### PR DESCRIPTION
This commit allows passing label matches to the fake client List()
function.

This is done in a way similar to the CachedReader. Both now share a
common call to `objectutil.FilterWithLabels`.

Signed-off-by: sebgl <contact.sebgl@gmail.com>

Backporting https://github.com/kubernetes-sigs/controller-runtime/pull/311 into release-0.1 branch.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
