### PR TITLE
:bug: set status in conversion response

### DIFF
--- a/pkg/webhook/conversion/conversion.go
+++ b/pkg/webhook/conversion/conversion.go
@@ -75,10 +75,11 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error(err, "failed to convert", "request", convertReview.Request.UID)
 		convertReview.Response = errored(err)
-		convertReview.Response.UID = convertReview.Request.UID
 	} else {
 		convertReview.Response = resp
 	}
+	convertReview.Response.UID = convertReview.Request.UID
+	convertReview.Request = nil
 
 	err = json.NewEncoder(w).Encode(convertReview)
 	if err != nil {
@@ -112,6 +113,9 @@ func (wh *Webhook) handleConvertRequest(req *apix.ConversionRequest) (*apix.Conv
 	return &apix.ConversionResponse{
 		UID:              req.UID,
 		ConvertedObjects: objects,
+		Result: metav1.Status{
+			Status: metav1.StatusSuccess,
+		},
 	}, nil
 }
 

--- a/pkg/webhook/conversion/conversion_test.go
+++ b/pkg/webhook/conversion/conversion_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Conversion Webhook", func() {
 		convReview := doRequest(convReq)
 
 		Expect(convReview.Response.ConvertedObjects).To(HaveLen(1))
+		Expect(convReview.Response.Result.Status).To(Equal(metav1.StatusSuccess))
 		got, _, err := decoder.Decode(convReview.Response.ConvertedObjects[0].Raw)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(got).To(Equal(expected))


### PR DESCRIPTION
We need to set "success" status in conversion response when we successfully convert the object.
kube-apiserver rejects it if the status is not set.