### PR TITLE
🐛 cross-namespace owner references should be disallowed

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -60,6 +60,17 @@ func SetControllerReference(owner, object metav1.Object, scheme *runtime.Scheme)
 		return fmt.Errorf("%T is not a runtime.Object, cannot call SetControllerReference", owner)
 	}
 
+	ownerNs := owner.GetNamespace()
+	if ownerNs != "" {
+		objNs := object.GetNamespace()
+		if objNs == "" {
+			return fmt.Errorf("cluster-scoped resource must not have a namespace-scoped owner, owner's namespace %s", ownerNs)
+		}
+		if ownerNs != objNs {
+			return fmt.Errorf("cross-namespace owner references are disallowed, owner's namespace %s, obj's namespace %s", owner.GetNamespace(), object.GetNamespace())
+		}
+	}
+
 	gvk, err := apiutil.GVKForObject(ro, scheme)
 	if err != nil {
 		return err

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -115,6 +115,24 @@ var _ = Describe("Controllerutil", func() {
 				BlockOwnerDeletion: &t,
 			}))
 		})
+
+		It("should return an error if it's setting a cross-namespace owner reference", func() {
+			rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "namespace1"}}
+			dep := &extensionsv1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "namespace2", UID: "foo-uid"}}
+
+			err := controllerutil.SetControllerReference(dep, rs, scheme.Scheme)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error if it's owner is namespaced resource but dependant is cluster-scoped resource", func() {
+			pv := &corev1.PersistentVolume{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "foo-uid"}}
+
+			err := controllerutil.SetControllerReference(pod, pv, scheme.Scheme)
+
+			Expect(err).To(HaveOccurred())
+		})
 	})
 
 	Describe("CreateOrUpdate", func() {


### PR DESCRIPTION
Based on https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#owners-and-dependents, cross-namespace owner references are disallowed by design. The `SetControllerReference()` should prevent owner reference from setting on dependents in different namespace.