### PR TITLE
🐛 Fix informer cache creating pointers to pointers

### DIFF
--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -93,7 +93,11 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 		}
 		// http://knowyourmeme.com/memes/this-is-fine
 		elemType := reflect.Indirect(reflect.ValueOf(itemsPtr)).Type().Elem()
-		cacheTypeValue := reflect.Zero(reflect.PtrTo(elemType))
+		if elemType.Kind() != reflect.Ptr {
+			elemType = reflect.PtrTo(elemType)
+		}
+
+		cacheTypeValue := reflect.Zero(elemType)
 		var ok bool
 		cacheTypeObj, ok = cacheTypeValue.Interface().(runtime.Object)
 		if !ok {


### PR DESCRIPTION
Fixes #656

It appears the code in controller-runtime/pkg/cache/informer_cache.go tries to determine whether the items can be cast to runtime.Object and in the process assumes that the slice's elements are not pointers.

This means that if you have a List whose Items type is `[]*Item` the informer cache will create a `cacheTypeValue` of `**Item` which then cannot be case to `runtime.Object` resulting in an error of:

```
"error": "cannot get cache for *v1.PrometheusRuleList, its element **v1.PrometheusRule is not a runtime.Object"}
```