### PR TITLE
⚠️, major: Allow pass a list of objects instead of specific args

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -45,14 +45,14 @@ var _ client.Client = &fakeClient{}
 // You can choose to initialize it with a slice of runtime.Object.
 // Deprecated: use NewFakeClientWithScheme.  You should always be
 // passing an explicit Scheme.
-func NewFakeClient(initObjs ...runtime.Object) client.Client {
-	return NewFakeClientWithScheme(scheme.Scheme, initObjs...)
+func NewFakeClient(initObjs []runtime.Object) client.Client {
+	return NewFakeClientWithScheme(scheme.Scheme, initObjs)
 }
 
 // NewFakeClientWithScheme creates a new fake client with the given scheme
 // for testing.
 // You can choose to initialize it with a slice of runtime.Object.
-func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
+func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs []runtime.Object) client.Client {
 	tracker := testing.NewObjectTracker(clientScheme, scheme.Codecs.UniversalDecoder())
 	for _, obj := range initObjs {
 		err := tracker.Add(obj)

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -235,7 +235,8 @@ var _ = Describe("Fake client", func() {
 
 	Context("with default scheme.Scheme", func() {
 		BeforeEach(func(done Done) {
-			cl = NewFakeClient(dep, dep2, cm)
+			objs:= []runtime.Object{dep, dep2, cm}
+			cl = NewFakeClient(objs)
 			close(done)
 		})
 		AssertClientBehavior()
@@ -246,7 +247,8 @@ var _ = Describe("Fake client", func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 			Expect(appsv1.AddToScheme(scheme)).To(Succeed())
-			cl = NewFakeClientWithScheme(scheme, dep, dep2, cm)
+			objs:= []runtime.Object{dep, dep2, cm}
+			cl = NewFakeClientWithScheme(scheme, objs)
 			close(done)
 		})
 		AssertClientBehavior()


### PR DESCRIPTION
 (:warning:, major)

## Motivaition:
https://github.com/kubernetes-sigs/controller-runtime/issues/505

## What
Allow users to pass a LIST of objects instead of making them add arg by arg in order to use the fake client. 
Replace

```go
func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.Object) client.Client {
````

For

```go
func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs []runtime.Object) client.Client {
```
## Why
Make easier we use the default testing golang API and centralize the code to pass a [] of mock objects. Following an example. 

```go
func TestReconcile_updateDBStatus(t *testing.T) {
	type fields struct {
		objs   []runtime.Object
		scheme *runtime.Scheme
	}
	type args struct {
		deploymentStatus *v1beta1.Deployment
		serviceStatus    *corev1.Service
		pvcStatus        *corev1.PersistentVolumeClaim
		request          reconcile.Request
	}
	tests := []struct {
		name    string
		fields  fields
		args    args
		wantErr bool
	}{
		{
			name: "should return an error when no name found",
			fields: fields{
				objs:   []runtime.Object{&dbInstance}, // each test I'd like to pass a [] of objects
				scheme: scheme.Scheme,
			},
			args: args{
				....
			},
			wantErr: true,
		},
	}
	for _, tt := range tests {
		t.Run(tt.name, func(t *testing.T) {

			r := buildReconcileWithFakeClientWithMocks(tt.fields.objs, t) // here it will add the [] of objects

			reqLogger := log.WithValues("Request.Namespace", tt.args.request.Namespace, "Request.Name", tt.args.request.Name)

			if err := r.updateDBStatus(reqLogger, tt.args.deploymentStatus, tt.args.serviceStatus, tt.args.pvcStatus, tt.args.request); (err != nil) != tt.wantErr {
				t.Errorf("ReconcileMobileSecurityServiceDB.updateDBStatus() error = %v, wantErr %v", err, tt.wantErr)
			}
		})
	}
} 


func buildReconcileWithFakeClientWithMocks(objs []runtime.Object, t *testing.T) *ReconcileMobileSecurityServiceDB {
	s := scheme.Scheme

	....
	// create a fake client to mock API calls with the mock objects
	cl := fake.NewFakeClientWithScheme(s, objs) // here I will be able to pass the []
         
	// create a ReconcileMobileSecurityService object with the scheme and fake client
	return &ReconcileKind{client: cl, scheme: s}
}
```