### PR TITLE
:sparkles: webhook/TLS: use a read lock for new connections

### DIFF
--- a/pkg/webhook/internal/certwatcher/certwatcher.go
+++ b/pkg/webhook/internal/certwatcher/certwatcher.go
@@ -30,7 +30,7 @@ var log = logf.RuntimeLog.WithName("certwatcher")
 // changes, it reads and parses both and calls an optional callback with the new
 // certificate.
 type CertWatcher struct {
-	sync.Mutex
+	sync.RWMutex
 
 	currentCert *tls.Certificate
 	watcher     *fsnotify.Watcher
@@ -63,8 +63,8 @@ func New(certPath, keyPath string) (*CertWatcher, error) {
 
 // GetCertificate fetches the currently loaded certificate, which may be nil.
 func (cw *CertWatcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
-	cw.Lock()
-	defer cw.Unlock()
+	cw.RLock()
+	defer cw.RUnlock()
 	return cw.currentCert, nil
 }
 


### PR DESCRIPTION
This allows to have multiple new client connections at the same time, without locking.

The certificate updater, use the regular lock for writes.