### PR TITLE
📖 Document environment variables supported by envtest

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -33,7 +33,18 @@ import (
 
 var log = logf.RuntimeLog.WithName("test-env")
 
-// Default binary path for test framework
+/*
+It's possible to override some defaults, by setting the following environment variables:
+	USE_EXISTING_CLUSTER (boolean): if set to true, envtest will use an existing cluster
+	TEST_ASSET_KUBE_APISERVER (string): path to the api-server binary to use
+	TEST_ASSET_ETCD (string): path to the etcd binary to use
+	TEST_ASSET_KUBECTL (string): path to the kubectl binary to use
+	KUBEBUILDER_ASSETS (string): directory containing the binaries to use (api-server, etcd and kubectl)
+	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start
+	KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start
+	KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT (boolean): if set to true, the control plane's stdout and stderr are attached to os.Stdout and os.Stderr
+
+*/
 const (
 	envUseExistingCluster  = "USE_EXISTING_CLUSTER"
 	envKubeAPIServerBin    = "TEST_ASSET_KUBE_APISERVER"
@@ -51,6 +62,7 @@ const (
 	defaultKubebuilderControlPlaneStopTimeout  = 20 * time.Second
 )
 
+// Default binary path for test framework
 func defaultAssetPath(binary string) string {
 	assetPath := os.Getenv(envKubebuilderPath)
 	if assetPath == "" {
@@ -118,7 +130,8 @@ type Environment struct {
 	AttachControlPlaneOutput bool
 }
 
-// Stop stops a running server
+// Stop stops a running server.
+// If USE_EXISTING_CLUSTER is set to true, this method is a no-op.
 func (te *Environment) Stop() error {
 	if te.useExistingCluster() {
 		return nil

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -39,9 +39,9 @@ It's possible to override some defaults, by setting the following environment va
 	TEST_ASSET_KUBE_APISERVER (string): path to the api-server binary to use
 	TEST_ASSET_ETCD (string): path to the etcd binary to use
 	TEST_ASSET_KUBECTL (string): path to the kubectl binary to use
-	KUBEBUILDER_ASSETS (string): directory containing the binaries to use (api-server, etcd and kubectl)
-	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start
-	KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start
+	KUBEBUILDER_ASSETS (string): directory containing the binaries to use (api-server, etcd and kubectl). Defaults to /usr/local/kubebuilder/bin.
+	KUBEBUILDER_CONTROLPLANE_START_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start. Defaults to 20s.
+	KUBEBUILDER_CONTROLPLANE_STOP_TIMEOUT (string supported by time.ParseDuration): timeout for test control plane to start. Defaults to 20s.
 	KUBEBUILDER_ATTACH_CONTROL_PLANE_OUTPUT (boolean): if set to true, the control plane's stdout and stderr are attached to os.Stdout and os.Stderr
 
 */


### PR DESCRIPTION
This is part of https://github.com/kubernetes-sigs/kubebuilder/issues/1000 and a followup to the work in https://github.com/kubernetes-sigs/kubebuilder/pull/1055.

Adds information on envtest environment variables to the GoDoc.

/kind documentation