### PR TITLE
:bug: List requests should not pass a body.

### DIFF
--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -134,7 +134,6 @@ func (c *typedClient) List(ctx context.Context, obj runtime.Object, opts ...List
 	return r.Get().
 		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
 		Resource(r.resource()).
-		Body(obj).
 		VersionedParams(listOpts.AsListOptions(), c.paramCodec).
 		Context(ctx).
 		Do().


### PR DESCRIPTION
Currently the typedClient.List call passes in the serialized object in the body of the HTTP request. This is unnecessary and should not be done. This PR makes it so that body is not passed in the HTTP request.

@DirectXMan12
cc @ilkercelikyilmaz