### PR TITLE
:book: Note on Manager#GetClient about delegating clients

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -63,7 +63,10 @@ type Manager interface {
 	// GetScheme returns an initialized Scheme
 	GetScheme() *runtime.Scheme
 
-	// GetClient returns a client configured with the Config
+	// GetClient returns a client configured with the Config. This client may
+	// not be a fully "direct" client -- it may read from a cache, for
+	// instance.  See Options.NewClient for more information on how the default
+	// implementation works.
 	GetClient() client.Client
 
 	// GetFieldIndexer returns a client.FieldIndexer configured with the client


### PR DESCRIPTION
While the concrete Options struct documents delegating behavior, and the
main overview documents it as well, this adds a note to `manager#GetClient`
that it may return a non-live client, just to avoid confusion.

For reference, it's also documented @ https://godoc.org/sigs.k8s.io/controller-runtime#hdr-Clients_and_Caches and https://godoc.org/sigs.k8s.io/controller-runtime/pkg/manager#Options, but it may not always be obvious that you need to look in either of those places.

We don't concretely say what the client will be, since it's an interface, just that it *may* be non-direct.  Concrete documentation is left to the referenced Options func.