### PR TITLE
:warning: Bump to Go 1.13

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -70,11 +70,18 @@ function is_installed {
   return 1
 }
 
+function golangci_lint_has_version {
+  # Trim "v" from version prefix since golangci-lint --version
+  # sometimes does not include it, depending on how it's built
+  golangci-lint --version | grep --quiet --fixed-strings "${1#"v"}"
+}
+
 function fetch_go_tools {
-  header_text "Checking for gometalinter.v2"
-  if ! is_installed golangci-lint; then
+  header_text "Checking for golangci-lint"
+  local golangci_lint_version="v1.21.0"
+  if ! is_installed golangci-lint || ! golangci_lint_has_version "${golangci_lint_version}"; then
     header_text "Installing golangci-lint"
-    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin "${golangci_lint_version}"
   fi
 }
 

--- a/hack/ci-check-everything.sh
+++ b/hack/ci-check-everything.sh
@@ -22,8 +22,4 @@ export TRACE=1
 export PATH=$(go env GOPATH)/bin:$PATH
 mkdir -p $(go env GOPATH)/bin
 
-echo "Installing golangci-lint"
-curl --location --silent --retry 5 --fail  https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
-echo "Finished installing golangci-lint"
-
 $(dirname ${BASH_SOURCE})/check-everything.sh

--- a/hack/ci-check-everything.sh
+++ b/hack/ci-check-everything.sh
@@ -16,7 +16,6 @@
 
 set -e
 
-export GO111MODULE=on
 export TRACE=1
 
 # Not included or existing by default in Prow

--- a/pkg/client/apiutil/dynamicrestmapper.go
+++ b/pkg/client/apiutil/dynamicrestmapper.go
@@ -17,11 +17,11 @@ limitations under the License.
 package apiutil
 
 import (
+	"errors"
 	"sync"
 	"time"
 
 	"golang.org/x/time/rate"
-	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -45,7 +45,7 @@ func (e ErrRateLimited) Error() string {
 // time.Duration value and false are returned if err is not a ErrRateLimited.
 func DelayIfRateLimited(err error) (time.Duration, bool) {
 	var rlerr ErrRateLimited
-	if xerrors.As(err, &rlerr) {
+	if errors.As(err, &rlerr) {
 		return rlerr.Delay, true
 	}
 	return 0, false
@@ -182,7 +182,7 @@ func (drm *dynamicRESTMapper) checkAndReload(needsReloadErr error, checkNeedsRel
 	// NB(directxman12): `Is` and `As` have a confusing relationship --
 	// `Is` is like `== or does this implement .Is`, whereas `As` says
 	// `can I type-assert into`
-	needsReload := xerrors.As(err, &needsReloadErr)
+	needsReload := errors.As(err, &needsReloadErr)
 	if !needsReload {
 		return err
 	}
@@ -193,7 +193,7 @@ func (drm *dynamicRESTMapper) checkAndReload(needsReloadErr error, checkNeedsRel
 
 	// ... and double-check that we didn't reload in the meantime
 	err = checkNeedsReload()
-	needsReload = xerrors.As(err, &needsReloadErr)
+	needsReload = errors.As(err, &needsReloadErr)
 	if !needsReload {
 		return err
 	}

--- a/pkg/client/apiutil/dynamicrestmapper_test.go
+++ b/pkg/client/apiutil/dynamicrestmapper_test.go
@@ -1,12 +1,12 @@
 package apiutil_test
 
 import (
+	"errors"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"golang.org/x/time/rate"
-	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -82,7 +82,7 @@ var _ = Describe("Dynamic REST Mapper", func() {
 
 			By("calling another time that would need a requery and failing")
 			Eventually(func() bool {
-				return xerrors.As(callWithTarget(), &apiutil.ErrRateLimited{})
+				return errors.As(callWithTarget(), &apiutil.ErrRateLimited{})
 			}, "10s").Should(BeTrue())
 		})
 

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -62,7 +62,7 @@ func NewFakeClientWithScheme(clientScheme *runtime.Scheme, initObjs ...runtime.O
 	for _, obj := range initObjs {
 		err := tracker.Add(obj)
 		if err != nil {
-			panic(fmt.Errorf("failed to add object %v to fake client: %v", obj, err))
+			panic(fmt.Errorf("failed to add object %v to fake client: %w", obj, err))
 		}
 	}
 	return &fakeClient{

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -228,7 +228,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 		}
 
 		if err := te.defaultTimeouts(); err != nil {
-			return nil, fmt.Errorf("failed to default controlplane timeouts: %v", err)
+			return nil, fmt.Errorf("failed to default controlplane timeouts: %w", err)
 		}
 		te.ControlPlane.Etcd.StartTimeout = te.ControlPlaneStartTimeout
 		te.ControlPlane.Etcd.StopTimeout = te.ControlPlaneStopTimeout
@@ -270,7 +270,7 @@ func (te *Environment) startControlPlane() error {
 		log.Error(err, "unable to start the controlplane", "tries", numTries)
 	}
 	if numTries == maxRetries {
-		return fmt.Errorf("failed to start the controlplane. retried %d times: %v", numTries, err)
+		return fmt.Errorf("failed to start the controlplane. retried %d times: %w", numTries, err)
 	}
 	return nil
 }

--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -42,7 +42,7 @@ type provider struct {
 func NewProvider(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, broadcaster record.EventBroadcaster) (recorder.Provider, error) {
 	clientSet, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init clientSet: %v", err)
+		return nil, fmt.Errorf("failed to init clientSet: %w", err)
 	}
 
 	p := &provider{scheme: scheme, logger: logger, eventBroadcaster: broadcaster}

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -62,7 +62,7 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 		var err error
 		options.LeaderElectionNamespace, err = getInClusterNamespace()
 		if err != nil {
-			return nil, fmt.Errorf("unable to find leader election namespace: %v", err)
+			return nil, fmt.Errorf("unable to find leader election namespace: %w", err)
 		}
 	}
 
@@ -98,13 +98,13 @@ func getInClusterNamespace() (string, error) {
 	if os.IsNotExist(err) {
 		return "", fmt.Errorf("not running in-cluster, please specify LeaderElectionNamespace")
 	} else if err != nil {
-		return "", fmt.Errorf("error checking namespace file: %v", err)
+		return "", fmt.Errorf("error checking namespace file: %w", err)
 	}
 
 	// Load the namespace file and return its content
 	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
 	if err != nil {
-		return "", fmt.Errorf("error reading namespace file: %v", err)
+		return "", fmt.Errorf("error reading namespace file: %w", err)
 	}
 	return string(namespace), nil
 }

--- a/pkg/metrics/listener.go
+++ b/pkg/metrics/listener.go
@@ -40,7 +40,7 @@ func NewListener(addr string) (net.Listener, error) {
 	log.Info("metrics server is starting to listen", "addr", addr)
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
-		er := fmt.Errorf("error listening on %s: %v", addr, err)
+		er := fmt.Errorf("error listening on %s: %w", addr, err)
 		log.Error(er, "metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts")
 		return nil, er
 	}

--- a/pkg/webhook/admission/multi.go
+++ b/pkg/webhook/admission/multi.go
@@ -47,7 +47,7 @@ func (hs multiMutating) Handle(ctx context.Context, req Request) Response {
 	var err error
 	marshaledPatch, err := json.Marshal(patches)
 	if err != nil {
-		return Errored(http.StatusBadRequest, fmt.Errorf("error when marshaling the patch: %v", err))
+		return Errored(http.StatusBadRequest, fmt.Errorf("error when marshaling the patch: %w", err))
 	}
 	return Response{
 		AdmissionResponse: admissionv1beta1.AdmissionResponse{

--- a/pkg/webhook/conversion/conversion.go
+++ b/pkg/webhook/conversion/conversion.go
@@ -161,12 +161,12 @@ func (wh *Webhook) convertViaHub(src, dst conversion.Convertible) error {
 
 	err = src.ConvertTo(hub)
 	if err != nil {
-		return fmt.Errorf("%T failed to convert to hub version %T : %v", src, hub, err)
+		return fmt.Errorf("%T failed to convert to hub version %T : %w", src, hub, err)
 	}
 
 	err = dst.ConvertFrom(hub)
 	if err != nil {
-		return fmt.Errorf("%T failed to convert from hub version %T : %v", dst, hub, err)
+		return fmt.Errorf("%T failed to convert from hub version %T : %w", dst, hub, err)
 	}
 
 	return nil
@@ -187,7 +187,7 @@ func (wh *Webhook) getHub(obj runtime.Object) (conversion.Hub, error) {
 	for _, gvk := range gvks {
 		instance, err := wh.scheme.New(gvk)
 		if err != nil {
-			return nil, fmt.Errorf("failed to allocate an instance for gvk %v %v", gvk, err)
+			return nil, fmt.Errorf("failed to allocate an instance for gvk %v: %w", gvk, err)
 		}
 		if val, isHub := instance.(conversion.Hub); isHub {
 			if hubFoundAlready {
@@ -237,7 +237,7 @@ func IsConvertible(scheme *runtime.Scheme, obj runtime.Object) (bool, error) {
 	for _, gvk := range gvks {
 		instance, err := scheme.New(gvk)
 		if err != nil {
-			return false, fmt.Errorf("failed to allocate an instance for gvk %v %v", gvk, err)
+			return false, fmt.Errorf("failed to allocate an instance for gvk %v: %w", gvk, err)
 		}
 
 		if isHub(instance) {


### PR DESCRIPTION
This PR builds on #598 by completing more of the tasks listed in #590:

- [x] Prune any uses of xerrors (89320998b0928b69df3b5fa255a3eb428333213c)
- [x] Use %w instead of %v in Errorf (fc42a0a06fc146f0a1d314ca254160409617295d)
- [x] Prune uses of GO111MODULE=on from our scripts (e0a1fbb718d55f200c27d2a7dfde7f91901cd8ec)

(note: we already did a soft-bump to 1.13 the previous release, this just starts using the features)