### PR TITLE
:sparkles:handle unstructured objects correctly in fake client

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -106,6 +106,17 @@ func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.
 	if err != nil {
 		return err
 	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
+
 	j, err := json.Marshal(o)
 	if err != nil {
 		return err
@@ -121,6 +132,8 @@ func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...clien
 		return err
 	}
 
+	OriginalKind := gvk.Kind
+
 	if !strings.HasSuffix(gvk.Kind, "List") {
 		return fmt.Errorf("non-list type %T (kind %q) passed as output", obj, gvk)
 	}
@@ -135,6 +148,13 @@ func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...clien
 	if err != nil {
 		return err
 	}
+
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(OriginalKind)
+
 	j, err := json.Marshal(o)
 	if err != nil {
 		return err
@@ -287,6 +307,16 @@ func (c *fakeClient) Patch(ctx context.Context, obj runtime.Object, patch client
 	if !handled {
 		panic("tracker could not handle patch method")
 	}
+
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+	ta, err := meta.TypeAccessor(o)
+	if err != nil {
+		return err
+	}
+	ta.SetKind(gvk.Kind)
 
 	j, err := json.Marshal(o)
 	if err != nil {

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 /*
+Deprecated: please use pkg/envtest for testing. This package will be dropped
+before the v1.0.0 release.
 Package fake provides a fake client for testing.
 
 An fake client is backed by its simple object store indexed by GroupVersionResource.


### PR DESCRIPTION
Set Kind correctly for unstructured objects 

```
unmarshalerDecoder: Object 'Kind' is missing in '{\"metadata\":{},\"items\":[{\"kind\":\"Deployment\",\"metadata\":{\"name\":\"test-deployment\",\"namespace\":\"ns1\",\"creationTimestamp\":null},\"spec\":{\"selector\":null,\"template\":{\"metadata\":{\"creationTimestamp\":null},\"spec\":{\"containers\":null}},\"strategy\":{}},\"status\":{}},{\"kind\":\"Deployment\",\"metadata\":{\"name\":\"test-deployment-2\",\"namespace\":\"ns1\",\"creationTimestamp\":null,\"labels\":{\"test-label\":\"label-value\"}},\"spec\":{\"selector\":null,\"template\":{\"metadata\":{\"creationTimestamp\":null},\"spec\":{\"containers\":null}},\"strategy\":{}},\"status\":{}}]}', error found in #10 byte of ...|tus\":{}}]}|..., bigger context ...|{\"containers\":null}},\"strategy\":{}},\"status\":{}}]}|...
```