### PR TITLE
:ghost: Don't do lazy discovery by default

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -313,7 +313,7 @@ func setOptionsDefaults(options Options) Options {
 
 	if options.MapperProvider == nil {
 		options.MapperProvider = func(c *rest.Config) (meta.RESTMapper, error) {
-			return apiutil.NewDynamicRESTMapper(c, apiutil.WithLazyDiscovery)
+			return apiutil.NewDynamicRESTMapper(c)
 		}
 	}
 


### PR DESCRIPTION
The DynamicRESTMapper PR accidentally set lazy discovery by default.  To
avoid causing confusion, I think we should stick with eager discovery by
default, at least for now.
