### PR TITLE
:sparkles: Pass HTTP request Context through to admission Webhook handlers

### DIFF
--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -17,7 +17,6 @@ limitations under the License.
 package admission
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -84,7 +83,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// TODO: add panic-recovery for Handle
-	reviewResponse = wh.Handle(context.Background(), req)
+	reviewResponse = wh.Handle(r.Context(), req)
 	wh.writeResponse(w, reviewResponse)
 }
 

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -92,6 +92,10 @@ func (r *Response) Complete(req Request) error {
 
 // Handler can handle an AdmissionRequest.
 type Handler interface {
+	// Handle yields a response to an AdmissionRequest.
+	//
+	// The supplied context is extracted from the received http.Request, allowing wrapping
+	// http.Handlers to inject values into and control cancelation of downstream request processing.
 	Handle(context.Context, Request) Response
 }
 


### PR DESCRIPTION
Rather than synthesizing a fresh `context.Context` for each admission Webhook request, instead pass through a `Context` obtained from the original `http.Request` passed in to the `http.Handler`. This way, we can wrap middleware `http.Handler`s around the `webhook.Admission` handlers, such as those that establish tracing spans, instrumentation, or logging context, and have our `admission.Handler`s continue to use that same context.

Note that if an `http.Request` had no `Context` bound explicitly with `http.WithContext`, [the `Request.Context` method returns `context.Background`](https://golang.org/src/net/http/request.go?s=12215:12258#L339).