### PR TITLE
:running: use :ghost: for no release note commits

### DIFF
--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -92,6 +92,10 @@ a:
 - Patch fix: :bug: (`:bug:`)
 - Docs: :book: (`:book:`)
 - Infra/Tests/Other: :running: (`:running:`)
+- No release note: :ghost: (`:ghost:`)
+
+Use :ghost: (no release note) only for the PRs that change or revert unreleased
+changes, which don't deserve a release note. Please don't abuse it.
 
 You can also use the equivalent emoji directly, since GitHub doesn't
 render the `:xyz:` aliases in PR titles.

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -5,6 +5,7 @@ cr_major_pattern=":warning:|$(printf "\xe2\x9a\xa0")"
 cr_minor_pattern=":sparkles:|$(printf "\xe2\x9c\xa8")"
 cr_patch_pattern=":bug:|$(printf "\xf0\x9f\x90\x9b")"
 cr_docs_pattern=":book:|$(printf "\xf0\x9f\x93\x96")"
+cr_no_release_note_pattern=":ghost:|$(printf "\xf0\x9f\x91\xbb")"
 cr_other_pattern=":running:|$(printf "\xf0\x9f\x8f\x83")"
 
 # cr::symbol-type-raw turns :xyz: and the corresponding emoji
@@ -23,6 +24,9 @@ cr::symbol-type-raw() {
             ;;
         @(${cr_docs_pattern})?('!'))
             echo "docs"
+            ;;
+        @(${cr_no_release_note_pattern})?('!'))
+            echo "no_release_note"
             ;;
         @(${cr_other_pattern})?('!'))
             echo "other"

--- a/hack/release/release-notes.sh
+++ b/hack/release/release-notes.sh
@@ -50,7 +50,7 @@ while read commit_word commit; do
         patch)
             bugfixes="${bugfixes}- ${pr_title} (#${pr_number})${NEWLINE}"
             ;;
-        docs|other)
+        docs|no_release_note|other)
             # skip non-code-changes
             ;;
         unknown)


### PR DESCRIPTION
fixes #433

I was thinking using `:see_no_evil:` :see_no_evil:, but I feel the wording `evil` may be offending. So this PR stay with `:ghost:` :ghost:.