### PR TITLE
:bug: fix SimpleController in builder test

### DIFF
--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -116,7 +116,12 @@ var _ = Describe("application", func() {
 				}
 				return nil, fmt.Errorf("max concurrent reconcilers expected %d but found %d", maxConcurrentReconciles, options.MaxConcurrentReconciles)
 			}
-			instance, err := SimpleController().
+
+			By("creating a controller manager")
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			instance, err := ControllerManagedBy(m).
 				For(&appsv1.ReplicaSet{}).
 				Owns(&appsv1.ReplicaSet{}).
 				WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).


### PR DESCRIPTION
Replace SimpleController with ControllerManagedBy.

HEAD is broken, because 2 independent PRs merged w/o 2nd run of the tests.
Ref: https://github.com/kubernetes-sigs/controller-runtime/pull/520/files#diff-6f42001696c3446318d286d877537c05R133 and https://github.com/kubernetes-sigs/controller-runtime/pull/542/files#diff-df5180876f8262addc299c5c76c39542L56
