### PR TITLE
✨Add option to use Lease lock if coordination group is available

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -935,6 +935,7 @@
     "k8s.io/api/apps/v1",
     "k8s.io/api/apps/v1beta1",
     "k8s.io/api/autoscaling/v1",
+    "k8s.io/api/coordination/v1",
     "k8s.io/api/core/v1",
     "k8s.io/api/extensions/v1beta1",
     "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1",

--- a/pkg/leaderelection/doc.go
+++ b/pkg/leaderelection/doc.go
@@ -19,6 +19,9 @@ Package leaderelection contains a constructors for a leader election resource lo
 This is used to ensure that multiple copies of a controller manager can be run with
 only one active set of controllers, for active-passive HA.
 
-It uses built-in Kubernetes leader election APIs.
+It uses built-in Kubernetes leader election APIs. The Lease lock type takes precedence
+as edits to Leases are less common and fewer objects in the cluster watch "all Leases".
+If the Lease API is not available, the ConfigMap resource lock is used.
+
 */
 package leaderelection

--- a/pkg/leaderelection/leader_election_suite_test.go
+++ b/pkg/leaderelection/leader_election_suite_test.go
@@ -1,0 +1,13 @@
+package leaderelection
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestLeaderElection(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Leader Election Suite")
+}

--- a/pkg/leaderelection/leader_election_test.go
+++ b/pkg/leaderelection/leader_election_test.go
@@ -1,0 +1,79 @@
+package leaderelection
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	tlog "github.com/go-logr/logr/testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/internal/recorder"
+)
+
+var _ = Describe("Leader Election", func() {
+	It("should use the Lease lock because coordination group is available.", func() {
+		coordinationGroup := &v1.APIGroupList{
+			Groups: []v1.APIGroup{
+				{Name: coordinationv1.GroupName},
+			},
+		}
+
+		clientConfig := &restclient.Config{
+			Transport: interceptAPIGroupCall(coordinationGroup),
+		}
+
+		rProvider, err := recorder.NewProvider(clientConfig, scheme.Scheme, tlog.NullLogger{}, record.NewBroadcaster())
+		Expect(err).ToNot(HaveOccurred())
+
+		lock, err := NewResourceLock(clientConfig, rProvider, Options{LeaderElection: true, LeaderElectionNamespace: "test-ns"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lock).To(BeAssignableToTypeOf(&resourcelock.LeaseLock{}))
+	})
+
+	It("should use the ConfigMap lock because coordination group is unavailable.", func() {
+		clientConfig := &restclient.Config{
+			Transport: interceptAPIGroupCall(&v1.APIGroupList{ /* no coordination group */ }),
+		}
+
+		rProvider, err := recorder.NewProvider(clientConfig, scheme.Scheme, tlog.NullLogger{}, record.NewBroadcaster())
+		Expect(err).ToNot(HaveOccurred())
+
+		lock, err := NewResourceLock(clientConfig, rProvider, Options{LeaderElection: true, LeaderElectionNamespace: "test-ns"})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(lock).To(BeAssignableToTypeOf(&resourcelock.ConfigMapLock{}))
+	})
+})
+
+func interceptAPIGroupCall(returnApis *v1.APIGroupList) roundTripper {
+	return roundTripper(func(req *http.Request) (*http.Response, error) {
+		if req.Method == "GET" && (req.URL.Path == "/apis" || req.URL.Path == "/api") {
+			return encode(returnApis)
+		}
+		return nil, fmt.Errorf("unexpected request: %v %#v\n%#v", req.Method, req.URL, req)
+	})
+}
+func encode(bodyStruct interface{}) (*http.Response, error) {
+	jsonBytes, err := json.Marshal(bodyStruct)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(bytes.NewReader(jsonBytes)),
+	}, nil
+}
+
+type roundTripper func(*http.Request) (*http.Response, error)
+
+func (f roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -111,10 +111,10 @@ type Options struct {
 	LeaderElection bool
 
 	// LeaderElectionNamespace determines the namespace in which the leader
-	// election configmap will be created.
+	// election will be created.
 	LeaderElectionNamespace string
 
-	// LeaderElectionID determines the name of the configmap that leader election
+	// LeaderElectionID determines the name of the resource lock that leader election
 	// will use for holding the leader lock.
 	LeaderElectionID string
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -53,10 +53,6 @@ type Server struct {
 	Port int
 
 	// CertDir is the directory that contains the server key and certificate.
-	// If using FSCertWriter in Provisioner, the server itself will provision the certificate and
-	// store it in this directory.
-	// If using SecretCertWriter in Provisioner, the server will provision the certificate in a secret,
-	// the user is responsible to mount the secret to the this location for the server to consume.
 	CertDir string
 
 	// WebhookMux is the multiplexer that handles different webhooks.


### PR DESCRIPTION
**Description**

- This PR adds new strategy for `NewResourceLock` method:  _Choose the Lease lock if `lease.coordination.k8s.io` is available otherwise, use ConfigMaps._
- Add tests coverage for implemented logic using ginko & gomega 
- Remove outdated information about cert generation (cert generation was removed in this PR: https://github.com/kubernetes-sigs/controller-runtime/pull/300)

**Notes to reviewer:**
- the `NewResourceLock` method is not easily testable. To do it you need to hack it via injected rest config. I did it in a similar way as in kubectl pkg.
- e2e tested with k8s 1.15 ([kind](https://github.com/kubernetes-sigs/kind))
- unit tests can be changed to `table tests`, see this: https://gist.github.com/mszostok/11278dbc9316d526cd8a2e09f063e50f
but IMO is not worth it.

Fixes: https://github.com/kubernetes-sigs/controller-runtime/issues/460

---
needs to be sync with https://github.com/kubernetes-sigs/controller-runtime/pull/444