### PR TITLE
:sparkles: stop allowing port 0

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -78,7 +78,7 @@ func (s *Server) setDefaults() {
 		s.WebhookMux = http.NewServeMux()
 	}
 
-	if s.Port < 0 {
+	if s.Port <= 0 {
 		s.Port = DefaultPort
 	}
 


### PR DESCRIPTION
This PR is reverting the change in https://github.com/kubernetes-sigs/controller-runtime/commit/ad30658629f706b1ac24f52eee6f861179111f79#diff-fbc18bb07cdd05391b7081acc1dfe170R81
Allowing port 0 doesn't actually provide much values when doing testing, since user will need to run some command e.g. `netstat` to figure which port is assigned. And it also make defaulting port hard.

This change is not a breaking change since https://github.com/kubernetes-sigs/controller-runtime/commit/ad30658629f706b1ac24f52eee6f861179111f79#diff-fbc18bb07cdd05391b7081acc1dfe170R81 has not been released in a stable release yet.

In term of testing, we could use `addr.Suggest()` to get an available port and then use it in testing.
