### PR TITLE
:running: fix various typos

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5,7 +5,7 @@
 **A**: Each controller should only reconcile one object type.  Other
 affected objects should be mapped to a single type of root object, using
 the `EnqueueRequestForOwner` or `EnqueueRequestsFromMapFunc` event
-handlers, and potentially indicies. Then, your Reconcile method should
+handlers, and potentially indices. Then, your Reconcile method should
 attempt to reconcile *all* state for that given root objects.
 
 ### Q: How do I have different logic in my reconciler for different types of events (e.g. create, update, delete)?

--- a/TMP-LOGGING.md
+++ b/TMP-LOGGING.md
@@ -30,7 +30,7 @@ or even write
 func (r *Reconciler) Reconcile(req reconcile.Request) (reconcile.Response, error) {
     logger := logger.WithValues("pod", req.NamespacedName)
     // do some stuff
-    logger.Info("starting reconcilation")
+    logger.Info("starting reconciliation")
 }
 ```
 
@@ -49,7 +49,7 @@ provides some helpers to make it easy to use
 
 You can configure the logging implementation using
 `"sigs.k8s.io/controller-runtime/pkg/log".SetLogger`.  That
-package also contains the convinience functions for setting up Zap.
+package also contains the convenience functions for setting up Zap.
 
 You can get a handle to the the "root" logger using
 `"sigs.k8s.io/controller-runtime/pkg/log".Log`, and can then call
@@ -58,7 +58,7 @@ repeatedly to chain names together:
 
 ```go
 logger := log.Log.WithName("controller").WithName("replicaset")
-// in reconile...
+// in reconcile...
 logger = logger.WithValues("replicaset", req.NamespacedName)
 // later on in reconcile...
 logger.Info("doing things with pods", "pod", newPod)
@@ -86,7 +86,7 @@ Errors should *always* be logged with `log.Error`, which allows logr
 implementations to provide special handling of errors (for instance,
 providing stack traces in debug mode).
 
-It's acceptible to log call `log.Error` with a nil error object.  This
+It's acceptable to log call `log.Error` with a nil error object.  This
 conveys that an error occurred in some capacity, but that no actual
 `error` object was involved.
 
@@ -125,12 +125,12 @@ logic.
 
 ### Groups, Versions, and Kinds
 
-- Kinds should not be logged alone (they're meanless alone).  Use
+- Kinds should not be logged alone (they're meaningless alone).  Use
   a `GroupKind` object to log them instead, or a `GroupVersionKind` when
   version is relevant.
 
 - If you need to log an API version string, use `api version` as the key
-  (formatted as with a `GroupVersion`, or as recieved directly from API
+  (formatted as with a `GroupVersion`, or as received directly from API
   discovery).
 
 ### Objects and Types

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -66,7 +66,7 @@ greatest code, including breaking changes, happens on master.
 The *release-X* branches contain stable, backwards compatible code.  Every
 major (X) release, a new such branch is created.  It is from these
 branches that minor and patch releases are tagged.  If some cases, it may
-be neccessary open PRs for bugfixes directly against stable branches, but
+be necessary open PRs for bugfixes directly against stable branches, but
 this should generally not be the case.
 
 The maintainers are responsible for updating the contents of this branch;
@@ -131,7 +131,7 @@ branch, except in exceptional circumstances.  Patches will be backported
 to maintained stable versions, as needed.
 
 Major releases are done shortly after a breaking change is merged -- once
-a breaking change is merged, the next release *must* be a major revison.
+a breaking change is merged, the next release *must* be a major revision.
 We don't intend to have a lot of these, so we may put off merging breaking
 PRs until a later date.
 
@@ -172,9 +172,9 @@ have to rewrite their code when they eventually upgrade, and for
 maintainers/contributors, who have to deal with differences between master
 and stable branches.
 
-That being said, we'll occaisonally want to make breaking changes. They'll
+That being said, we'll occasionally want to make breaking changes. They'll
 be merged onto master, and will then trigger a major release (see [Release
-Proccess](#release-process)).  Because breaking changes induce a major
+Process](#release-process)).  Because breaking changes induce a major
 revision, the maintainers may delay a particular breaking change until
 a later date when they are ready to make a major revision with a few
 breaking changes.
@@ -187,7 +187,7 @@ Maintainers should treat breaking changes with caution, and evaluate
 potential non-breaking solutions (see below).
 
 Note that API breakage in public APIs due to dependencies will trigger
-a major revision, so you may occaisonally need to have a major release
+a major revision, so you may occasionally need to have a major release
 anyway, due to changes in libraries like `k8s.io/client-go` or
 `k8s.io/apimachinery`.
 

--- a/doc.go
+++ b/doc.go
@@ -64,7 +64,7 @@ limitations under the License.
 // sources (pkg/source), like Kubernetes API object changes, to event handlers
 // (pkg/handler), like "enqueue a reconcile request for the object owner".
 // Predicates (pkg/predicate) can be used to filter which events actually
-// trigger reconciles.  There are pre-written utilies for the common cases, and
+// trigger reconciles.  There are pre-written utilities for the common cases, and
 // interfaces and helpers for advanced cases.
 //
 // Reconcilers

--- a/examples/builtins/controller.go
+++ b/examples/builtins/controller.go
@@ -38,7 +38,7 @@ type reconcileReplicaSet struct {
 var _ reconcile.Reconciler = &reconcileReplicaSet{}
 
 func (r *reconcileReplicaSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	// set up a convinient log object so we don't have to type request over and over again
+	// set up a convenient log object so we don't have to type request over and over again
 	log := r.log.WithValues("request", request)
 
 	// Fetch the ReplicaSet from the cache

--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -77,7 +77,7 @@ var _ = AfterSuite(func() {
 
 func addCRDToEnvironment(env *envtest.Environment, gvks ...schema.GroupVersionKind) {
 	for _, gvk := range gvks {
-		plural, singlar := meta.UnsafeGuessKindToResource(gvk)
+		plural, singular := meta.UnsafeGuessKindToResource(gvk)
 		crd := &apiextensionsv1beta1.CustomResourceDefinition{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "apiextensions.k8s.io",
@@ -91,7 +91,7 @@ func addCRDToEnvironment(env *envtest.Environment, gvks ...schema.GroupVersionKi
 				Version: gvk.Version,
 				Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 					Plural:   plural.Resource,
-					Singular: singlar.Resource,
+					Singular: singular.Resource,
 					Kind:     gvk.Kind,
 				},
 				Versions: []apiextensionsv1beta1.CustomResourceDefinitionVersion{

--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -59,7 +59,7 @@ func (blder *WebhookBuilder) Complete() error {
 		return err
 	}
 
-	// Set the Webook if needed
+	// Set the Webhook if needed
 	return blder.registerWebhooks()
 }
 

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -36,17 +36,17 @@ var log = logf.RuntimeLog.WithName("object-cache")
 
 // Cache knows how to load Kubernetes objects, fetch informers to request
 // to receive events for Kubernetes objects (at a low-level),
-// and add indicies to fields on the objects stored in the cache.
+// and add indices to fields on the objects stored in the cache.
 type Cache interface {
 	// Cache acts as a client to objects stored in the cache.
 	client.Reader
 
-	// Cache loads informers and adds field indicies.
+	// Cache loads informers and adds field indices.
 	Informers
 }
 
 // Informers knows how to create or fetch informers for different
-// group-version-kinds, and add indicies to those informers.  It's safe to call
+// group-version-kinds, and add indices to those informers.  It's safe to call
 // GetInformer from multiple threads.
 type Informers interface {
 	// GetInformer fetches or constructs an informer for the given object that corresponds to a single
@@ -64,7 +64,7 @@ type Informers interface {
 	// WaitForCacheSync waits for all the caches to sync.  Returns false if it could not sync a cache.
 	WaitForCacheSync(stop <-chan struct{}) bool
 
-	// Informers knows how to add indicies to the caches (informers) that it manages.
+	// Informers knows how to add indices to the caches (informers) that it manages.
 	client.FieldIndexer
 }
 

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -75,7 +75,7 @@ func deletePod(pod runtime.Object) {
 var _ = Describe("Informer Cache", func() {
 	CacheTest(cache.New)
 })
-var _ = Describe("Multi-Namesapce Informer Cache", func() {
+var _ = Describe("Multi-Namespace Informer Cache", func() {
 	CacheTest(cache.MultiNamespacedCacheBuilder([]string{testNamespaceOne, testNamespaceTwo, "default"}))
 })
 

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -97,7 +97,7 @@ func (c *CacheReader) List(_ context.Context, out runtime.Object, opts ...client
 
 	if listOpts.FieldSelector != nil {
 		// TODO(directxman12): support more complicated field selectors by
-		// combining multiple indicies, GetIndexers, etc
+		// combining multiple indices, GetIndexers, etc
 		field, val, requiresExact := requiresExactMatch(listOpts.FieldSelector)
 		if !requiresExact {
 			return fmt.Errorf("non-exact field matches are not supported by the cache")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -48,7 +48,7 @@ type Options struct {
 //
 // In the case of normal types, the scheme will be used to look up the
 // corresponding group, version, and kind for the given type.  In the
-// case of unstrctured types, the group, version, and kind will be extracted
+// case of unstructured types, the group, version, and kind will be extracted
 // from the corresponding fields on the object.
 func New(config *rest.Config, options Options) (Client, error) {
 	if config == nil {

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -74,7 +74,7 @@ func ExampleClient_get() {
 	}, u)
 }
 
-// This example shows how to use the client with typed and unstrucurted objects to create objects.
+// This example shows how to use the client with typed and unstructured objects to create objects.
 func ExampleClient_create() {
 	// Using a typed object.
 	pod := &corev1.Pod{
@@ -129,7 +129,7 @@ func ExampleClient_create() {
 	_ = c.Create(context.Background(), u)
 }
 
-// This example shows how to use the client with typed and unstrucurted objects to list objects.
+// This example shows how to use the client with typed and unstructured objects to list objects.
 func ExampleClient_list() {
 	// Using a typed object.
 	pod := &corev1.PodList{}
@@ -146,7 +146,7 @@ func ExampleClient_list() {
 	_ = c.List(context.Background(), u)
 }
 
-// This example shows how to use the client with typed and unstrucurted objects to update objects.
+// This example shows how to use the client with typed and unstructured objects to update objects.
 func ExampleClient_update() {
 	// Using a typed object.
 	pod := &corev1.Pod{}
@@ -173,7 +173,7 @@ func ExampleClient_update() {
 	_ = c.Update(context.Background(), u)
 }
 
-// This example shows how to use the client with typed and unstrucurted objects to delete objects.
+// This example shows how to use the client with typed and unstructured objects to delete objects.
 func ExampleClient_delete() {
 	// Using a typed object.
 	pod := &corev1.Pod{

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -87,7 +87,7 @@ func (p applyPatch) Type() types.PatchType {
 
 // Data implements Patch.
 func (p applyPatch) Data(obj runtime.Object) ([]byte, error) {
-	// NB(directxman12): we might techically want to be using an actual encoder
+	// NB(directxman12): we might technically want to be using an actual encoder
 	// here (in case some more performant encoder is introduced) but this is
 	// correct and sufficient for our uses (it's what the JSON serializer in
 	// client-go does, more-or-less).

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Controllerutil", func() {
 			Expect(op).To(BeEquivalentTo(controllerutil.OperationResultNone))
 		})
 
-		It("errors when MutateFn changes objct name on creation", func() {
+		It("errors when MutateFn changes object name on creation", func() {
 			op, err := controllerutil.CreateOrUpdate(context.TODO(), c, deploy, func() error {
 				Expect(specr()).To(Succeed())
 				return deploymentRenamer(deploy)()

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -101,7 +101,7 @@ func getInClusterNamespace() (string, error) {
 		return "", fmt.Errorf("error checking namespace file: %v", err)
 	}
 
-	// Load the namespace file and return itss content
+	// Load the namespace file and return its content
 	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading namespace file: %v", err)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -243,7 +243,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
-	// Create the mertics listener. This will throw an error if the metrics bind
+	// Create the metrics listener. This will throw an error if the metrics bind
 	// address is invalid or already in use.
 	metricsListener, err := options.newMetricsListener(options.MetricsBindAddress)
 	if err != nil {

--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -120,7 +120,7 @@ func registerClientMetrics() {
 	clientmetrics.Register(&latencyAdapter{metric: requestLatency}, &resultAdapter{metric: requestResult})
 }
 
-// registerReflectorMetrics sets up reflector (reconile) loop metrics
+// registerReflectorMetrics sets up reflector (reconcile) loop metrics
 func registerReflectorMetrics() {
 	Registry.MustRegister(listsTotal)
 	Registry.MustRegister(listsDuration)
@@ -134,7 +134,7 @@ func registerReflectorMetrics() {
 	reflectormetrics.SetReflectorMetricsProvider(reflectorMetricsProvider{})
 }
 
-// this section contains adapters, implementations, and other sundry organic, artisinally
+// this section contains adapters, implementations, and other sundry organic, artisanally
 // hand-crafted syntax trees required to convince client-go that it actually wants to let
 // someone use its metrics.
 

--- a/pkg/runtime/inject/inject_test.go
+++ b/pkg/runtime/inject/inject_test.go
@@ -50,7 +50,7 @@ var _ = Describe("runtime inject", func() {
 		Expect(res).To(Equal(true))
 		Expect(injectedCache).To(Equal(instance.GetCache()))
 
-		By("Returing false if the type does not implement inject.Cache")
+		By("Returning false if the type does not implement inject.Cache")
 		res, err = CacheInto(injectedCache, uninjectable)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(Equal(expectedFalse))

--- a/pkg/runtime/log/log.go
+++ b/pkg/runtime/log/log.go
@@ -35,7 +35,7 @@ var (
 	ZapLogger = zap.Logger
 
 	// ZapLoggerTo returns a new Logger implementation using Zap which logs
-	// to the given destination, instead of stderr.  It otherise behaves like
+	// to the given destination, instead of stderr.  It otherwise behaves like
 	// ZapLogger.
 	ZapLoggerTo = zap.Logger
 

--- a/pkg/webhook/admission/webhook_test.go
+++ b/pkg/webhook/admission/webhook_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Admission Webhooks", func() {
 			}),
 		}
 
-		By("invoking the webhoook")
+		By("invoking the webhook")
 		resp := webhook.Handle(context.Background(), Request{})
 
 		By("checking that a JSON patch is populated on the response")

--- a/pkg/webhook/internal/certwatcher/certwatcher.go
+++ b/pkg/webhook/internal/certwatcher/certwatcher.go
@@ -124,7 +124,7 @@ func (cw *CertWatcher) ReadCertificate() error {
 	cw.currentCert = &cert
 	cw.Unlock()
 
-	log.Info("Updated current TLS certiface")
+	log.Info("Updated current TLS certificate")
 
 	return nil
 }


### PR DESCRIPTION
This fixes various typos in the codebase, comments, and log messages