### PR TITLE
:ghost:add apiversion handling to fake client

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -116,6 +116,7 @@ func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj runtime.
 		return err
 	}
 	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
 
 	j, err := json.Marshal(o)
 	if err != nil {
@@ -154,6 +155,7 @@ func (c *fakeClient) List(ctx context.Context, obj runtime.Object, opts ...clien
 		return err
 	}
 	ta.SetKind(OriginalKind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
 
 	j, err := json.Marshal(o)
 	if err != nil {
@@ -317,6 +319,7 @@ func (c *fakeClient) Patch(ctx context.Context, obj runtime.Object, patch client
 		return err
 	}
 	ta.SetKind(gvk.Kind)
+	ta.SetAPIVersion(gvk.GroupVersion().String())
 
 	j, err := json.Marshal(o)
 	if err != nil {

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -41,7 +41,8 @@ var _ = Describe("Fake client", func() {
 	BeforeEach(func() {
 		dep = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
-				Kind: "Deployment",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-deployment",
@@ -50,7 +51,8 @@ var _ = Describe("Fake client", func() {
 		}
 		dep2 = &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
-				Kind: "Deployment",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-deployment-2",
@@ -62,7 +64,8 @@ var _ = Describe("Fake client", func() {
 		}
 		cm = &corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
-				Kind: "ConfigMap",
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-cm",
@@ -135,7 +138,8 @@ var _ = Describe("Fake client", func() {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "ConfigMap",
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "new-test-cm",
@@ -161,7 +165,8 @@ var _ = Describe("Fake client", func() {
 			By("Updating a new configmap")
 			newcm := &corev1.ConfigMap{
 				TypeMeta: metav1.TypeMeta{
-					Kind: "ConfigMap",
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            "test-cm",


### PR DESCRIPTION
This is a followup PR of #682.
After examining https://github.com/kubernetes/kubernetes/pull/70087, it seems to be safer to also add APIVersion