### PR TITLE
:sparkles: Expose CRDInstallOptions via envtest.Environment

### DIFF
--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -103,6 +103,6 @@ func addCRDToEnvironment(env *envtest.Environment, gvks ...schema.GroupVersionKi
 				},
 			},
 		}
-		env.CRDs = append(env.CRDs, crd)
+		env.CRDInstallOptions.CRDs = append(env.CRDInstallOptions.CRDs, crd)
 	}
 }

--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -37,7 +37,7 @@ import (
 
 // CRDInstallOptions are the options for installing CRDs
 type CRDInstallOptions struct {
-	// Paths is the path to the directory containing CRDs
+	// Paths is a list of paths to the directories containing CRDs
 	Paths []string
 
 	// CRDs is a list of CRDs to install
@@ -46,11 +46,11 @@ type CRDInstallOptions struct {
 	// ErrorIfPathMissing will cause an error if a Path does not exist
 	ErrorIfPathMissing bool
 
-	// maxTime is the max time to wait
-	maxTime time.Duration
+	// MaxTime is the max time to wait
+	MaxTime time.Duration
 
-	// pollInterval is the interval to check
-	pollInterval time.Duration
+	// PollInterval is the interval to check
+	PollInterval time.Duration
 }
 
 const defaultPollInterval = 100 * time.Millisecond
@@ -97,11 +97,11 @@ func readCRDFiles(options *CRDInstallOptions) error {
 
 // defaultCRDOptions sets the default values for CRDs
 func defaultCRDOptions(o *CRDInstallOptions) {
-	if o.maxTime == 0 {
-		o.maxTime = defaultMaxWait
+	if o.MaxTime == 0 {
+		o.MaxTime = defaultMaxWait
 	}
-	if o.pollInterval == 0 {
-		o.pollInterval = defaultPollInterval
+	if o.PollInterval == 0 {
+		o.PollInterval = defaultPollInterval
 	}
 }
 
@@ -132,7 +132,7 @@ func WaitForCRDs(config *rest.Config, crds []*apiextensionsv1beta1.CustomResourc
 
 	// Poll until all resources are found in discovery
 	p := &poller{config: config, waitingFor: waitingFor}
-	return wait.PollImmediate(options.pollInterval, options.maxTime, p.poll)
+	return wait.PollImmediate(options.PollInterval, options.MaxTime, p.poll)
 }
 
 // poller checks if all the resources have been found in discovery, and returns false if not

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Test", func() {
 						}},
 				},
 			},
-				CRDInstallOptions{maxTime: 50 * time.Millisecond, pollInterval: 15 * time.Millisecond},
+				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -178,7 +178,7 @@ var _ = Describe("Test", func() {
 							}},
 					},
 				},
-				CRDInstallOptions{maxTime: 50 * time.Millisecond, pollInterval: 15 * time.Millisecond},
+				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).To(HaveOccurred())
 
@@ -209,7 +209,7 @@ var _ = Describe("Test", func() {
 							Plural: "fake",
 						}},
 				}},
-				CRDInstallOptions{maxTime: 50 * time.Millisecond, pollInterval: 15 * time.Millisecond},
+				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).To(HaveOccurred())
 

--- a/pkg/envtest/helper.go
+++ b/pkg/envtest/helper.go
@@ -1,0 +1,41 @@
+package envtest
+
+import apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+
+// mergePaths merges two string slices containing paths.
+// This function makes no guarantees about order of the merged slice.
+func mergePaths(s1, s2 []string) []string {
+	m := make(map[string]struct{})
+	for _, s := range s1 {
+		m[s] = struct{}{}
+	}
+	for _, s := range s2 {
+		m[s] = struct{}{}
+	}
+	merged := make([]string, len(m))
+	i := 0
+	for key := range m {
+		merged[i] = key
+		i++
+	}
+	return merged
+}
+
+// mergeCRDs merges two CRD slices using their names.
+// This function makes no guarantees about order of the merged slice.
+func mergeCRDs(s1, s2 []*apiextensionsv1beta1.CustomResourceDefinition) []*apiextensionsv1beta1.CustomResourceDefinition {
+	m := make(map[string]*apiextensionsv1beta1.CustomResourceDefinition)
+	for _, crd := range s1 {
+		m[crd.Name] = crd
+	}
+	for _, crd := range s2 {
+		m[crd.Name] = crd
+	}
+	merged := make([]*apiextensionsv1beta1.CustomResourceDefinition, len(m))
+	i := 0
+	for _, crd := range m {
+		merged[i] = crd
+		i++
+	}
+	return merged
+}

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -81,10 +81,17 @@ type Environment struct {
 	// loading.
 	Config *rest.Config
 
-	// CRDs is a list of CRDs to install
+	// CRDInstallOptions are the options for installing CRDs.
+	CRDInstallOptions CRDInstallOptions
+
+	// CRDs is a list of CRDs to install.
+	// If both this field and CRDs field in CRDInstallOptions are specified, the
+	// values are merged.
 	CRDs []*apiextensionsv1beta1.CustomResourceDefinition
 
 	// CRDDirectoryPaths is a list of paths containing CRD yaml or json configs.
+	// If both this field and Paths field in CRDInstallOptions are specified, the
+	// values are merged.
 	CRDDirectoryPaths []string
 
 	// UseExisting indicates that this environments should use an
@@ -203,10 +210,9 @@ func (te *Environment) Start() (*rest.Config, error) {
 	}
 
 	log.V(1).Info("installing CRDs")
-	_, err := InstallCRDs(te.Config, CRDInstallOptions{
-		Paths: te.CRDDirectoryPaths,
-		CRDs:  te.CRDs,
-	})
+	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
+	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
+	_, err := InstallCRDs(te.Config, te.CRDInstallOptions)
 	return te.Config, err
 }
 


### PR DESCRIPTION
This change provides better control for installing CRDs in `envtest`.

Fixes #541

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
