### PR TITLE
:bug: prevent controller.New and manager's errChan from leaking goroutines

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -80,13 +80,15 @@ func New(name string, mgr manager.Manager, options Options) (Controller, error) 
 
 	// Create controller with dependencies set
 	c := &controller.Controller{
-		Do:                      options.Reconciler,
-		Cache:                   mgr.GetCache(),
-		Config:                  mgr.GetConfig(),
-		Scheme:                  mgr.GetScheme(),
-		Client:                  mgr.GetClient(),
-		Recorder:                mgr.GetEventRecorderFor(name),
-		Queue:                   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name),
+		Do:       options.Reconciler,
+		Cache:    mgr.GetCache(),
+		Config:   mgr.GetConfig(),
+		Scheme:   mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Recorder: mgr.GetEventRecorderFor(name),
+		MakeQueue: func() workqueue.RateLimitingInterface {
+			return workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), name)
+		},
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
 		Name:                    name,
 	}

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -68,6 +68,11 @@ type Controller struct {
 	// specified, or the ~/.kube/Config.
 	Config *rest.Config
 
+	// MakeQueue constructs the queue for this controller once the controller is ready to start.
+	// This exists because the standard Kubernetes workqueues start themselves immediately, which
+	// leads to goroutine leaks if something calls controller.New repeatedly.
+	MakeQueue func() workqueue.RateLimitingInterface
+
 	// Queue is an listeningQueue that listens for events from Informers and adds object keys to
 	// the Queue for processing
 	Queue workqueue.RateLimitingInterface
@@ -93,6 +98,16 @@ type Controller struct {
 	Recorder record.EventRecorder
 
 	// TODO(community): Consider initializing a logger with the Controller Name as the tag
+
+	// watches maintains a list of sources, handlers, and predicates to start when the controller is started.
+	watches []watchDescription
+}
+
+// watchDescription contains all the information necessary to start a watch.
+type watchDescription struct {
+	src        source.Source
+	handler    handler.EventHandler
+	predicates []predicate.Predicate
 }
 
 // Reconcile implements reconcile.Reconciler
@@ -118,47 +133,72 @@ func (c *Controller) Watch(src source.Source, evthdler handler.EventHandler, prc
 		}
 	}
 
-	log.Info("Starting EventSource", "controller", c.Name, "source", src)
-	return src.Start(evthdler, c.Queue, prct...)
+	c.watches = append(c.watches, watchDescription{src: src, handler: evthdler, predicates: prct})
+	if c.Started {
+		log.Info("Starting EventSource", "controller", c.Name, "source", src)
+		return src.Start(evthdler, c.Queue, prct...)
+	}
+
+	return nil
 }
 
 // Start implements controller.Controller
 func (c *Controller) Start(stop <-chan struct{}) error {
+	// use an IIFE to get proper lock handling
+	// but lock outside to get proper handling of the queue shutdown
 	c.mu.Lock()
 
-	// TODO(pwittrock): Reconsider HandleCrash
-	defer utilruntime.HandleCrash()
-	defer c.Queue.ShutDown()
+	c.Queue = c.MakeQueue()
+	defer c.Queue.ShutDown() // needs to be outside the iife so that we shutdown after the stop channel is closed
 
-	// Start the SharedIndexInformer factories to begin populating the SharedIndexInformer caches
-	log.Info("Starting Controller", "controller", c.Name)
+	err := func() error {
+		defer c.mu.Unlock()
 
-	// Wait for the caches to be synced before starting workers
-	if c.WaitForCacheSync == nil {
-		c.WaitForCacheSync = c.Cache.WaitForCacheSync
-	}
-	if ok := c.WaitForCacheSync(stop); !ok {
-		// This code is unreachable right now since WaitForCacheSync will never return an error
-		// Leaving it here because that could happen in the future
-		err := fmt.Errorf("failed to wait for %s caches to sync", c.Name)
-		log.Error(err, "Could not wait for Cache to sync", "controller", c.Name)
-		c.mu.Unlock()
+		// TODO(pwittrock): Reconsider HandleCrash
+		defer utilruntime.HandleCrash()
+
+		// NB(directxman12): launch the sources *before* trying to wait for the
+		// caches to sync so that they have a chance to register their intendeded
+		// caches.
+		for _, watch := range c.watches {
+			log.Info("Starting EventSource", "controller", c.Name, "source", watch.src)
+			if err := watch.src.Start(watch.handler, c.Queue, watch.predicates...); err != nil {
+				return err
+			}
+		}
+
+		// Start the SharedIndexInformer factories to begin populating the SharedIndexInformer caches
+		log.Info("Starting Controller", "controller", c.Name)
+
+		// Wait for the caches to be synced before starting workers
+		if c.WaitForCacheSync == nil {
+			c.WaitForCacheSync = c.Cache.WaitForCacheSync
+		}
+		if ok := c.WaitForCacheSync(stop); !ok {
+			// This code is unreachable right now since WaitForCacheSync will never return an error
+			// Leaving it here because that could happen in the future
+			err := fmt.Errorf("failed to wait for %s caches to sync", c.Name)
+			log.Error(err, "Could not wait for Cache to sync", "controller", c.Name)
+			return err
+		}
+
+		if c.JitterPeriod == 0 {
+			c.JitterPeriod = 1 * time.Second
+		}
+
+		// Launch workers to process resources
+		log.Info("Starting workers", "controller", c.Name, "worker count", c.MaxConcurrentReconciles)
+		for i := 0; i < c.MaxConcurrentReconciles; i++ {
+			// Process work items
+			go wait.Until(c.worker, c.JitterPeriod, stop)
+		}
+
+		c.Started = true
+		return nil
+	}()
+	if err != nil {
 		return err
 	}
-
-	if c.JitterPeriod == 0 {
-		c.JitterPeriod = 1 * time.Second
-	}
-
-	// Launch workers to process resources
-	log.Info("Starting workers", "controller", c.Name, "worker count", c.MaxConcurrentReconciles)
-	for i := 0; i < c.MaxConcurrentReconciles; i++ {
-		// Process work items
-		go wait.Until(c.worker, c.JitterPeriod, stop)
-	}
-
-	c.Started = true
-	c.mu.Unlock()
 
 	<-stop
 	log.Info("Stopping workers", "controller", c.Name)

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -455,6 +455,9 @@ func (cm *controllerManager) startNonLeaderElectionRunnables() {
 			if err := ctrl.Start(cm.internalStop); err != nil {
 				cm.errSignal.SignalError(err)
 			}
+			// we use %T here because we don't have a good stand-in for "name",
+			// and the full runnable might not serialize (mutexes, etc)
+			log.V(1).Info("non-leader-election runnable finished", "runnable type", fmt.Sprintf("%T", ctrl))
 		}()
 	}
 }
@@ -474,6 +477,9 @@ func (cm *controllerManager) startLeaderElectionRunnables() {
 			if err := ctrl.Start(cm.internalStop); err != nil {
 				cm.errSignal.SignalError(err)
 			}
+			// we use %T here because we don't have a good stand-in for "name",
+			// and the full runnable might not serialize (mutexes, etc)
+			log.V(1).Info("leader-election runnable finished", "runnable type", fmt.Sprintf("%T", ctrl))
 		}()
 	}
 

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -114,7 +114,11 @@ type controllerManager struct {
 	started        bool
 	startedLeader  bool
 	healthzStarted bool
-	errChan        chan error
+
+	// NB(directxman12): we don't just use an error channel here to avoid the situation where the
+	// error channel is too small and we end up blocking some goroutines waiting to report their errors.
+	// errSignal lets us track when we should stop because an error occurred
+	errSignal *errSignaler
 
 	// internalStop is the stop channel *actually* used by everything involved
 	// with the manager as a stop channel, so that we can pass a stop channel
@@ -150,6 +154,51 @@ type controllerManager struct {
 	retryPeriod time.Duration
 }
 
+type errSignaler struct {
+	// errSignal indicates that an error occurred, when closed.  It shouldn't
+	// be written to.
+	errSignal chan struct{}
+
+	// err is the received error
+	err error
+
+	mu sync.Mutex
+}
+
+func (r *errSignaler) SignalError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err == nil {
+		// non-error, ignore
+		log.Error(nil, "SignalError called without an (with a nil) error, which should never happen, ignoring")
+		return
+	}
+
+	if r.err != nil {
+		// we already have an error, don't try again
+		return
+	}
+
+	// save the error and report it
+	r.err = err
+	close(r.errSignal)
+}
+
+func (r *errSignaler) Error() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.err
+}
+
+func (r *errSignaler) GotError() chan struct{} {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.errSignal
+}
+
 // Add sets dependencies on i, and adds it to the list of Runnables to start.
 func (cm *controllerManager) Add(r Runnable) error {
 	cm.mu.Lock()
@@ -174,7 +223,9 @@ func (cm *controllerManager) Add(r Runnable) error {
 	if shouldStart {
 		// If already started, start the controller
 		go func() {
-			cm.errChan <- r.Start(cm.internalStop)
+			if err := r.Start(cm.internalStop); err != nil {
+				cm.errSignal.SignalError(err)
+			}
 		}()
 	}
 
@@ -304,7 +355,7 @@ func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {
 	go func() {
 		log.Info("starting metrics server", "path", metricsPath)
 		if err := server.Serve(cm.metricsListener); err != nil && err != http.ErrServerClosed {
-			cm.errChan <- err
+			cm.errSignal.SignalError(err)
 		}
 	}()
 
@@ -312,7 +363,7 @@ func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {
 	select {
 	case <-stop:
 		if err := server.Shutdown(context.Background()); err != nil {
-			cm.errChan <- err
+			cm.errSignal.SignalError(err)
 		}
 	}
 }
@@ -334,7 +385,7 @@ func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
 	// Run server
 	go func() {
 		if err := server.Serve(cm.healthProbeListener); err != nil && err != http.ErrServerClosed {
-			cm.errChan <- err
+			cm.errSignal.SignalError(err)
 		}
 	}()
 	cm.healthzStarted = true
@@ -344,7 +395,7 @@ func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
 	select {
 	case <-stop:
 		if err := server.Shutdown(context.Background()); err != nil {
-			cm.errChan <- err
+			cm.errSignal.SignalError(err)
 		}
 	}
 }
@@ -352,6 +403,9 @@ func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
 func (cm *controllerManager) Start(stop <-chan struct{}) error {
 	// join the passed-in stop channel as an upstream feeding into cm.internalStopper
 	defer close(cm.internalStopper)
+
+	// initialize this here so that we reset the signal channel state on every start
+	cm.errSignal = &errSignaler{errSignal: make(chan struct{})}
 
 	// Metrics should be served whether the controller is leader or not.
 	// (If we don't serve metrics for non-leaders, prometheus will still scrape
@@ -380,9 +434,9 @@ func (cm *controllerManager) Start(stop <-chan struct{}) error {
 	case <-stop:
 		// We are done
 		return nil
-	case err := <-cm.errChan:
+	case <-cm.errSignal.GotError():
 		// Error starting a controller
-		return err
+		return cm.errSignal.Error()
 	}
 }
 
@@ -398,7 +452,9 @@ func (cm *controllerManager) startNonLeaderElectionRunnables() {
 		// Write any Start errors to a channel so we can return them
 		ctrl := c
 		go func() {
-			cm.errChan <- ctrl.Start(cm.internalStop)
+			if err := ctrl.Start(cm.internalStop); err != nil {
+				cm.errSignal.SignalError(err)
+			}
 		}()
 	}
 }
@@ -415,7 +471,9 @@ func (cm *controllerManager) startLeaderElectionRunnables() {
 		// Write any Start errors to a channel so we can return them
 		ctrl := c
 		go func() {
-			cm.errChan <- ctrl.Start(cm.internalStop)
+			if err := ctrl.Start(cm.internalStop); err != nil {
+				cm.errSignal.SignalError(err)
+			}
 		}()
 	}
 
@@ -433,7 +491,7 @@ func (cm *controllerManager) waitForCache() {
 	}
 	go func() {
 		if err := cm.startCache(cm.internalStop); err != nil {
-			cm.errChan <- err
+			cm.errSignal.SignalError(err)
 		}
 	}()
 
@@ -457,7 +515,7 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 				// Most implementations of leader election log.Fatal() here.
 				// Since Start is wrapped in log.Fatal when called, we can just return
 				// an error here which will cause the program to exit.
-				cm.errChan <- fmt.Errorf("leader election lost")
+				cm.errSignal.SignalError(fmt.Errorf("leader election lost"))
 			},
 		},
 	})

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -291,7 +291,6 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	return &controllerManager{
 		config:                config,
 		scheme:                options.Scheme,
-		errChan:               make(chan error),
 		cache:                 cache,
 		fieldIndexes:          cache,
 		client:                writeObj,

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -283,7 +283,7 @@ var _ = Describe("manger.Manager", func() {
 				mgr.startCache = func(stop <-chan struct{}) error {
 					return fmt.Errorf("expected error")
 				}
-				Expect(m.Start(stop).Error()).To(ContainSubstring("expected error"))
+				Expect(m.Start(stop)).To(MatchError(ContainSubstring("expected error")))
 
 				close(done)
 			})
@@ -314,7 +314,9 @@ var _ = Describe("manger.Manager", func() {
 
 				go func() {
 					defer GinkgoRecover()
-					Expect(m.Start(stop)).NotTo(HaveOccurred())
+					// NB(directxman12): this should definitely return an error.  If it doesn't happen,
+					// it means someone was signaling "stop: error" with a nil "error".
+					Expect(m.Start(stop)).NotTo(Succeed())
 					close(done)
 				}()
 				<-c1


### PR DESCRIPTION
This prevents a couple of goroutine leaks related to the controller and manager logic.

The first is in controller: `controller.New` previously created a new workqueue, which launched goroutines expecting to be stopped with `Shutdown`.  This is semi-unexpected in CR, since we generally state that things don't happen until Start is called (and, indeed, we don't call shutdown unless start is called).  This means that calling `controller.New` without ever starting the controller will cause a goroutine leak.  We fix this by delaying workqueue initialization (and consequently source starting) until the controller's Start is called.

The second is in the manager's handling of errors -- we used to use an error channel to report errors from internal goroutines and runnables.  However, we only ever read the first error from the channel, and it was a non-buffered channel.  This meant that if multiple things tried to return results on the channel, all but one would block forever.  This was exacerbated by the fact that the goroutines that launched controllers tried to return all results (nil values) on the channel, not just errors.  We fix this by using a mutex to save a single error, using a channel's closing to signal shutdown *only*, and by only ever returning non-nil errors via the error signaler.  This means that the only blocking is ever on a short-duration mutex.

Fixes #649 