### PR TITLE
:sparkles: Fix runtime/scheme type aliases

### DIFF
--- a/pkg/runtime/scheme/scheme.go
+++ b/pkg/runtime/scheme/scheme.go
@@ -20,3 +20,10 @@ limitations under the License.
 //
 // Deprecated: use pkg/scheme instead.
 package scheme
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+// Builder builds a new Scheme for mapping go types to Kubernetes GroupVersionKinds.
+type Builder = scheme.Builder


### PR DESCRIPTION
pkg/runtime/scheme was supposed to maintain a type alias to make it
easier for people to upgrade and/or interact with projects written
around older versions, but apparently, I forgot to actually leave the
type alias around.  This fixes that.
