### PR TITLE
:bug: Fix builder `For` and `Watches` method conflict

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -157,11 +157,13 @@ func (blder *Builder) Build(r reconcile.Reconciler) (controller.Controller, erro
 
 func (blder *Builder) doWatch() error {
 	// Reconcile type
-	src := &source.Kind{Type: blder.apiType}
-	hdler := &handler.EnqueueRequestForObject{}
-	err := blder.ctrl.Watch(src, hdler, blder.predicates...)
-	if err != nil {
-		return err
+	if blder.apiType != nil {
+		src := &source.Kind{Type: blder.apiType}
+		hdler := &handler.EnqueueRequestForObject{}
+		err := blder.ctrl.Watch(src, hdler, blder.predicates...)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Watches the managed types


### PR DESCRIPTION
If `For` method has been used, there is no way to specify own eventhandler. But if `Watches` method is used, an error of lacking object will happend when no apiType is passed.
If both `For` and `Watches` are used with same apiType, the later one will be ignored as it has been watched. Just add nil assertion to avoid object type error.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
