### PR TITLE
🐛 Fix delete example not setting metadata properly for CRDs

### DIFF
--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -187,10 +187,8 @@ func ExampleClient_delete() {
 
 	// Using a unstructured object.
 	u := &unstructured.Unstructured{}
-	u.Object = map[string]interface{}{
-		"name":      "name",
-		"namespace": "namespace",
-	}
+	u.SetName("name")
+	u.SetNamespace("namespace")
 	u.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   "apps",
 		Kind:    "Deployment",


### PR DESCRIPTION
`name` and `namespace` should go into the metadata of the `unstructured.Unstructured` object. 
