### PR TITLE
:running: Verify Emoji with GH actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,9 @@
+workflow "PR Checks" {
+    on = "pull_request"
+    resolves = ["verify-emoji"]
+}
+
+action "verify-emoji" {
+    uses = "./hack/release"
+    secrets = ["GITHUB_TOKEN"]
+}

--- a/hack/release/Dockerfile
+++ b/hack/release/Dockerfile
@@ -1,0 +1,13 @@
+FROM k8s.gcr.io/debian-base:v1.0.0
+
+LABEL com.github.actions.name="KubeBuilder PR Emoji"
+LABEL com.github.actions.name="Verify that KubeBuilder release notes emoji are present on the PR"
+LABEL com.github.actions.icon="git-pull-request"
+LABEL com.github.actions.color="blue"
+
+RUN apt-get update -y && apt-get install -y bash jq curl
+
+COPY common.sh /common.sh
+COPY verify-emoji.sh /verify-emoji.sh
+
+ENTRYPOINT ["/verify-emoji.sh"]

--- a/hack/release/common.sh
+++ b/hack/release/common.sh
@@ -6,6 +6,7 @@ cr_minor_pattern=":sparkles:|$(printf "\xe2\x9c\xa8")"
 cr_patch_pattern=":bug:|$(printf "\xf0\x9f\x90\x9b")"
 cr_docs_pattern=":book:|$(printf "\xf0\x9f\x93\x96")"
 cr_other_pattern=":running:|$(printf "\xf0\x9f\x8f\x83")"
+cr_all_pattern="${cr_major_pattern}|${cr_minor_pattern}|${cr_patch_pattern}|${cr_docs_pattern}|${cr_other_pattern}"
 
 # cr::symbol-type-raw turns :xyz: and the corresponding emoji
 # into one of "major", "minor", "patch", "docs", "other", or

--- a/hack/release/verify-emoji.sh
+++ b/hack/release/verify-emoji.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eu
+set -o pipefail
+
+pr_title=$(jq -r '.pull_request.title' < ${GITHUB_EVENT_PATH})
+
+read pr_prefix rest <<<${pr_title}
+
+source "$(dirname ${BASH_SOURCE})/common.sh"
+
+pr_type=$(cr::symbol-type ${pr_prefix})
+
+summary=""
+conclusion="success"
+if [[ ${pr_type} == "unknown" ]]; then
+    summary="You must specify an emoji at the beginning of the PR to indicate what kind of change this is.\nValid emoji: ${cr_all_pattern}.\nYou specified '${pr_prefix}'.\nSee VERSIONING.md for more information."
+    conclusion="failure"
+else
+    summary="PR is a ${pr_type} change (${pr_prefix})."
+fi
+
+# get the PR (the PR sent from the event has the base branch head as the head)
+base_link=$(jq -r '.pull_request.url' < ${GITHUB_EVENT_PATH})
+head_commit=$(curl -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github.antiope-preview+json' -q ${base_link} | jq -r '.head.sha')
+echo "head commit is ${head_commit}"
+
+curl https://api.github.com/repos/${GITHUB_REPOSITORY}/check-runs -XPOST -H "Authorization: Bearer ${GITHUB_TOKEN}" -H 'Accept: application/vnd.github.antiope-preview+json' -H 'Content-Type: application/json' -q --data-raw '{"name": "Verify Emoji", "head_sha": "'${head_commit}'", "conclusion": "'${conclusion}'", "status": "completed", "completed_at": "'$(date -Iseconds)'", "output": {"title": "Verify Emoji", "summary": "'"${summary}"'"}}'
+


### PR DESCRIPTION
This introduces a GitHub action that verifies emoji.  We could move this
to prow, but in the mean time, it can live here.

It's a bit wonky b/c PRs show up oddly in GH actions for security reasons, but basically, we receive the PR request, figure out the actual head commit, and add a check status depending on if the emoji is ok