### PR TITLE
:sparkles: webhook server doesn't use leader election by default

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -89,6 +89,12 @@ func (s *Server) setDefaults() {
 	}
 }
 
+// NeedLeaderElection implements the LeaderElectionRunnable interface, which indicates
+// the webhook server doesn't need leader election.
+func (*Server) NeedLeaderElection() bool {
+	return false
+}
+
 // Register marks the given webhook as being served at the given path.
 // It panics if two hooks are registered on the same path.
 func (s *Server) Register(path string, hook http.Handler) {


### PR DESCRIPTION
webhook server should not use leader election by default.
Ref: https://github.com/kubernetes-sigs/controller-runtime/pull/424