### PR TITLE
🐛 Fix runnable race in manager

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -288,6 +288,41 @@ func (cm *controllerManager) startNonLeaderElectionRunnables() {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
+	cm.waitForCache()
+
+	// Start the non-leaderelection Runnables after the cache has synced
+	for _, c := range cm.nonLeaderElectionRunnables {
+		// Controllers block, but we want to return an error if any have an error starting.
+		// Write any Start errors to a channel so we can return them
+		ctrl := c
+		go func() {
+			cm.errChan <- ctrl.Start(cm.internalStop)
+		}()
+	}
+}
+
+func (cm *controllerManager) startLeaderElectionRunnables() {
+	cm.mu.Lock()
+	defer cm.mu.Unlock()
+
+	cm.waitForCache()
+
+	// Start the leader election Runnables after the cache has synced
+	for _, c := range cm.leaderElectionRunnables {
+		// Controllers block, but we want to return an error if any have an error starting.
+		// Write any Start errors to a channel so we can return them
+		ctrl := c
+		go func() {
+			cm.errChan <- ctrl.Start(cm.internalStop)
+		}()
+	}
+}
+
+func (cm *controllerManager) waitForCache() {
+	if cm.started {
+		return
+	}
+
 	// Start the Cache. Allow the function to start the cache to be mocked out for testing
 	if cm.startCache == nil {
 		cm.startCache = cm.cache.Start
@@ -301,35 +336,6 @@ func (cm *controllerManager) startNonLeaderElectionRunnables() {
 	// Wait for the caches to sync.
 	// TODO(community): Check the return value and write a test
 	cm.cache.WaitForCacheSync(cm.internalStop)
-
-	// Start the non-leaderelection Runnables after the cache has synced
-	for _, c := range cm.nonLeaderElectionRunnables {
-		// Controllers block, but we want to return an error if any have an error starting.
-		// Write any Start errors to a channel so we can return them
-		ctrl := c
-		go func() {
-			cm.errChan <- ctrl.Start(cm.internalStop)
-		}()
-	}
-
-	cm.started = true
-}
-
-func (cm *controllerManager) startLeaderElectionRunnables() {
-	// Wait for the caches to sync.
-	// TODO(community): Check the return value and write a test
-	cm.cache.WaitForCacheSync(cm.internalStop)
-
-	// Start the leader election Runnables after the cache has synced
-	for _, c := range cm.leaderElectionRunnables {
-		// Controllers block, but we want to return an error if any have an error starting.
-		// Write any Start errors to a channel so we can return them
-		ctrl := c
-		go func() {
-			cm.errChan <- ctrl.Start(cm.internalStop)
-		}()
-	}
-
 	cm.started = true
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -206,15 +206,15 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err).NotTo(HaveOccurred())
 				c1 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
-					defer close(c1)
 					defer GinkgoRecover()
+					close(c1)
 					return nil
 				}))).To(Succeed())
 
 				c2 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
-					defer close(c2)
 					defer GinkgoRecover()
+					close(c2)
 					return nil
 				}))).To(Succeed())
 
@@ -257,21 +257,21 @@ var _ = Describe("manger.Manager", func() {
 				c1 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
 					defer GinkgoRecover()
-					defer close(c1)
+					close(c1)
 					return nil
 				}))).To(Succeed())
 
 				c2 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
 					defer GinkgoRecover()
-					defer close(c2)
+					close(c2)
 					return fmt.Errorf("expected error")
 				}))).To(Succeed())
 
 				c3 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
 					defer GinkgoRecover()
-					defer close(c3)
+					close(c3)
 					return nil
 				}))).To(Succeed())
 
@@ -441,8 +441,8 @@ var _ = Describe("manger.Manager", func() {
 				// Add one component before starting
 				c1 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
-					defer close(c1)
 					defer GinkgoRecover()
+					close(c1)
 					return nil
 				}))).To(Succeed())
 
@@ -457,8 +457,8 @@ var _ = Describe("manger.Manager", func() {
 				// Add another component after starting
 				c2 := make(chan struct{})
 				Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
-					defer close(c2)
 					defer GinkgoRecover()
+					close(c2)
 					return nil
 				}))).To(Succeed())
 				<-c1
@@ -483,8 +483,8 @@ var _ = Describe("manger.Manager", func() {
 
 			c1 := make(chan struct{})
 			Expect(m.Add(RunnableFunc(func(s <-chan struct{}) error {
-				defer close(c1)
 				defer GinkgoRecover()
+				close(c1)
 				return nil
 			}))).To(Succeed())
 			<-c1


### PR DESCRIPTION
In `controllerManager`, `startLeaderElectionRunnables` doesn't protect its read of `leaderElectionRunnables` and write of `started`. This may cause a Runnable to be run twice:

- `startNonLeaderElectionRunnables` sets `started` to true
- `Add` appends the runnable to `leaderElectionRunnables`, sees that that `started` is true, and starts the runnable
- `startLeaderElectionRunnables` starts all of the runnables in `leaderElectionRunnables`


See https://travis-ci.org/kubernetes-sigs/controller-runtime/jobs/541066866 for an example.