### PR TITLE
 🐛Prevent NewDiscoveryRESTMapper from panicking by calling NewDiscoveryClientForConfig

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -35,7 +35,10 @@ import (
 // information fetched by a new client with the given config.
 func NewDiscoveryRESTMapper(c *rest.Config) (meta.RESTMapper, error) {
 	// Get a mapper
-	dc := discovery.NewDiscoveryClientForConfigOrDie(c)
+	dc, err := discovery.NewDiscoveryClientForConfig(c)
+	if err != nil {
+		return nil, err
+	}
 	gr, err := restmapper.GetAPIGroupResources(dc)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Fix https://github.com/kubernetes-sigs/controller-runtime/issues/613