### PR TITLE
 add apiClient make requests to the api server and not the cache

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -73,6 +73,9 @@ type controllerManager struct {
 	// apiReader is the reader that will make requests to the api server and not the cache.
 	apiReader client.Reader
 
+	// apiClient is the client that will make requests to the api server and not the cache.
+	apiClient client.Client
+
 	// fieldIndexes knows how to add field indexes over the Cache used by this controller,
 	// which can later be consumed via field selectors from the injected client.
 	fieldIndexes client.FieldIndexer
@@ -218,6 +221,10 @@ func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {
 
 func (cm *controllerManager) GetAPIReader() client.Reader {
 	return cm.apiReader
+}
+
+func (cm *controllerManager) GetAPIClient() client.Client {
+	return cm.apiClient
 }
 
 func (cm *controllerManager) GetWebhookServer() *webhook.Server {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -86,6 +86,11 @@ type Manager interface {
 	// use case.
 	GetAPIReader() client.Reader
 
+	// GetAPIClient returns a client that will be configured to use the API server.
+	// This should be used sparingly and only when the cached client does not fit your
+	// use case. It suitable for create some command line or CNI needs query CRD.
+	GetAPIClient() client.Client
+
 	// GetWebhookServer returns a webhook.Server
 	GetWebhookServer() *webhook.Server
 }
@@ -227,7 +232,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
-	apiReader, err := client.New(config, client.Options{Scheme: options.Scheme, Mapper: mapper})
+	apiClient, err := client.New(config, client.Options{Scheme: options.Scheme, Mapper: mapper})
 	if err != nil {
 		return nil, err
 	}
@@ -270,7 +275,8 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		cache:            cache,
 		fieldIndexes:     cache,
 		client:           writeObj,
-		apiReader:        apiReader,
+		apiReader:        apiClient,
+		apiClient:        apiClient,
 		recorderProvider: recorderProvider,
 		resourceLock:     resourceLock,
 		mapper:           mapper,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -88,7 +88,7 @@ type Manager interface {
 
 	// GetAPIClient returns a client that will be configured to use the API server.
 	// This should be used sparingly and only when the cached client does not fit your
-	// use case. It suitable for create some command line or CNI needs query CRD.
+	// use case.
 	GetAPIClient() client.Client
 
 	// GetWebhookServer returns a webhook.Server


### PR DESCRIPTION
:sparkles:

https://github.com/kubernetes-sigs/kubebuilder/issues/947

If we want to query and write CRD in some agents, like CNI. or create a command line (not long live process). apiClient without cache is needed