### PR TITLE
✨ added health probes

### DIFF
--- a/pkg/healthz/doc.go
+++ b/pkg/healthz/doc.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This package is almost exact copy of apiserver's healthz package:
+//   https://github.com/kubernetes/apiserver/tree/master/pkg/server/healthz
+//
+// Except that LogHealthz checker removed
+// and some style fixes is made to satisfy linters
+package healthz
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+)
+
+var log = logf.RuntimeLog.WithName("healthz")

--- a/pkg/healthz/doc.go
+++ b/pkg/healthz/doc.go
@@ -14,11 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This package is almost exact copy of apiserver's healthz package:
-//   https://github.com/kubernetes/apiserver/tree/master/pkg/server/healthz
+// Package healthz contains helpers from supporting liveness and readiness endpoints.
+// (often referred to as healthz and readyz, respectively).
 //
-// Except that LogHealthz checker removed
-// and some style fixes is made to satisfy linters
+// This package draws heavily from the apiserver's healthz package
+// ( https://github.com/kubernetes/apiserver/tree/master/pkg/server/healthz )
+// but has some changes to bring it in line with controller-runtime's style.
+//
+// The main entrypoint is the Handler -- this serves both aggregated health status
+// and individual health check endpoints.
 package healthz
 
 import (

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+type Handler struct {
+	checks []Checker
+}
+
+// GetChecks returns all health checks.
+func (h *Handler) GetChecks() []Checker {
+	return h.checks
+}
+
+// AddCheck adds new health check to handler.
+func (h *Handler) AddCheck(check Checker) {
+	h.checks = append(h.checks, check)
+}
+
+// Build creates http.Handler that serves checks.
+func (h *Handler) Build() http.Handler {
+	return handleRootHealthz(h.checks...)
+}
+
+// HealthzChecker is a named healthz checker.
+type Checker interface {
+	Name() string
+	Check(req *http.Request) error
+}
+
+// PingHealthz returns true automatically when checked
+var PingHealthz Checker = ping{}
+
+// ping implements the simplest possible healthz checker.
+type ping struct{}
+
+func (ping) Name() string {
+	return "ping"
+}
+
+// PingHealthz is a health check that returns true.
+func (ping) Check(_ *http.Request) error {
+	return nil
+}
+
+// NamedCheck returns a healthz checker for the given name and function.
+func NamedCheck(name string, check func(r *http.Request) error) Checker {
+	return &healthzCheck{name, check}
+}
+
+// InstallPathHandler registers handlers for health checking on
+// a specific path to mux. *All handlers* for the path must be
+// specified in exactly one call to InstallPathHandler. Calling
+// InstallPathHandler more than once for the same path and mux will
+// result in a panic.
+func InstallPathHandler(mux mux, path string, handler *Handler) {
+	if len(handler.GetChecks()) == 0 {
+		log.V(1).Info("No default health checks specified. Installing the ping handler.")
+		handler.AddCheck(PingHealthz)
+	}
+
+	mux.Handle(path, handler.Build())
+	for _, check := range handler.GetChecks() {
+		log.V(1).Info("installing healthz checker", "checker", check.Name())
+		mux.Handle(fmt.Sprintf("%s/%s", path, check.Name()), adaptCheckToHandler(check.Check))
+	}
+}
+
+// mux is an interface describing the methods InstallHandler requires.
+type mux interface {
+	Handle(pattern string, handler http.Handler)
+}
+
+// healthzCheck implements HealthzChecker on an arbitrary name and check function.
+type healthzCheck struct {
+	name  string
+	check func(r *http.Request) error
+}
+
+var _ Checker = &healthzCheck{}
+
+func (c *healthzCheck) Name() string {
+	return c.name
+}
+
+func (c *healthzCheck) Check(r *http.Request) error {
+	return c.check(r)
+}
+
+// getExcludedChecks extracts the health check names to be excluded from the query param
+func getExcludedChecks(r *http.Request) sets.String {
+	checks, found := r.URL.Query()["exclude"]
+	if found {
+		return sets.NewString(checks...)
+	}
+	return sets.NewString()
+}
+
+// handleRootHealthz returns an http.HandlerFunc that serves the provided checks.
+func handleRootHealthz(checks ...Checker) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		failed := false
+		excluded := getExcludedChecks(r)
+		var verboseOut bytes.Buffer
+		for _, check := range checks {
+			// no-op the check if we've specified we want to exclude the check
+			if excluded.Has(check.Name()) {
+				excluded.Delete(check.Name())
+				fmt.Fprintf(&verboseOut, "[+]%s excluded: ok\n", check.Name())
+				continue
+			}
+			if err := check.Check(r); err != nil {
+				// don't include the error since this endpoint is public.  If someone wants more detail
+				// they should have explicit permission to the detailed checks.
+				log.V(1).Info("healthz check failed", "checker", check.Name(), "error", err)
+				fmt.Fprintf(&verboseOut, "[-]%s failed: reason withheld\n", check.Name())
+				failed = true
+			} else {
+				fmt.Fprintf(&verboseOut, "[+]%s ok\n", check.Name())
+			}
+		}
+		if excluded.Len() > 0 {
+			fmt.Fprintf(&verboseOut, "warn: some health checks cannot be excluded: no matches for %s\n", formatQuoted(excluded.List()...))
+			for _, c := range excluded.List() {
+				log.Info("cannot exclude health check, no matches for it", "checker", c)
+			}
+		}
+		// always be verbose on failure
+		if failed {
+			log.V(1).Info("healthz check failed", "message", verboseOut.String())
+			http.Error(w, fmt.Sprintf("%shealthz check failed", verboseOut.String()), http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Content-Type-Options", "nosniff")
+		if _, found := r.URL.Query()["verbose"]; !found {
+			fmt.Fprint(w, "ok")
+			return
+		}
+
+		_, err := verboseOut.WriteTo(w)
+		if err != nil {
+			log.V(1).Info("healthz check failed", "message", verboseOut.String())
+			http.Error(w, fmt.Sprintf("%shealthz check failed", verboseOut.String()), http.StatusInternalServerError)
+			return
+		}
+		fmt.Fprint(w, "healthz check passed\n")
+	})
+}
+
+// adaptCheckToHandler returns an http.HandlerFunc that serves the provided checks.
+func adaptCheckToHandler(c func(r *http.Request) error) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := c(r)
+		if err != nil {
+			http.Error(w, fmt.Sprintf("internal server error: %v", err), http.StatusInternalServerError)
+		} else {
+			fmt.Fprint(w, "ok")
+		}
+	})
+}
+
+// formatQuoted returns a formatted string of the health check names,
+// preserving the order passed in.
+func formatQuoted(names ...string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	return strings.Join(quoted, ",")
+}

--- a/pkg/healthz/healthz_suite_test.go
+++ b/pkg/healthz/healthz_suite_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestHealthz(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Healthz Suite", []Reporter{envtest.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+})

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthz_test
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+)
+
+const (
+	contentType = "text/plain; charset=utf-8"
+)
+
+var _ = Describe("Healthz", func() {
+	Describe("Install", func() {
+		It("should install handler", func(done Done) {
+			mux := http.NewServeMux()
+			handler := &healthz.Handler{}
+
+			healthz.InstallPathHandler(mux, "/healthz/test", handler)
+			req, err := http.NewRequest("GET", "http://example.com/healthz/test", nil)
+			Expect(req).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(w.Header().Get("Content-Type")).To(Equal(contentType))
+			Expect(w.Body.String()).To(Equal("ok"))
+
+			close(done)
+		})
+	})
+
+	Describe("Checks", func() {
+		var testMultipleChecks = func(path string) {
+			tests := []struct {
+				path             string
+				expectedResponse string
+				expectedStatus   int
+				addBadCheck      bool
+			}{
+				{"?verbose", "[+]ping ok\nhealthz check passed\n", http.StatusOK,
+					false},
+				{"?exclude=dontexist", "ok", http.StatusOK, false},
+				{"?exclude=bad", "ok", http.StatusOK, true},
+				{"?verbose=true&exclude=bad", "[+]ping ok\n[+]bad excluded: ok\nhealthz check passed\n",
+					http.StatusOK, true},
+				{"?verbose=true&exclude=dontexist",
+					"[+]ping ok\nwarn: some health checks cannot be excluded: no matches for \"dontexist\"\nhealthz check passed\n",
+					http.StatusOK, false},
+				{"/ping", "ok", http.StatusOK, false},
+				{"", "ok", http.StatusOK, false},
+				{"?verbose", "[+]ping ok\n[-]bad failed: reason withheld\nhealthz check failed\n",
+					http.StatusInternalServerError, true},
+				{"/ping", "ok", http.StatusOK, true},
+				{"/bad", "internal server error: this will fail\n",
+					http.StatusInternalServerError, true},
+				{"", "[+]ping ok\n[-]bad failed: reason withheld\nhealthz check failed\n",
+					http.StatusInternalServerError, true},
+			}
+
+			for _, test := range tests {
+				mux := http.NewServeMux()
+				checks := []healthz.Checker{healthz.PingHealthz}
+				if test.addBadCheck {
+					checks = append(checks, healthz.NamedCheck("bad", func(_ *http.Request) error {
+						return errors.New("this will fail")
+					}))
+				}
+				handler := &healthz.Handler{}
+				for _, check := range checks {
+					handler.AddCheck(check)
+				}
+
+				if path == "" {
+					path = "/healthz"
+				}
+
+				healthz.InstallPathHandler(mux, path, handler)
+				req, err := http.NewRequest("GET", fmt.Sprintf("http://example.com%s%v", path, test.path), nil)
+				Expect(req).ToNot(BeNil())
+				Expect(err).ToNot(HaveOccurred())
+
+				w := httptest.NewRecorder()
+				mux.ServeHTTP(w, req)
+				Expect(w.Code).To(Equal(test.expectedStatus))
+				Expect(w.Header().Get("Content-Type")).To(Equal(contentType))
+				Expect(w.Body.String()).To(Equal(test.expectedResponse))
+			}
+		}
+
+		It("should do multiple checks", func(done Done) {
+			testMultipleChecks("")
+			close(done)
+		})
+
+		It("should do multiple path checks", func(done Done) {
+			testMultipleChecks("/ready")
+			close(done)
+		})
+	})
+})

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 	"time"
 
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -45,6 +47,9 @@ const (
 	defaultLeaseDuration = 15 * time.Second
 	defaultRenewDeadline = 10 * time.Second
 	defaultRetryPeriod   = 2 * time.Second
+
+	defaultReadinessEndpoint = "/readyz"
+	defaultLivenessEndpoint  = "/healthz"
 )
 
 var log = logf.RuntimeLog.WithName("manager")
@@ -90,10 +95,26 @@ type controllerManager struct {
 	// metricsListener is used to serve prometheus metrics
 	metricsListener net.Listener
 
-	mu            sync.Mutex
-	started       bool
-	startedLeader bool
-	errChan       chan error
+	// healthProbeListener is used to serve liveness probe
+	healthProbeListener net.Listener
+
+	// Readiness probe endpoint name
+	readinessEndpointName string
+
+	// Liveness probe endpoint name
+	livenessEndpointName string
+
+	// Readyz probe handler
+	readyzHandler *healthz.Handler
+
+	// Healthz probe handler
+	healthzHandler *healthz.Handler
+
+	mu             sync.Mutex
+	started        bool
+	startedLeader  bool
+	healthzStarted bool
+	errChan        chan error
 
 	// internalStop is the stop channel *actually* used by everything involved
 	// with the manager as a stop channel, so that we can pass a stop channel
@@ -188,6 +209,40 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 	return nil
 }
 
+// AddHealthzCheck allows you to add Healthz checker
+func (cm *controllerManager) AddHealthzCheck(check healthz.Checker) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if cm.healthzStarted {
+		return fmt.Errorf("unable to add new checker because healthz endpoint has already been created")
+	}
+
+	if cm.healthzHandler == nil {
+		cm.healthzHandler = &healthz.Handler{}
+	}
+
+	cm.healthzHandler.AddCheck(check)
+	return nil
+}
+
+// AddReadyzCheck allows you to add Readyz checker
+func (cm *controllerManager) AddReadyzCheck(check healthz.Checker) error {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	if cm.healthzStarted {
+		return fmt.Errorf("unable to add new checker because readyz endpoint has already been created")
+	}
+
+	if cm.readyzHandler == nil {
+		cm.readyzHandler = &healthz.Handler{}
+	}
+
+	cm.readyzHandler.AddCheck(check)
+	return nil
+}
+
 func (cm *controllerManager) GetConfig() *rest.Config {
 	return cm.config
 }
@@ -262,6 +317,38 @@ func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {
 	}
 }
 
+func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
+	cm.mu.Lock()
+	mux := http.NewServeMux()
+
+	if cm.readyzHandler != nil {
+		healthz.InstallPathHandler(mux, cm.readinessEndpointName, cm.readyzHandler)
+	}
+	if cm.healthzHandler != nil {
+		healthz.InstallPathHandler(mux, cm.livenessEndpointName, cm.healthzHandler)
+	}
+
+	server := http.Server{
+		Handler: mux,
+	}
+	// Run server
+	go func() {
+		if err := server.Serve(cm.healthProbeListener); err != nil && err != http.ErrServerClosed {
+			cm.errChan <- err
+		}
+	}()
+	cm.healthzStarted = true
+	cm.mu.Unlock()
+
+	// Shutdown the server when stop is closed
+	select {
+	case <-stop:
+		if err := server.Shutdown(context.Background()); err != nil {
+			cm.errChan <- err
+		}
+	}
+}
+
 func (cm *controllerManager) Start(stop <-chan struct{}) error {
 	// join the passed-in stop channel as an upstream feeding into cm.internalStopper
 	defer close(cm.internalStopper)
@@ -271,6 +358,11 @@ func (cm *controllerManager) Start(stop <-chan struct{}) error {
 	// the pod but will get a connection refused)
 	if cm.metricsListener != nil {
 		go cm.serveMetrics(cm.internalStop)
+	}
+
+	// Serve health probes
+	if cm.healthProbeListener != nil {
+		go cm.serveHealthProbes(cm.internalStop)
 	}
 
 	go cm.startNonLeaderElectionRunnables()

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	internalrecorder "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -52,6 +53,12 @@ type Manager interface {
 	// SetFields will set any dependencies on an object for which the object has implemented the inject
 	// interface - e.g. inject.Client.
 	SetFields(interface{}) error
+
+	// AddHealthzCheck allows you to add Healthz checker
+	AddHealthzCheck(check healthz.Checker) error
+
+	// AddReadyzCheck allows you to add Readyz checker
+	AddReadyzCheck(check healthz.Checker) error
 
 	// Start starts all registered Controllers and blocks until the Stop channel is closed.
 	// Returns an error if there is an error starting any controller.
@@ -142,6 +149,16 @@ type Options struct {
 	// It can be set to "0" to disable the metrics serving.
 	MetricsBindAddress string
 
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	HealthProbeBindAddress string
+
+	// Readiness probe endpoint name, defaults to "readyz"
+	ReadinessEndpointName string
+
+	// Liveness probe endpoint name, defaults to "healthz"
+	LivenessEndpointName string
+
 	// Port is the port that the webhook server serves at.
 	// It is used to set webhook.Server.Port.
 	Port int
@@ -169,9 +186,10 @@ type Options struct {
 	EventBroadcaster record.EventBroadcaster
 
 	// Dependency injection for testing
-	newRecorderProvider func(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, broadcaster record.EventBroadcaster) (recorder.Provider, error)
-	newResourceLock     func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error)
-	newMetricsListener  func(addr string) (net.Listener, error)
+	newRecorderProvider    func(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, broadcaster record.EventBroadcaster) (recorder.Provider, error)
+	newResourceLock        func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error)
+	newMetricsListener     func(addr string) (net.Listener, error)
+	newHealthProbeListener func(addr string) (net.Listener, error)
 }
 
 // NewClientFunc allows a user to define how to create a client
@@ -261,28 +279,38 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
+	// Create health probes listener. This will throw an error if the bind
+	// address is invalid or already in use.
+	healthProbeListener, err := options.newHealthProbeListener(options.HealthProbeBindAddress)
+	if err != nil {
+		return nil, err
+	}
+
 	stop := make(chan struct{})
 
 	return &controllerManager{
-		config:           config,
-		scheme:           options.Scheme,
-		errChan:          make(chan error),
-		cache:            cache,
-		fieldIndexes:     cache,
-		client:           writeObj,
-		apiReader:        apiReader,
-		recorderProvider: recorderProvider,
-		resourceLock:     resourceLock,
-		mapper:           mapper,
-		metricsListener:  metricsListener,
-		internalStop:     stop,
-		internalStopper:  stop,
-		port:             options.Port,
-		host:             options.Host,
-		certDir:          options.CertDir,
-		leaseDuration:    *options.LeaseDuration,
-		renewDeadline:    *options.RenewDeadline,
-		retryPeriod:      *options.RetryPeriod,
+		config:                config,
+		scheme:                options.Scheme,
+		errChan:               make(chan error),
+		cache:                 cache,
+		fieldIndexes:          cache,
+		client:                writeObj,
+		apiReader:             apiReader,
+		recorderProvider:      recorderProvider,
+		resourceLock:          resourceLock,
+		mapper:                mapper,
+		metricsListener:       metricsListener,
+		internalStop:          stop,
+		internalStopper:       stop,
+		port:                  options.Port,
+		host:                  options.Host,
+		certDir:               options.CertDir,
+		leaseDuration:         *options.LeaseDuration,
+		renewDeadline:         *options.RenewDeadline,
+		retryPeriod:           *options.RetryPeriod,
+		healthProbeListener:   healthProbeListener,
+		readinessEndpointName: options.ReadinessEndpointName,
+		livenessEndpointName:  options.LivenessEndpointName,
 	}, nil
 }
 
@@ -302,6 +330,19 @@ func defaultNewClient(cache cache.Cache, config *rest.Config, options client.Opt
 		Writer:       c,
 		StatusClient: c,
 	}, nil
+}
+
+// defaultHealthProbeListener creates the default health probes listener bound to the given address
+func defaultHealthProbeListener(addr string) (net.Listener, error) {
+	if addr == "" || addr == "0" {
+		return nil, nil
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("error listening on %s: %v", addr, err)
+	}
+	return ln, nil
 }
 
 // setOptionsDefaults set default values for Options fields
@@ -353,6 +394,18 @@ func setOptionsDefaults(options Options) Options {
 
 	if options.EventBroadcaster == nil {
 		options.EventBroadcaster = record.NewBroadcaster()
+	}
+
+	if options.ReadinessEndpointName == "" {
+		options.ReadinessEndpointName = defaultReadinessEndpoint
+	}
+
+	if options.LivenessEndpointName == "" {
+		options.LivenessEndpointName = defaultLivenessEndpoint
+	}
+
+	if options.newHealthProbeListener == nil {
+		options.newHealthProbeListener = defaultHealthProbeListener
 	}
 
 	return options

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -55,10 +55,10 @@ type Manager interface {
 	SetFields(interface{}) error
 
 	// AddHealthzCheck allows you to add Healthz checker
-	AddHealthzCheck(check healthz.Checker) error
+	AddHealthzCheck(name string, check healthz.Checker) error
 
 	// AddReadyzCheck allows you to add Readyz checker
-	AddReadyzCheck(check healthz.Checker) error
+	AddReadyzCheck(name string, check healthz.Checker) error
 
 	// Start starts all registered Controllers and blocks until the Stop channel is closed.
 	// Returns an error if there is an error starting any controller.

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -520,8 +520,8 @@ var _ = Describe("manger.Manager", func() {
 			m, err := New(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
 
-			readyzChecker := &checker{check: fmt.Errorf("not ready yet")}
-			err = m.AddReadyzCheck(readyzChecker)
+			res := fmt.Errorf("not ready yet")
+			err = m.AddReadyzCheck("check", func(_ *http.Request) error { return res })
 			Expect(err).NotTo(HaveOccurred())
 
 			s := make(chan struct{})
@@ -540,7 +540,7 @@ var _ = Describe("manger.Manager", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 
 			// Controller is ready
-			readyzChecker.check = nil
+			res = nil
 			resp, err = http.Get(readinessEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -551,8 +551,8 @@ var _ = Describe("manger.Manager", func() {
 			m, err := New(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
 
-			healthzChecker := &checker{check: fmt.Errorf("not alive")}
-			err = m.AddHealthzCheck(healthzChecker)
+			res := fmt.Errorf("not alive")
+			err = m.AddHealthzCheck("check", func(_ *http.Request) error { return res })
 			Expect(err).NotTo(HaveOccurred())
 
 			s := make(chan struct{})
@@ -571,7 +571,7 @@ var _ = Describe("manger.Manager", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusInternalServerError))
 
 			// Controller is ready
-			healthzChecker.check = nil
+			res = nil
 			resp, err = http.Get(livenessEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
@@ -858,16 +858,4 @@ func (i *injectable) InjectStopChannel(stop <-chan struct{}) error {
 
 func (i *injectable) Start(<-chan struct{}) error {
 	return nil
-}
-
-type checker struct {
-	check error
-}
-
-func (*checker) Name() string {
-	return "check"
-}
-
-func (c *checker) Check(req *http.Request) error {
-	return c.check
 }


### PR DESCRIPTION
Attempt to solve https://github.com/kubernetes-sigs/controller-runtime/issues/297.  Adds server, that can serve readiness and liveness probes. Probes return response based on manager's fields `isReady` and `isAlive`, that can be changed via methods `SetReady`/`SetAlive`
