### PR TITLE
:warning: Allow reconcilers to add watches dynamically

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -33,9 +32,7 @@ import (
 )
 
 // Supporting mocking out functions for testing
-var getConfig = config.GetConfig
 var newController = controller.New
-var newManager = manager.New
 var getGvk = apiutil.GVKForObject
 
 // Builder builds a Controller.
@@ -50,16 +47,9 @@ type Builder struct {
 	name           string
 }
 
-// SimpleController returns a new Builder.
-//
-// Deprecated: Use ControllerManagedBy(Manager) instead.
-func SimpleController() *Builder {
-	return &Builder{}
-}
-
 // ControllerManagedBy returns a new controller builder that will be started by the provided Manager
 func ControllerManagedBy(m manager.Manager) *Builder {
-	return SimpleController().WithManager(m)
+	return &Builder{mgr: m}
 }
 
 // ForType defines the type of Object being *reconciled*, and configures the ControllerManagedBy to respond to create / delete /
@@ -109,14 +99,6 @@ func (blder *Builder) WithConfig(config *rest.Config) *Builder {
 	return blder
 }
 
-// WithManager sets the Manager to use for registering the ControllerManagedBy.  Defaults to a new manager.Manager.
-//
-// Deprecated: Use ControllerManagedBy(Manager) and this isn't needed.
-func (blder *Builder) WithManager(m manager.Manager) *Builder {
-	blder.mgr = m
-	return blder
-}
-
 // WithEventFilter sets the event filters, to filter which create/update/delete/generic events eventually
 // trigger reconciliations.  For example, filtering on whether the resource version has changed.
 // Defaults to the empty list.
@@ -141,23 +123,17 @@ func (blder *Builder) Complete(r reconcile.Reconciler) error {
 	return err
 }
 
-// Build builds the Application ControllerManagedBy and returns the Manager used to start it.
-//
-// Deprecated: Use Complete
-func (blder *Builder) Build(r reconcile.Reconciler) (manager.Manager, error) {
+// Build builds the Application ControllerManagedBy and returns the Controller it created.
+func (blder *Builder) Build(r reconcile.Reconciler) (controller.Controller, error) {
 	if r == nil {
 		return nil, fmt.Errorf("must provide a non-nil Reconciler")
 	}
+	if blder.mgr == nil {
+		return nil, fmt.Errorf("must provide a non-nil Manager")
+	}
 
 	// Set the Config
-	if err := blder.loadRestConfig(); err != nil {
-		return nil, err
-	}
-
-	// Set the Manager
-	if err := blder.doManager(); err != nil {
-		return nil, err
-	}
+	blder.loadRestConfig()
 
 	// Set the ControllerManagedBy
 	if err := blder.doController(r); err != nil {
@@ -169,7 +145,7 @@ func (blder *Builder) Build(r reconcile.Reconciler) (manager.Manager, error) {
 		return nil, err
 	}
 
-	return blder.mgr, nil
+	return blder.ctrl, nil
 }
 
 func (blder *Builder) doWatch() error {
@@ -203,26 +179,10 @@ func (blder *Builder) doWatch() error {
 	return nil
 }
 
-func (blder *Builder) loadRestConfig() error {
-	if blder.config != nil {
-		return nil
-	}
-	if blder.mgr != nil {
+func (blder *Builder) loadRestConfig() {
+	if blder.config == nil {
 		blder.config = blder.mgr.GetConfig()
-		return nil
 	}
-	var err error
-	blder.config, err = getConfig()
-	return err
-}
-
-func (blder *Builder) doManager() error {
-	if blder.mgr != nil {
-		return nil
-	}
-	var err error
-	blder.mgr, err = newManager(blder.config, manager.Options{})
-	return err
 }
 
 func (blder *Builder) getControllerName() (string, error) {

--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -55,25 +55,16 @@ func (blder *WebhookBuilder) For(apiType runtime.Object) *WebhookBuilder {
 // Complete builds the webhook.
 func (blder *WebhookBuilder) Complete() error {
 	// Set the Config
-	if err := blder.loadRestConfig(); err != nil {
-		return err
-	}
+	blder.loadRestConfig()
 
 	// Set the Webhook if needed
 	return blder.registerWebhooks()
 }
 
-func (blder *WebhookBuilder) loadRestConfig() error {
-	if blder.config != nil {
-		return nil
-	}
-	if blder.mgr != nil {
+func (blder *WebhookBuilder) loadRestConfig() {
+	if blder.config == nil {
 		blder.config = blder.mgr.GetConfig()
-		return nil
 	}
-	var err error
-	blder.config, err = getConfig()
-	return err
 }
 
 func (blder *WebhookBuilder) registerWebhooks() error {

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -28,7 +28,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
@@ -40,9 +39,7 @@ var _ = Describe("application", func() {
 
 	BeforeEach(func() {
 		stop = make(chan struct{})
-		getConfig = func() (*rest.Config, error) { return cfg, nil }
 		newController = controller.New
-		newManager = manager.New
 	})
 
 	AfterEach(func() {

--- a/pkg/patterns/application/doc.go
+++ b/pkg/patterns/application/doc.go
@@ -20,7 +20,7 @@ limitations under the License.
 // An application is a Controller and Resource that together implement the operational logic for an application.
 // They are often used to take off-the-shelf OSS applications, and make them Kubernetes native.
 //
-// A typical application Controller may use a new builder.SimpleController() to create a Controller
+// A typical application Controller may use builder.ControllerManagedBy() to create a Controller
 // for a single API type that manages other objects it creates.
 //
 // Application Controllers are most useful for stateful applications such as Cassandra, Etcd and MySQL


### PR DESCRIPTION
Allow reconcilers to add watches dynamically by getting a handle to the controller created by the builder via `Build` (changes the signature of `Build`).

Fixes #540