### PR TITLE
:sparkles Add env support for setting ErrorIfCRDPathMissing during testing

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -58,10 +58,28 @@ var _ = Describe("Test", func() {
 	})
 
 	Describe("InstallCRDs", func() {
+
+		It("should set ErrorIfCRDPathMissing through env settings", func(done Done) {
+
+			testEnv := &Environment{
+				ErrorIfCRDPathMissing: true,
+			}
+
+			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+				Paths:              []string{"fake"},
+				ErrorIfPathMissing: testEnv.ErrorIfCRDPathMissing,
+			})
+
+			Expect(err).To(HaveOccurred())
+
+			close(done)
+		})
+
 		It("should install the CRDs into the cluster", func(done Done) {
 
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
-				Paths: []string{filepath.Join(".", "testdata")},
+				Paths:              []string{filepath.Join(".", "testdata")},
+				ErrorIfPathMissing: env.ErrorIfCRDPathMissing,
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -81,6 +81,11 @@ type Environment struct {
 	// loading.
 	Config *rest.Config
 
+	// ErrorIfCRDPathMissing provides an interface for the underlying
+	// CRDInstallOptions.ErrorIfPathMissing. It prevents silent failures
+	// for missing CRD paths.
+	ErrorIfCRDPathMissing bool
+
 	// CRDs is a list of CRDs to install
 	CRDs []*apiextensionsv1beta1.CustomResourceDefinition
 


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
A simpler interface for CRDInstallOptions.ErrorIfPathMissing. Adds ability to control, through the env, how errors are propagated when InstallCRDs is invoked with an invalid CRD path.

Closes #481