### PR TITLE
:sparkles: add GetConfigWithContext to retrieve a config with a specific context

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -970,6 +970,7 @@
     "k8s.io/client-go/testing",
     "k8s.io/client-go/tools/cache",
     "k8s.io/client-go/tools/clientcmd",
+    "k8s.io/client-go/tools/clientcmd/api",
     "k8s.io/client-go/tools/leaderelection",
     "k8s.io/client-go/tools/leaderelection/resourcelock",
     "k8s.io/client-go/tools/metrics",


### PR DESCRIPTION
This PR adds a new function to the config package. Before it was only possible to retrieve the current context of a kubeconfig file via `GetConfig`. Now there's an additional `GetConfigWithContext` where a specific context can be retrieved. 

The advantage is when developing locally (run controllers via IDE) with a specified context, the controller is not dependent on whatever the current context is of the used kubeconfig file.

Fixes #479 
