### PR TITLE
:sparkles: envtest set service-cluster-ip-range if user not set

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -68,6 +68,7 @@ var DefaultKubeAPIServerFlags = []string{
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
 	"--admission-control=AlwaysAdmit",
+	"--service-cluster-ip-range=10.0.0.0/24",
 }
 
 // Environment creates a Kubernetes test environment that will start / stop the Kubernetes control plane and
@@ -131,6 +132,17 @@ func (te Environment) getAPIServerFlags() []string {
 	// Set default API server flags if not set.
 	if len(te.KubeAPIServerFlags) == 0 {
 		return DefaultKubeAPIServerFlags
+	}
+	// Check KubeAPIServerFlags contains service-cluster-ip-range, if not, set default value to service-cluster-ip-range
+	containServiceClusterIPRange := false
+	for _, flag := range te.KubeAPIServerFlags {
+		if strings.Contains(flag, "service-cluster-ip-range") {
+			containServiceClusterIPRange = true
+			break
+		}
+	}
+	if !containServiceClusterIPRange {
+		te.KubeAPIServerFlags = append(te.KubeAPIServerFlags, "--service-cluster-ip-range=10.0.0.0/24")
 	}
 	return te.KubeAPIServerFlags
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
fix #641 
service-cluster-ip-range is no longer going to be defaulted after 1.16, so if user not set service-cluster-ip-range, add default value(10.0.0.0/24) to envtest set