### PR TITLE
:warning: Remove defaulting for leader election ID

### DIFF
--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -17,6 +17,7 @@ limitations under the License.
 package leaderelection
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -52,9 +53,9 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 		return nil, nil
 	}
 
-	// Default the LeaderElectionID
+	// LeaderElectionID must be provided to prevent clashes
 	if options.LeaderElectionID == "" {
-		options.LeaderElectionID = "controller-leader-election-helper"
+		return nil, errors.New("LeaderElectionID must be configured")
 	}
 
 	// Default the namespace (if running in cluster)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -143,15 +143,16 @@ var _ = Describe("manger.Manager", func() {
 				m, err := New(cfg, Options{
 					LeaderElection:          true,
 					LeaderElectionNamespace: "default",
+					LeaderElectionID:        "test-leader-election-id",
 					newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
 						var err error
 						rl, err = leaderelection.NewResourceLock(config, recorderProvider, options)
 						return rl, err
 					},
 				})
-				Expect(m).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
-				Expect(rl.Describe()).To(Equal("default/controller-leader-election-helper"))
+				Expect(m).ToNot(BeNil())
+				Expect(rl.Describe()).To(Equal("default/test-leader-election-id"))
 			})
 
 			It("should return an error if namespace not set and not running in cluster", func() {


### PR DESCRIPTION
With the current defaulting for the leader election ID, there is a clash
as soon as two controller that do not have it explicitly configured run
in the same namespace or have the same namespace configured for leader
election.

This is especially bad since there is no logging about the lock being
held by a different controller, so from a users perspective this looks
like the controller just froze.

Fixes #445

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @DirectXMan12 
/cc @JoelSpeed 