### PR TITLE
✨ Implement `IgnoreNotFound`

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -19,6 +19,8 @@ package client
 import (
 	"context"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -503,4 +505,13 @@ func PatchWithForce() PatchOptionFunc {
 	return func(opts *PatchOptions) {
 		opts.Force = &force
 	}
+}
+
+// IgnoreNotFound returns nil on NotFound errors.
+// All other values that are not NotFound errors or nil are returned unmodified.
+func IgnoreNotFound(err error) error {
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
 }


### PR DESCRIPTION
implement `IgnoreNotFound` that ignores `NotFound` errors
create test cases

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->
Fixes #357 

<!-- What does this do, and why do we need it? -->
This allows to easily ignore `NotFound` errors which is often required in case where it's just necessary to see that a resource is gone.
