### PR TITLE
:running: Tolerate merge commits in the release notes script

### DIFF
--- a/hack/release/release-notes.sh
+++ b/hack/release/release-notes.sh
@@ -26,8 +26,9 @@ while read commit_word commit; do
         continue
     fi
     read title
-    if [[ ${title} == "Merge branch '"*"' into release-"* ]]; then
-        # skip temporary merge commits for calculating release notes
+    if [[ ${title} == "Merge branch '"*"' into"* ]]; then
+        # skip temporary merge commits and accidental merge commit inclusion
+        # for calcuating release notes.
         continue
     fi
 


### PR DESCRIPTION
A merge commit has snuck into our history, so we need to tolerate it
when running the release notes script :-(.
