### PR TITLE
✨ unstructured client should key off unstructured

### DIFF
--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -69,7 +69,7 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 	}
 	// we need the non-list GVK, so chop off the "List" from the end of the kind
 	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	_, isUnstructured := out.(*unstructured.UnstructuredList)
+	_, isUnstructured := out.(runtime.Unstructured)
 	var cacheTypeObj runtime.Object
 	if isUnstructured {
 		u := &unstructured.Unstructured{}

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
@@ -74,9 +73,7 @@ func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
 func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object) (*MapEntry, error) {
-	_, isUnstructured := obj.(*unstructured.Unstructured)
-	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
-	isUnstructured = isUnstructured || isUnstructuredList
+	_, isUnstructured := obj.(runtime.Unstructured)
 
 	if isUnstructured {
 		return m.unstructured.Get(gvk, obj)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -22,7 +22,6 @@ import (
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/dynamic"
@@ -105,54 +104,54 @@ type client struct {
 
 // Create implements client.Client
 func (c *client) Create(ctx context.Context, obj runtime.Object, opts ...CreateOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.Create(ctx, obj, opts...)
+		return c.unstructuredClient.Create(ctx, u, opts...)
 	}
 	return c.typedClient.Create(ctx, obj, opts...)
 }
 
 // Update implements client.Client
 func (c *client) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.Update(ctx, obj, opts...)
+		return c.unstructuredClient.Update(ctx, u, opts...)
 	}
 	return c.typedClient.Update(ctx, obj, opts...)
 }
 
 // Delete implements client.Client
 func (c *client) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.Delete(ctx, obj, opts...)
+		return c.unstructuredClient.Delete(ctx, u, opts...)
 	}
 	return c.typedClient.Delete(ctx, obj, opts...)
 }
 
 // Patch implements client.Client
 func (c *client) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.Patch(ctx, obj, patch, opts...)
+		return c.unstructuredClient.Patch(ctx, u, patch, opts...)
 	}
 	return c.typedClient.Patch(ctx, obj, patch, opts...)
 }
 
 // Get implements client.Client
 func (c *client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.Get(ctx, key, obj)
+		return c.unstructuredClient.Get(ctx, key, u)
 	}
 	return c.typedClient.Get(ctx, key, obj)
 }
 
 // List implements client.Client
 func (c *client) List(ctx context.Context, obj runtime.Object, opts ...ListOptionFunc) error {
-	_, ok := obj.(*unstructured.UnstructuredList)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return c.unstructuredClient.List(ctx, obj, opts...)
+		return c.unstructuredClient.List(ctx, u, opts...)
 	}
 	return c.typedClient.List(ctx, obj, opts...)
 }
@@ -172,18 +171,18 @@ var _ StatusWriter = &statusWriter{}
 
 // Update implements client.StatusWriter
 func (sw *statusWriter) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return sw.client.unstructuredClient.UpdateStatus(ctx, obj, opts...)
+		return sw.client.unstructuredClient.UpdateStatus(ctx, u, opts...)
 	}
 	return sw.client.typedClient.UpdateStatus(ctx, obj, opts...)
 }
 
 // Patch implements client.Client
 func (sw *statusWriter) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOptionFunc) error {
-	_, ok := obj.(*unstructured.Unstructured)
+	u, ok := obj.(runtime.Unstructured)
 	if ok {
-		return sw.client.unstructuredClient.PatchStatus(ctx, obj, patch, opts...)
+		return sw.client.unstructuredClient.PatchStatus(ctx, u, patch, opts...)
 	}
 	return sw.client.typedClient.PatchStatus(ctx, obj, patch, opts...)
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -44,6 +44,8 @@ type Patch interface {
 	Type() types.PatchType
 	// Data is the raw data representing the patch.
 	Data(obj runtime.Object) ([]byte, error)
+	// DataFromUnstructured is the raw data representing the patch from unstructured
+	DataFromUnstructured(obj runtime.Unstructured) ([]byte, error)
 }
 
 // TODO(directxman12): is there a sane way to deal with get/delete options?

--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -19,7 +19,6 @@ package client
 import (
 	"context"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -44,7 +43,7 @@ type DelegatingReader struct {
 
 // Get retrieves an obj for a given object key from the Kubernetes Cluster.
 func (d *DelegatingReader) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
-	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructured := obj.(runtime.Unstructured)
 	if isUnstructured {
 		return d.ClientReader.Get(ctx, key, obj)
 	}
@@ -53,7 +52,7 @@ func (d *DelegatingReader) Get(ctx context.Context, key ObjectKey, obj runtime.O
 
 // List retrieves list of objects for a given namespace and list options.
 func (d *DelegatingReader) List(ctx context.Context, list runtime.Object, opts ...ListOptionFunc) error {
-	_, isUnstructured := list.(*unstructured.UnstructuredList)
+	_, isUnstructured := list.(runtime.Unstructured)
 	if isUnstructured {
 		return d.ClientReader.List(ctx, list, opts...)
 	}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Make Unstructured client to key off unstructured

Issue : https://github.com/kubernetes-sigs/controller-runtime/issues/415