### PR TITLE
:sparkles: Add support for multi-value KUBECONFIG

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -20,8 +20,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"os/user"
-	"path/filepath"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -100,30 +98,30 @@ func loadConfig(context string) (*rest.Config, error) {
 
 	// If a flag is specified with the config location, use that
 	if len(kubeconfig) > 0 {
-		return loadConfigWithContext(apiServerURL, kubeconfig, context)
+		return loadConfigWithContext(apiServerURL, &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}, context)
 	}
-	// If an env variable is specified with the config location, use that
-	if len(os.Getenv("KUBECONFIG")) > 0 {
-		return loadConfigWithContext(apiServerURL, os.Getenv("KUBECONFIG"), context)
-	}
-	// If no explicit location, try the in-cluster config
-	if c, err := rest.InClusterConfig(); err == nil {
-		return c, nil
-	}
-	// If no in-cluster config, try the default location in the user's home directory
-	if usr, err := user.Current(); err == nil {
-		if c, err := loadConfigWithContext(apiServerURL, filepath.Join(usr.HomeDir, ".kube", "config"),
-			context); err == nil {
+
+	// If the recommended kubeconfig env variable is not specified,
+	// try the in-cluster config.
+	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
+	if len(kubeconfigPath) == 0 {
+		if c, err := rest.InClusterConfig(); err == nil {
 			return c, nil
 		}
+	}
+
+	// If the recommended kubeconfig env variable is set, or there
+	// is no in-cluster config, try the default recommended locations.
+	if c, err := loadConfigWithContext(apiServerURL, clientcmd.NewDefaultClientConfigLoadingRules(), context); err == nil {
+		return c, nil
 	}
 
 	return nil, fmt.Errorf("could not locate a kubeconfig")
 }
 
-func loadConfigWithContext(apiServerURL, kubeconfig, context string) (*rest.Config, error) {
+func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoader, context string) (*rest.Config, error) {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig},
+		loader,
 		&clientcmd.ConfigOverrides{
 			ClusterInfo: clientcmdapi.Cluster{
 				Server: apiServerURL,

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -93,6 +93,11 @@ func GetConfigWithContext(context string) (*rest.Config, error) {
 	return cfg, nil
 }
 
+// loadInClusterConfig is a function used to load the in-cluster
+// Kubernetes client config. This variable makes is possible to
+// test the precedence of loading the config.
+var loadInClusterConfig = rest.InClusterConfig
+
 // loadConfig loads a REST Config as per the rules specified in GetConfig
 func loadConfig(context string) (*rest.Config, error) {
 
@@ -105,7 +110,7 @@ func loadConfig(context string) (*rest.Config, error) {
 	// try the in-cluster config.
 	kubeconfigPath := os.Getenv(clientcmd.RecommendedConfigPathEnvVar)
 	if len(kubeconfigPath) == 0 {
-		if c, err := rest.InClusterConfig(); err == nil {
+		if c, err := loadInClusterConfig(); err == nil {
 			return c, nil
 		}
 	}

--- a/pkg/client/config/config_suite_test.go
+++ b/pkg/client/config/config_suite_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Client Config Test Suite", []Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
+
+	close(done)
+}, 60)

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type testCase struct {
+	text           string
+	apiServerURL   string
+	context        string
+	kubeconfigFlag string
+	kubeconfigEnv  []string
+	wantHost       string
+}
+
+var _ = Describe("Config", func() {
+
+	var dir string
+
+	origRecommendedHomeFile := clientcmd.RecommendedHomeFile
+
+	kubeconfigFiles := map[string]string{
+		"kubeconfig-flag":          genKubeconfig("from-flag"),
+		"kubeconfig-multi-context": genKubeconfig("ctx-1", "ctx-2"),
+		"kubeconfig-env-1":         genKubeconfig("from-env-1"),
+		"kubeconfig-env-2":         genKubeconfig("from-env-2"),
+		".kubeconfig":              genKubeconfig("from-home"),
+	}
+
+	BeforeEach(func() {
+		// create temporary directory for test case
+		var err error
+		dir, err = ioutil.TempDir("", "cr-test")
+		Expect(err).NotTo(HaveOccurred())
+
+		// override $HOME/.kube/config
+		clientcmd.RecommendedHomeFile = filepath.Join(dir, ".kubeconfig")
+	})
+
+	AfterEach(func() {
+		os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
+		kubeconfig = ""
+		apiServerURL = ""
+		clientcmd.RecommendedHomeFile = origRecommendedHomeFile
+
+		err := os.RemoveAll(dir)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Describe("GetConfigWithContext", func() {
+		Context("when kubeconfig files don't exist", func() {
+			It("should fail", func() {
+				cfg, err := GetConfigWithContext("")
+				Expect(cfg).To(BeNil())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
+		Context("when kubeconfig files exist", func() {
+			BeforeEach(func() {
+				err := createFiles(kubeconfigFiles, dir)
+				Expect(err).NotTo(HaveOccurred())
+			})
+			testCases := []testCase{
+				{
+					text:           "should use the --kubeconfig flag",
+					kubeconfigFlag: "kubeconfig-flag",
+					wantHost:       "from-flag",
+				},
+				{
+					text:          "should use the envvar",
+					kubeconfigEnv: []string{"kubeconfig-multi-context"},
+					wantHost:      "ctx-1",
+				},
+				{
+					text:     "should use the recommended home file",
+					wantHost: "from-home",
+				},
+				{
+					text:           "should prefer the flag over the envvar",
+					kubeconfigFlag: "kubeconfig-flag",
+					kubeconfigEnv:  []string{"kubeconfig-multi-context"},
+					wantHost:       "from-flag",
+				},
+				{
+					text:          "should prefer the envar over the recommended home file",
+					kubeconfigEnv: []string{"kubeconfig-multi-context"},
+					wantHost:      "ctx-1",
+				},
+				{
+					text:          "should allow overriding the API server URL",
+					apiServerURL:  "override",
+					kubeconfigEnv: []string{"kubeconfig-multi-context"},
+					wantHost:      "override",
+				},
+				{
+					text:          "should allow overriding the context",
+					context:       "ctx-2",
+					kubeconfigEnv: []string{"kubeconfig-multi-context"},
+					wantHost:      "ctx-2",
+				},
+				{
+					text:          "should support a multi-value envvar",
+					context:       "from-env-2",
+					kubeconfigEnv: []string{"kubeconfig-env-1", "kubeconfig-env-2"},
+					wantHost:      "from-env-2",
+				},
+			}
+
+			for _, testCase := range testCases {
+				tc := testCase
+				It(tc.text, func() {
+					// set global and environment configs
+					setConfigs(tc, dir)
+
+					// run the test
+					cfg, err := GetConfigWithContext(tc.context)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(cfg.Host).To(Equal(tc.wantHost))
+				})
+			}
+		})
+	})
+})
+
+func setConfigs(tc testCase, dir string) {
+	// Set API Server URL
+	apiServerURL = tc.apiServerURL
+
+	// Set kubeconfig flag value
+	if len(tc.kubeconfigFlag) > 0 {
+		kubeconfig = filepath.Join(dir, tc.kubeconfigFlag)
+	}
+
+	// Set KUBECONFIG env value
+	if len(tc.kubeconfigEnv) > 0 {
+		kubeconfigEnvPaths := []string{}
+		for _, k := range tc.kubeconfigEnv {
+			kubeconfigEnvPaths = append(kubeconfigEnvPaths, filepath.Join(dir, k))
+		}
+		os.Setenv(clientcmd.RecommendedConfigPathEnvVar, strings.Join(kubeconfigEnvPaths, ":"))
+	}
+}
+
+func createFiles(files map[string]string, dir string) error {
+	for path, data := range files {
+		if err := ioutil.WriteFile(filepath.Join(dir, path), []byte(data), 0644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func genKubeconfig(contexts ...string) string {
+	var sb strings.Builder
+	sb.WriteString(`---
+apiVersion: v1
+kind: Config
+clusters:
+`)
+	for _, ctx := range contexts {
+		sb.WriteString(`- cluster:
+    server: ` + ctx + `
+  name: ` + ctx + `
+`)
+	}
+	sb.WriteString("contexts:\n")
+	for _, ctx := range contexts {
+		sb.WriteString(`- context:
+    cluster: ` + ctx + `
+    user: ` + ctx + `
+  name: ` + ctx + `
+`)
+	}
+
+	sb.WriteString("users:\n")
+	for _, ctx := range contexts {
+		sb.WriteString(`- name: ` + ctx + `
+`)
+	}
+	sb.WriteString("preferences: {}\n")
+	if len(contexts) > 0 {
+		sb.WriteString("current-context: " + contexts[0] + "\n")
+	}
+
+	return sb.String()
+}


### PR DESCRIPTION
This PR adds support in `pkg/client/config.GetConfig()` and `pkg/client/config.GetConfigWithContext()` to handle multi-value KUBECONFIG environment variable values, as documented in the [docs about kubeconfig](https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/#set-the-kubeconfig-environment-variable).

It also adds unit tests, which test config loading for the kubeconfig flag, environment variable, and default home directory location. In-cluster configurations are not tested because they require files to exist in hard-coded file system locations.

Closes #564
