### PR TITLE
:sparkles: Client option types implement client option interfaces

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -878,11 +878,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:14e8a3b53e6d8cb5f44783056b71bb2ca1ac7e333939cc97f3e50b579c920845"
+  digest = "1:ee6063c66a2b3be97487a8df6f359cd5f38b3a0d1fc2442b49f214f24622d321"
   name = "k8s.io/utils"
   packages = [
     "buffer",
     "integer",
+    "pointer",
     "trace",
   ]
   pruneopts = "UT"
@@ -978,6 +979,7 @@
     "k8s.io/client-go/tools/reference",
     "k8s.io/client-go/util/workqueue",
     "k8s.io/kube-openapi/pkg/common",
+    "k8s.io/utils/pointer",
     "sigs.k8s.io/testing_frameworks/integration",
     "sigs.k8s.io/testing_frameworks/integration/addr",
     "sigs.k8s.io/yaml",

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -446,6 +446,21 @@ func (o *UpdateOptions) ApplyOptions(opts []UpdateOption) *UpdateOptions {
 	return o
 }
 
+var _ UpdateOption = &UpdateOptions{}
+
+// ApplyToUpdate implements UpdateOption
+func (o *UpdateOptions) ApplyToUpdate(uo *UpdateOptions) {
+	if o.DryRun != nil {
+		uo.DryRun = o.DryRun
+	}
+	if o.FieldManager != "" {
+		uo.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		uo.Raw = o.Raw
+	}
+}
+
 // UpdateDryRunAll sets the "dry run" option to "all".
 //
 // Deprecated: Use DryRunAll

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -518,6 +518,24 @@ func (o *PatchOptions) AsPatchOptions() *metav1.PatchOptions {
 	return o.Raw
 }
 
+var _ PatchOption = &PatchOptions{}
+
+// ApplyToPatch implements PatchOptions
+func (o *PatchOptions) ApplyToPatch(po *PatchOptions) {
+	if o.DryRun != nil {
+		po.DryRun = o.DryRun
+	}
+	if o.Force != nil {
+		po.Force = o.Force
+	}
+	if o.FieldManager != "" {
+		po.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		po.Raw = o.Raw
+	}
+}
+
 // ForceOwnership indicates that in case of conflicts with server-side apply,
 // the client should acquire ownership of the conflicting field.  Most
 // controllers should use this.

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -273,6 +273,24 @@ type ListOptions struct {
 	Raw *metav1.ListOptions
 }
 
+var _ ListOption = &ListOptions{}
+
+// ApplyToList implements ListOption for ListOptions
+func (o *ListOptions) ApplyToList(lo *ListOptions) {
+	if o.LabelSelector != nil {
+		lo.LabelSelector = o.LabelSelector
+	}
+	if o.FieldSelector != nil {
+		lo.FieldSelector = o.FieldSelector
+	}
+	if o.Namespace != "" {
+		lo.Namespace = o.Namespace
+	}
+	if o.Raw != nil {
+		lo.Raw = o.Raw
+	}
+}
+
 // AsListOptions returns these options as a flattened metav1.ListOptions.
 // This may mutate the Raw field.
 func (o *ListOptions) AsListOptions() *metav1.ListOptions {

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -142,6 +142,21 @@ func (o *CreateOptions) ApplyOptions(opts []CreateOption) *CreateOptions {
 	return o
 }
 
+// ApplyToCreate implements CreateOption
+func (o *CreateOptions) ApplyToCreate(co *CreateOptions) {
+	if o.DryRun != nil {
+		co.DryRun = o.DryRun
+	}
+	if o.FieldManager != "" {
+		co.FieldManager = o.FieldManager
+	}
+	if o.Raw != nil {
+		co.Raw = o.Raw
+	}
+}
+
+var _ CreateOption = &CreateOptions{}
+
 // CreateDryRunAll sets the "dry run" option to "all".
 //
 // Deprecated: Use DryRunAll

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -575,4 +575,12 @@ func (o *DeleteAllOfOptions) ApplyOptions(opts []DeleteAllOfOption) *DeleteAllOf
 	return o
 }
 
+var _ DeleteAllOfOption = &DeleteAllOfOptions{}
+
+// ApplyToDeleteAllOf implements DeleteAllOfOption
+func (o *DeleteAllOfOptions) ApplyToDeleteAllOf(do *DeleteAllOfOptions) {
+	o.ApplyToList(&do.ListOptions)
+	o.ApplyToDelete(&do.DeleteOptions)
+}
+
 // }}}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -226,6 +226,27 @@ func (o *DeleteOptions) ApplyOptions(opts []DeleteOption) *DeleteOptions {
 	return o
 }
 
+var _ DeleteOption = &DeleteOptions{}
+
+// ApplyToDelete implements DeleteOption
+func (o *DeleteOptions) ApplyToDelete(do *DeleteOptions) {
+	if o.GracePeriodSeconds != nil {
+		do.GracePeriodSeconds = o.GracePeriodSeconds
+	}
+	if o.Preconditions != nil {
+		do.Preconditions = o.Preconditions
+	}
+	if o.PropagationPolicy != nil {
+		do.PropagationPolicy = o.PropagationPolicy
+	}
+	if o.Raw != nil {
+		do.Raw = o.Raw
+	}
+	if o.DryRun != nil {
+		do.DryRun = o.DryRun
+	}
+}
+
 // GracePeriodSeconds sets the grace period for the deletion
 // to the given number of seconds.
 type GracePeriodSeconds int64

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -188,3 +188,18 @@ var _ = Describe("PatchOptions", func() {
 		Expect(newPatchOpts).To(Equal(o))
 	})
 })
+
+var _ = Describe("DeleteAllOfOptions", func() {
+	It("Should set ListOptions", func() {
+		o := &client.DeleteAllOfOptions{ListOptions: client.ListOptions{Raw: &metav1.ListOptions{}}}
+		newDeleteAllOfOpts := &client.DeleteAllOfOptions{}
+		o.ApplyToDeleteAllOf(newDeleteAllOfOpts)
+		Expect(newDeleteAllOfOpts).To(Equal(o))
+	})
+	It("Should set DeleleteOptions", func() {
+		o := &client.DeleteAllOfOptions{DeleteOptions: client.DeleteOptions{GracePeriodSeconds: utilpointer.Int64Ptr(44)}}
+		newDeleteAllOfOpts := &client.DeleteAllOfOptions{}
+		o.ApplyToDeleteAllOf(newDeleteAllOfOpts)
+		Expect(newDeleteAllOfOpts).To(Equal(o))
+	})
+})

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -128,3 +128,30 @@ var _ = Describe("DeleteOptions", func() {
 		Expect(newDeleteOpts).To(Equal(o))
 	})
 })
+
+var _ = Describe("UpdateOptions", func() {
+	It("Should set DryRun", func() {
+		o := &client.UpdateOptions{DryRun: []string{"Bye", "Pippa"}}
+		newUpdateOpts := &client.UpdateOptions{}
+		o.ApplyToUpdate(newUpdateOpts)
+		Expect(newUpdateOpts).To(Equal(o))
+	})
+	It("Should set FieldManager", func() {
+		o := &client.UpdateOptions{FieldManager: "Hello Boris"}
+		newUpdateOpts := &client.UpdateOptions{}
+		o.ApplyToUpdate(newUpdateOpts)
+		Expect(newUpdateOpts).To(Equal(o))
+	})
+	It("Should set Raw", func() {
+		o := &client.UpdateOptions{Raw: &metav1.UpdateOptions{}}
+		newUpdateOpts := &client.UpdateOptions{}
+		o.ApplyToUpdate(newUpdateOpts)
+		Expect(newUpdateOpts).To(Equal(o))
+	})
+	It("Should not set anything", func() {
+		o := &client.UpdateOptions{}
+		newUpdateOpts := &client.UpdateOptions{}
+		o.ApplyToUpdate(newUpdateOpts)
+		Expect(newUpdateOpts).To(Equal(o))
+	})
+})

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -155,3 +155,36 @@ var _ = Describe("UpdateOptions", func() {
 		Expect(newUpdateOpts).To(Equal(o))
 	})
 })
+
+var _ = Describe("PatchOptions", func() {
+	It("Should set DryRun", func() {
+		o := &client.PatchOptions{DryRun: []string{"Bye", "Boris"}}
+		newPatchOpts := &client.PatchOptions{}
+		o.ApplyToPatch(newPatchOpts)
+		Expect(newPatchOpts).To(Equal(o))
+	})
+	It("Should set Force", func() {
+		o := &client.PatchOptions{Force: utilpointer.BoolPtr(true)}
+		newPatchOpts := &client.PatchOptions{}
+		o.ApplyToPatch(newPatchOpts)
+		Expect(newPatchOpts).To(Equal(o))
+	})
+	It("Should set FieldManager", func() {
+		o := &client.PatchOptions{FieldManager: "Hello Julian"}
+		newPatchOpts := &client.PatchOptions{}
+		o.ApplyToPatch(newPatchOpts)
+		Expect(newPatchOpts).To(Equal(o))
+	})
+	It("Should set Raw", func() {
+		o := &client.PatchOptions{Raw: &metav1.PatchOptions{}}
+		newPatchOpts := &client.PatchOptions{}
+		o.ApplyToPatch(newPatchOpts)
+		Expect(newPatchOpts).To(Equal(o))
+	})
+	It("Should not set anything", func() {
+		o := &client.PatchOptions{}
+		newPatchOpts := &client.PatchOptions{}
+		o.ApplyToPatch(newPatchOpts)
+		Expect(newPatchOpts).To(Equal(o))
+	})
+})

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -60,3 +60,30 @@ var _ = Describe("ListOptions", func() {
 		Expect(newListOpts).To(Equal(o))
 	})
 })
+
+var _ = Describe("CreateOptions", func() {
+	It("Should set DryRun", func() {
+		o := &client.CreateOptions{DryRun: []string{"Hello", "Theodore"}}
+		newCreatOpts := &client.CreateOptions{}
+		o.ApplyToCreate(newCreatOpts)
+		Expect(newCreatOpts).To(Equal(o))
+	})
+	It("Should set FieldManager", func() {
+		o := &client.CreateOptions{FieldManager: "FieldManager"}
+		newCreatOpts := &client.CreateOptions{}
+		o.ApplyToCreate(newCreatOpts)
+		Expect(newCreatOpts).To(Equal(o))
+	})
+	It("Should set Raw", func() {
+		o := &client.CreateOptions{Raw: &metav1.CreateOptions{DryRun: []string{"Bye", "Theodore"}}}
+		newCreatOpts := &client.CreateOptions{}
+		o.ApplyToCreate(newCreatOpts)
+		Expect(newCreatOpts).To(Equal(o))
+	})
+	It("Should not set anything", func() {
+		o := &client.CreateOptions{}
+		newCreatOpts := &client.CreateOptions{}
+		o.ApplyToCreate(newCreatOpts)
+		Expect(newCreatOpts).To(Equal(o))
+	})
+})

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -85,5 +86,45 @@ var _ = Describe("CreateOptions", func() {
 		newCreatOpts := &client.CreateOptions{}
 		o.ApplyToCreate(newCreatOpts)
 		Expect(newCreatOpts).To(Equal(o))
+	})
+})
+
+var _ = Describe("DeleteOptions", func() {
+	It("Should set GracePeriodSeconds", func() {
+		o := &client.DeleteOptions{GracePeriodSeconds: utilpointer.Int64Ptr(42)}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
+	})
+	It("Should set Preconditions", func() {
+		o := &client.DeleteOptions{Preconditions: &metav1.Preconditions{}}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
+	})
+	It("Should set PropagationPolicy", func() {
+		policy := metav1.DeletePropagationBackground
+		o := &client.DeleteOptions{PropagationPolicy: &policy}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
+	})
+	It("Should set Raw", func() {
+		o := &client.DeleteOptions{Raw: &metav1.DeleteOptions{}}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
+	})
+	It("Should set DryRun", func() {
+		o := &client.DeleteOptions{DryRun: []string{"Hello", "Pippa"}}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
+	})
+	It("Should not set anything", func() {
+		o := &client.DeleteOptions{}
+		newDeleteOpts := &client.DeleteOptions{}
+		o.ApplyToDelete(newDeleteOpts)
+		Expect(newDeleteOpts).To(Equal(o))
 	})
 })

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ListOptions", func() {
+	It("Should set LabelSelector", func() {
+		labelSelector, err := labels.Parse("a=b")
+		Expect(err).NotTo(HaveOccurred())
+		o := &client.ListOptions{LabelSelector: labelSelector}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should set FieldSelector", func() {
+		o := &client.ListOptions{FieldSelector: fields.Nothing()}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should set Namespace", func() {
+		o := &client.ListOptions{Namespace: "my-ns"}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should set Raw", func() {
+		o := &client.ListOptions{Raw: &metav1.ListOptions{FieldSelector: "Hans"}}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should not set anything", func() {
+		o := &client.ListOptions{}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+})


### PR DESCRIPTION
Currently setting multiple `ListOption`s is pretty annoying, because it is not defined as a function but as an interface, which can not be defined inline.

This PR extends the existing `ListOptions` struct to implement the `ListOption` interface to allow using it as a `ListOption`.

If anyhow possible, I'd be super, super glad if we could get this into the `release-0.2` branch as well :grimacing: 

/assign @DirectXMan12 
