### PR TITLE
:sparkles: add 10% jitter to ResyncPeriod

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -93,7 +93,10 @@ type Options struct {
 	// Mapper is the RESTMapper to use for mapping GroupVersionKinds to Resources
 	Mapper meta.RESTMapper
 
-	// Resync is the resync period. Defaults to defaultResyncTime.
+	// Resync is the base frequency the informers are resynced.
+	// Defaults to defaultResyncTime.
+	// A 10 percent jitter will be added to the Resync period between informers
+	// So that all informers will not send list requests simultaneously.
 	Resync *time.Duration
 
 	// Namespace restricts the cache's ListWatch to the desired namespace

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -111,6 +111,8 @@ type Options struct {
 	// reconciled. A lower period will correct entropy more quickly, but reduce
 	// responsiveness to change if there are many watched resources. Change this
 	// value only if you know what you are doing. Defaults to 10 hours if unset.
+	// there will a 10 percent jitter between the SyncPeriod of all controllers
+	// so that all controllers will not send list requests simultaneously.
 	SyncPeriod *time.Duration
 
 	// LeaderElection determines whether or not to use leader election when


### PR DESCRIPTION
all informers use the same resync period, this may cause multi controllers send list requests to apiserver simultaneously, add a jitter to resync period would be better.
fixes #648 

this pr uses `ResyncPeriod ` to add a jitter to the `SyncPeriod` option before finally pass to the `NewInformer` func