### PR TITLE
:warning: Soft-bump to Go 1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime
 
-go 1.12
+go 1.13
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible


### PR DESCRIPTION
This soft-bumps to Go 1.13.  Mandatory Go 1.13 changes may follow in
future point releases (e.g. #606).
