### PR TITLE
:book: fix spelling of function EnqueueRequestsFromMapFunc

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -171,7 +171,7 @@ Watching and EventHandling
 
 Controllers may Watch multiple Kinds of objects (e.g. Pods, ReplicaSets and Deployments), but they reconcile
 only a single Type.  When one Type of object must be updated in response to changes in another Type of object,
-an EnqueueRequestFromMapFunc may be used to map events from one type to another.  e.g. Respond to a cluster resize
+an EnqueueRequestsFromMapFunc may be used to map events from one type to another.  e.g. Respond to a cluster resize
 event (add / delete Node) by re-reconciling all instances of some API.
 
 A Deployment Controller might use an EnqueueRequestForObject and EnqueueRequestForOwner to:

--- a/pkg/handler/eventhandler.go
+++ b/pkg/handler/eventhandler.go
@@ -33,7 +33,7 @@ import (
 // * Use EnqueueRequestForOwner to reconcile the owner of the object the event is for
 // - do this for events for the types the Controller creates.  (e.g. ReplicaSets created by a Deployment Controller)
 //
-// * Use EnqueueRequestFromMapFunc to transform an event for an object to a reconcile of an object
+// * Use EnqueueRequestsFromMapFunc to transform an event for an object to a reconcile of an object
 // of a different type - do this for events for types the Controller may be interested in, but doesn't create.
 // (e.g. If Foo responds to cluster size events, map Node events to Foo objects.)
 //


### PR DESCRIPTION
The implementations of `EventHandler` are

- `EnqueueRequestForObject`
- `EnqueueRequestForOwner`
- `EnqueueRequestsFromMapFunc`

The first two are singular `Request`, the last one is plural `Requests`.

This PR fixes the docs in a couple places to use the correct plural form.

