### PR TITLE
:sparkles: expose NewResourceLock in manager.Options 

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -325,7 +325,6 @@ func setOptionsDefaults(options Options) Options {
 		options.newRecorderProvider = internalrecorder.NewProvider
 	}
 
-	// Allow NewResourceLock to be mocked
 	if options.NewResourceLock == nil {
 		options.NewResourceLock = leaderelection.NewResourceLock
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -162,7 +162,7 @@ type Options struct {
 
 	// NewResourceLock is the function to create a resourceLock
 	// Manager can use customized resourcelock for leader selection
-	// If not privided, will use configmapLocks as default
+	// If not privided, will use ConfigMapsResourceLock as default
 	NewResourceLock func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error)
 
 	// Dependency injection for testing

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -143,7 +143,7 @@ var _ = Describe("manger.Manager", func() {
 				m, err := New(cfg, Options{
 					LeaderElection:          true,
 					LeaderElectionNamespace: "default",
-					newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
+					NewResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
 						var err error
 						rl, err = leaderelection.NewResourceLock(config, recorderProvider, options)
 						return rl, err
@@ -299,7 +299,7 @@ var _ = Describe("manger.Manager", func() {
 				LeaderElection:          true,
 				LeaderElectionID:        "controller-runtime",
 				LeaderElectionNamespace: "default",
-				newResourceLock:         fakeleaderelection.NewResourceLock,
+				NewResourceLock:         fakeleaderelection.NewResourceLock,
 			})
 		})
 


### PR DESCRIPTION
This is to enable controllers to use customized resource locks for leader election. 

It is for the use case that a standalone aggregation-like apiserver running without native kube-apiserver, thus the corev1 resources are not available through apiserver REST API. 

With this, Mangers can use customized resourceLocks, without relying on corev1 resources.

Closes https://github.com/kubernetes-sigs/controller-runtime/issues/534
