### PR TITLE
✨ Add support for creating namespaced watches

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -53,9 +53,17 @@ type Informers interface {
 	// API kind and resource.
 	GetInformer(obj runtime.Object) (Informer, error)
 
+	// GetInformer fetches or constructs an informer for the given object that corresponds to a single
+	// API kind and resource.
+	GetInformerInNamespace(obj runtime.Object, namespace *string) (Informer, error)
+
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.
 	GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error)
+
+	// GetInformerForKindInNamespace is similar to GetInformerInNamespace, except that it takes a group-version-kind, instead
+	// of the underlying object.
+	GetInformerForKindInNamespace(gvk schema.GroupVersionKind, namespace *string) (Informer, error)
 
 	// Start runs all the informers known to this cache until the given channel is closed.
 	// It blocks.

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runt
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(gvk, out, &key.Namespace)
+	started, cache, err := ip.InformersMap.Get(gvk, out, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runt
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(gvk, out)
+	started, cache, err := ip.InformersMap.Get(gvk, out, &key.Namespace)
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 		}
 	}
 
-	started, cache, err := ip.InformersMap.Get(gvk, cacheTypeObj)
+	started, cache, err := ip.InformersMap.Get(gvk, cacheTypeObj, nil)
 	if err != nil {
 		return err
 	}
@@ -115,12 +115,16 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 
 // GetInformerForKind returns the informer for the GroupVersionKind
 func (ip *informerCache) GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error) {
+	return ip.GetInformerForKindInNamespace(gvk, nil)
+}
+
+func (ip *informerCache) GetInformerForKindInNamespace(gvk schema.GroupVersionKind, namespace *string) (Informer, error) {
 	// Map the gvk to an object
 	obj, err := ip.Scheme.New(gvk)
 	if err != nil {
 		return nil, err
 	}
-	_, i, err := ip.InformersMap.Get(gvk, obj)
+	_, i, err := ip.InformersMap.Get(gvk, obj, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -129,11 +133,15 @@ func (ip *informerCache) GetInformerForKind(gvk schema.GroupVersionKind) (Inform
 
 // GetInformer returns the informer for the obj
 func (ip *informerCache) GetInformer(obj runtime.Object) (Informer, error) {
+	return ip.GetInformerInNamespace(obj, nil)
+}
+
+func (ip *informerCache) GetInformerInNamespace(obj runtime.Object, namespace *string) (Informer, error) {
 	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
 	if err != nil {
 		return nil, err
 	}
-	_, i, err := ip.InformersMap.Get(gvk, obj)
+	_, i, err := ip.InformersMap.Get(gvk, obj, namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -50,6 +50,18 @@ func (c *FakeInformers) GetInformerForKind(gvk schema.GroupVersionKind) (cache.I
 	return c.informerFor(gvk, obj)
 }
 
+// GetInformerForKindInNamespace implements Informers
+func (c *FakeInformers) GetInformerForKindInNamespace(gvk schema.GroupVersionKind, namespace *string) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	obj, err := c.Scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return c.informerFor(gvk, obj)
+}
+
 // FakeInformerForKind implements Informers
 func (c *FakeInformers) FakeInformerForKind(gvk schema.GroupVersionKind) (*controllertest.FakeInformer, error) {
 	if c.Scheme == nil {
@@ -68,6 +80,19 @@ func (c *FakeInformers) FakeInformerForKind(gvk schema.GroupVersionKind) (*contr
 
 // GetInformer implements Informers
 func (c *FakeInformers) GetInformer(obj runtime.Object) (cache.Informer, error) {
+	if c.Scheme == nil {
+		c.Scheme = scheme.Scheme
+	}
+	gvks, _, err := c.Scheme.ObjectKinds(obj)
+	if err != nil {
+		return nil, err
+	}
+	gvk := gvks[0]
+	return c.informerFor(gvk, obj)
+}
+
+// GetInformerInNamespace implements Informers
+func (c *FakeInformers) GetInformerInNamespace(obj runtime.Object, namespace *string) (cache.Informer, error) {
 	if c.Scheme == nil {
 		c.Scheme = scheme.Scheme
 	}

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -73,16 +73,16 @@ func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
-func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object, namespace *string) (bool, *MapEntry, error) {
 	_, isUnstructured := obj.(*unstructured.Unstructured)
 	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
 	isUnstructured = isUnstructured || isUnstructuredList
 
 	if isUnstructured {
-		return m.unstructured.Get(gvk, obj)
+		return m.unstructured.Get(gvk, obj, namespace)
 	}
 
-	return m.structured.Get(gvk, obj)
+	return m.structured.Get(gvk, obj, namespace)
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -69,9 +69,12 @@ var _ Cache = &multiNamespaceCache{}
 
 // Methods for multiNamespaceCache to conform to the Informers interface
 func (c *multiNamespaceCache) GetInformer(obj runtime.Object) (Informer, error) {
+	return c.GetInformerInNamespace(obj, nil)
+}
+func (c *multiNamespaceCache) GetInformerInNamespace(obj runtime.Object, namespace *string) (Informer, error) {
 	informers := map[string]Informer{}
 	for ns, cache := range c.namespaceToCache {
-		informer, err := cache.GetInformer(obj)
+		informer, err := cache.GetInformerInNamespace(obj, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -81,9 +84,13 @@ func (c *multiNamespaceCache) GetInformer(obj runtime.Object) (Informer, error) 
 }
 
 func (c *multiNamespaceCache) GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error) {
+	return c.GetInformerForKindInNamespace(gvk, nil)
+}
+
+func (c *multiNamespaceCache) GetInformerForKindInNamespace(gvk schema.GroupVersionKind, namespace *string) (Informer, error) {
 	informers := map[string]Informer{}
 	for ns, cache := range c.namespaceToCache {
-		informer, err := cache.GetInformerForKind(gvk)
+		informer, err := cache.GetInformerForKindInNamespace(gvk, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -60,6 +60,9 @@ type Kind struct {
 	// Type is the type of object to watch.  e.g. &v1.Pod{}
 	Type runtime.Object
 
+	// Namespace is the namespace for watching the objects
+	Namespace *string
+
 	// cache used to watch APIs
 	cache cache.Cache
 }
@@ -82,7 +85,7 @@ func (ks *Kind) Start(handler handler.EventHandler, queue workqueue.RateLimiting
 	}
 
 	// Lookup the Informer from the Cache and add an EventHandler which populates the Queue
-	i, err := ks.cache.GetInformer(ks.Type)
+	i, err := ks.cache.GetInformerInNamespace(ks.Type, ks.Namespace)
 	if err != nil {
 		if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
 			log.Error(err, "if kind is a CRD, it should be installed before calling Start",


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

Extends the Source type with an optional Namespace parameter, which will override the default namespace by adding the namespace as a key in the informer map. Existing usage will remain as is, sharing the same key as before, whereas if namespace is specified, a new informer will be created for that case. 

This allows creating an operator watching resources in multiple namespaces without requiring cluster-wide privileges for that resource, as desired in #687 .

Simple tests suggest that it works for me, but there are probably pitfalls I have not considered.

I'd love some feedback on this approach and if you think this is the right or wrong direction.