### PR TITLE
🐛 Set limit and continue in ApplyToList method

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -336,6 +336,12 @@ func (o *ListOptions) ApplyToList(lo *ListOptions) {
 	if o.Raw != nil {
 		lo.Raw = o.Raw
 	}
+	if o.Limit > 0 {
+		lo.Limit = o.Limit
+	}
+	if o.Continue != "" {
+		lo.Continue = o.Continue
+	}
 }
 
 // AsListOptions returns these options as a flattened metav1.ListOptions.

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -54,6 +54,18 @@ var _ = Describe("ListOptions", func() {
 		o.ApplyToList(newListOpts)
 		Expect(newListOpts).To(Equal(o))
 	})
+	It("Should set Limit", func() {
+		o := &client.ListOptions{Limit: int64(1)}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should set Continue", func() {
+		o := &client.ListOptions{Continue: "foo"}
+		newListOpts := &client.ListOptions{}
+		o.ApplyToList(newListOpts)
+		Expect(newListOpts).To(Equal(o))
+	})
 	It("Should not set anything", func() {
 		o := &client.ListOptions{}
 		newListOpts := &client.ListOptions{}


### PR DESCRIPTION
Limit and continue support for ListOptions were recently added, but it
was missing in ApplyToList method.
