### PR TITLE
:running: Properly check if binary exists

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -60,7 +60,7 @@ function fetch_kb_tools {
 }
 
 function is_installed {
-  if type "$1" &>/dev/null; then
+  if command -v "$1" &>/dev/null; then
     return 0
   fi
   return 1

--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -60,7 +60,7 @@ function fetch_kb_tools {
 }
 
 function is_installed {
-  if [ command -v $1 &>/dev/null ]; then
+  if type "$1" &>/dev/null; then
     return 0
   fi
   return 1


### PR DESCRIPTION
Currently this is used to determine if `golangci-lint` and `dep` are installed. This fixes the bash syntax to correctly determine if its installed. So locally and in CI the tools will not be reinstalled every time

As you can see in [the build](https://travis-ci.org/kubernetes-sigs/controller-runtime/jobs/562844729#L525) dep is properly now detected


Additionally I've noticed in both [the contributing docs](https://github.com/kubernetes-sigs/controller-runtime/blob/72ab3feaa306ee16af7aa2bd9a6b916b042bffd3/CONTRIBUTING.md#test-locally) and in [CI](https://github.com/kubernetes-sigs/controller-runtime/blob/72ab3feaa306ee16af7aa2bd9a6b916b042bffd3/.travis.yml#L21) these tools are installed outside of this script anyways though, and don't exactly align everywhere

