### PR TITLE
:bug: pkg/log/zap: use enabled in UseDevMode, add tests

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -82,7 +82,7 @@ type Opts func(*Options)
 // See Options.Development
 func UseDevMode(enabled bool) Opts {
 	return func(o *Options) {
-		o.Development = true
+		o.Development = enabled
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug where `func UseDevMode(enabled bool)` always sets the `Development` option to `true`, regardless of the value of `enabled`.

This PR also adds tests for the `New()` function and the `Opts`-related functions.
