### PR TITLE
:bug: InformerCache: Do not require leader lease

### DIFF
--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -140,6 +140,12 @@ func (ip *informerCache) GetInformer(obj runtime.Object) (Informer, error) {
 	return i.Informer, err
 }
 
+// NeedLeaderElection implements the LeaderElectionRunnable interface
+// to indicate that this can be started without requiring the leader lock
+func (ip *informerCache) NeedLeaderElection() bool {
+	return false
+}
+
 // IndexField adds an indexer to the underlying cache, using extraction function to get
 // value(s) from the given field.  This index can then be used by passing a field selector
 // to List. For one-to-one compatibility with "normal" field selectors, only return one value.

--- a/pkg/cache/informer_cache_test.go
+++ b/pkg/cache/informer_cache_test.go
@@ -1,0 +1,28 @@
+package cache_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+var _ = Describe("informerCache", func() {
+	It("should not require LeaderElection", func() {
+		cfg := &rest.Config{}
+
+		mapper, err := apiutil.NewDynamicRESTMapper(cfg, apiutil.WithLazyDiscovery)
+		Expect(err).ToNot(HaveOccurred())
+
+		c, err := cache.New(cfg, cache.Options{Mapper: mapper})
+		Expect(err).ToNot(HaveOccurred())
+
+		leaderElectionRunnable, ok := c.(manager.LeaderElectionRunnable)
+		Expect(ok).To(BeTrue())
+		Expect(leaderElectionRunnable.NeedLeaderElection()).To(BeFalse())
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This PR makes the `informerCache` implement the `LeaderElectionRunnable` interface to signal that it doesn't need leader election. This is done so other `runnables` that also do not need leader election can use the cache-backed reader.

Fixes #677
