### PR TITLE
✨ ZapLoggerTo points to zap.LoggerTo

### DIFF
--- a/pkg/runtime/log/log.go
+++ b/pkg/runtime/log/log.go
@@ -37,7 +37,7 @@ var (
 	// ZapLoggerTo returns a new Logger implementation using Zap which logs
 	// to the given destination, instead of stderr.  It otherise behaves like
 	// ZapLogger.
-	ZapLoggerTo = zap.Logger
+	ZapLoggerTo = zap.LoggerTo
 
 	// SetLogger sets a concrete logging implementation for all deferred Loggers.
 	SetLogger = log.SetLogger


### PR DESCRIPTION
In `runtime/log` we have 2 variables [`ZapLogger`](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/runtime/log/log.go#L35) and [`ZapLoggerTo`](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/runtime/log/log.go#L40). 

They both point to the same function `zap.Logger`. In case of  `ZapLoggerTo` it probably should point to `zap.LoggerTo`.

Fixes #558