### PR TITLE
:warning: support delete validation in validator interface

### DIFF
--- a/examples/crd/pkg/resource.go
+++ b/examples/crd/pkg/resource.go
@@ -93,6 +93,16 @@ func (c *ChaosPod) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
+// ValidateDelete implements webhookutil.validator so a webhook will be registered for the type
+func (c *ChaosPod) ValidateDelete() error {
+	log.Info("validate delete", "name", c.Name)
+
+	if c.Spec.NextStop.Before(&metav1.Time{Time: time.Now()}) {
+		return fmt.Errorf(".spec.nextStop must be later than current time")
+	}
+	return nil
+}
+
 // +kubebuilder:webhook:path=/mutate-chaosapps-metamagical-io-v1-chaospod,mutating=true,failurePolicy=fail,groups=chaosapps.metamagical.io,resources=chaospods,verbs=create;update,versions=v1,name=mchaospod.kb.io
 
 var _ webhook.Defaulter = &ChaosPod{}

--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -96,37 +96,43 @@ func (blder *WebhookBuilder) registerWebhooks() error {
 
 // registerDefaultingWebhook registers a defaulting webhook if th
 func (blder *WebhookBuilder) registerDefaultingWebhook() {
-	if defaulter, isDefaulter := blder.apiType.(admission.Defaulter); isDefaulter {
-		mwh := admission.DefaultingWebhookFor(defaulter)
-		if mwh != nil {
-			path := generateMutatePath(blder.gvk)
+	defaulter, isDefaulter := blder.apiType.(admission.Defaulter)
+	if !isDefaulter {
+		log.Info("skip registering a mutating webhook, admission.Defaulter interface is not implemented", "GVK", blder.gvk)
+		return
+	}
+	mwh := admission.DefaultingWebhookFor(defaulter)
+	if mwh != nil {
+		path := generateMutatePath(blder.gvk)
 
-			// Checking if the path is already registered.
-			// If so, just skip it.
-			if !blder.isAlreadyHandled(path) {
-				log.Info("Registering a mutating webhook",
-					"GVK", blder.gvk,
-					"path", path)
-				blder.mgr.GetWebhookServer().Register(path, mwh)
-			}
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			log.Info("Registering a mutating webhook",
+				"GVK", blder.gvk,
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, mwh)
 		}
 	}
 }
 
 func (blder *WebhookBuilder) registerValidatingWebhook() {
-	if validator, isValidator := blder.apiType.(admission.Validator); isValidator {
-		vwh := admission.ValidatingWebhookFor(validator)
-		if vwh != nil {
-			path := generateValidatePath(blder.gvk)
+	validator, isValidator := blder.apiType.(admission.Validator)
+	if !isValidator {
+		log.Info("skip registering a validating webhook, admission.Validator interface is not implemented", "GVK", blder.gvk)
+		return
+	}
+	vwh := admission.ValidatingWebhookFor(validator)
+	if vwh != nil {
+		path := generateValidatePath(blder.gvk)
 
-			// Checking if the path is already registered.
-			// If so, just skip it.
-			if !blder.isAlreadyHandled(path) {
-				log.Info("Registering a validating webhook",
-					"GVK", blder.gvk,
-					"path", path)
-				blder.mgr.GetWebhookServer().Register(path, vwh)
-			}
+		// Checking if the path is already registered.
+		// If so, just skip it.
+		if !blder.isAlreadyHandled(path) {
+			log.Info("Registering a validating webhook",
+				"GVK", blder.gvk,
+				"path", path)
+			blder.mgr.GetWebhookServer().Register(path, vwh)
 		}
 	}
 }

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -269,6 +269,103 @@ var _ = Describe("application", func() {
 			Expect(w.Body).To(ContainSubstring(`"allowed":true`))
 			Expect(w.Body).To(ContainSubstring(`"code":200`))
 		})
+
+		It("should scaffold a validating webhook if the type implements the Validator interface to validate deletes", func() {
+			By("creating a controller manager")
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("registering the type in the Scheme")
+			builder := scheme.Builder{GroupVersion: testValidatorGVK.GroupVersion()}
+			builder.Register(&TestValidator{}, &TestValidatorList{})
+			err = builder.AddToScheme(m.GetScheme())
+			Expect(err).NotTo(HaveOccurred())
+
+			err = WebhookManagedBy(m).
+				For(&TestValidator{}).
+				Complete()
+			Expect(err).NotTo(HaveOccurred())
+			svr := m.GetWebhookServer()
+			Expect(svr).NotTo(BeNil())
+
+			reader := strings.NewReader(`{
+  "kind":"AdmissionReview",
+  "apiVersion":"admission.k8s.io/v1beta1",
+  "request":{
+    "uid":"07e52e8d-4513-11e9-a716-42010a800270",
+    "kind":{
+      "group":"",
+      "version":"v1",
+      "kind":"TestValidator"
+    },
+    "resource":{
+      "group":"",
+      "version":"v1",
+      "resource":"testvalidator"
+    },
+    "namespace":"default",
+    "operation":"DELETE",
+    "object":null,
+    "oldObject":{
+      "replica":1
+    }
+  }
+}`)
+			stopCh := make(chan struct{})
+			close(stopCh)
+			// TODO: we may want to improve it to make it be able to inject dependencies,
+			// but not always try to load certs and return not found error.
+			err = svr.Start(stopCh)
+			if err != nil && !os.IsNotExist(err) {
+				Expect(err).NotTo(HaveOccurred())
+			}
+
+			By("sending a request to a validating webhook path to check for failed delete")
+			path := generateValidatePath(testValidatorGVK)
+			req := httptest.NewRequest("POST", "http://svc-name.svc-ns.svc"+path, reader)
+			req.Header.Add(http.CanonicalHeaderKey("Content-Type"), "application/json")
+			w := httptest.NewRecorder()
+			svr.WebhookMux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			By("sanity checking the response contains reasonable field")
+			Expect(w.Body).To(ContainSubstring(`"allowed":false`))
+			Expect(w.Body).To(ContainSubstring(`"code":403`))
+
+			reader = strings.NewReader(`{
+  "kind":"AdmissionReview",
+  "apiVersion":"admission.k8s.io/v1beta1",
+  "request":{
+    "uid":"07e52e8d-4513-11e9-a716-42010a800270",
+    "kind":{
+      "group":"",
+      "version":"v1",
+      "kind":"TestValidator"
+    },
+    "resource":{
+      "group":"",
+      "version":"v1",
+      "resource":"testvalidator"
+    },
+    "namespace":"default",
+    "operation":"DELETE",
+    "object":null,
+    "oldObject":{
+      "replica":0
+    }
+  }
+}`)
+			By("sending a request to a validating webhook path with correct request")
+			path = generateValidatePath(testValidatorGVK)
+			req = httptest.NewRequest("POST", "http://svc-name.svc-ns.svc"+path, reader)
+			req.Header.Add(http.CanonicalHeaderKey("Content-Type"), "application/json")
+			w = httptest.NewRecorder()
+			svr.WebhookMux.ServeHTTP(w, req)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			By("sanity checking the response contains reasonable field")
+			Expect(w.Body).To(ContainSubstring(`"allowed":true`))
+			Expect(w.Body).To(ContainSubstring(`"code":200`))
+
+		})
 	})
 })
 
@@ -357,6 +454,13 @@ func (v *TestValidator) ValidateUpdate(old runtime.Object) error {
 	return nil
 }
 
+func (v *TestValidator) ValidateDelete() error {
+	if v.Replica > 0 {
+		return errors.New("number of replica should be less than or equal to 0 to delete")
+	}
+	return nil
+}
+
 // TestDefaultValidator
 var _ runtime.Object = &TestDefaultValidator{}
 
@@ -404,6 +508,13 @@ func (dv *TestDefaultValidator) ValidateCreate() error {
 func (dv *TestDefaultValidator) ValidateUpdate(old runtime.Object) error {
 	if dv.Replica < 0 {
 		return errors.New("number of replica should be greater than or equal to 0")
+	}
+	return nil
+}
+
+func (dv *TestDefaultValidator) ValidateDelete() error {
+	if dv.Replica > 0 {
+		return errors.New("number of replica should be less than or equal to 0 to delete")
 	}
 	return nil
 }


### PR DESCRIPTION
- Currently validator interface supports create and update
- Add support for delete as well, which could be a breaking change
- Users need to implement ValidateDelete since interface is updated