### PR TITLE
✨ Add support for creating namespaced watches

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -51,11 +51,11 @@ type Cache interface {
 type Informers interface {
 	// GetInformer fetches or constructs an informer for the given object that corresponds to a single
 	// API kind and resource.
-	GetInformer(obj runtime.Object) (Informer, error)
+	GetInformer(obj runtime.Object, opts ...client.ListOption) (Informer, error)
 
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.
-	GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error)
+	GetInformerForKind(gvk schema.GroupVersionKind, opts ...client.ListOption) (Informer, error)
 
 	// Start runs all the informers known to this cache until the given channel is closed.
 	// It blocks.

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -57,7 +57,7 @@ func (ip *informerCache) Get(ctx context.Context, key client.ObjectKey, out runt
 		return err
 	}
 
-	started, cache, err := ip.InformersMap.Get(gvk, out)
+	started, cache, err := ip.InformersMap.Get(gvk, out, client.InNamespace(key.Namespace))
 	if err != nil {
 		return err
 	}
@@ -101,7 +101,7 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 		}
 	}
 
-	started, cache, err := ip.InformersMap.Get(gvk, cacheTypeObj)
+	started, cache, err := ip.InformersMap.Get(gvk, cacheTypeObj, opts...)
 	if err != nil {
 		return err
 	}
@@ -114,13 +114,13 @@ func (ip *informerCache) List(ctx context.Context, out runtime.Object, opts ...c
 }
 
 // GetInformerForKind returns the informer for the GroupVersionKind
-func (ip *informerCache) GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error) {
+func (ip *informerCache) GetInformerForKind(gvk schema.GroupVersionKind, opts ...client.ListOption) (Informer, error) {
 	// Map the gvk to an object
 	obj, err := ip.Scheme.New(gvk)
 	if err != nil {
 		return nil, err
 	}
-	_, i, err := ip.InformersMap.Get(gvk, obj)
+	_, i, err := ip.InformersMap.Get(gvk, obj, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -128,12 +128,12 @@ func (ip *informerCache) GetInformerForKind(gvk schema.GroupVersionKind) (Inform
 }
 
 // GetInformer returns the informer for the obj
-func (ip *informerCache) GetInformer(obj runtime.Object) (Informer, error) {
+func (ip *informerCache) GetInformer(obj runtime.Object, opts ...client.ListOption) (Informer, error) {
 	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
 	if err != nil {
 		return nil, err
 	}
-	_, i, err := ip.InformersMap.Get(gvk, obj)
+	_, i, err := ip.InformersMap.Get(gvk, obj, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -39,7 +39,7 @@ type FakeInformers struct {
 }
 
 // GetInformerForKind implements Informers
-func (c *FakeInformers) GetInformerForKind(gvk schema.GroupVersionKind) (cache.Informer, error) {
+func (c *FakeInformers) GetInformerForKind(gvk schema.GroupVersionKind, opts ...client.ListOption) (cache.Informer, error) {
 	if c.Scheme == nil {
 		c.Scheme = scheme.Scheme
 	}
@@ -67,7 +67,7 @@ func (c *FakeInformers) FakeInformerForKind(gvk schema.GroupVersionKind) (*contr
 }
 
 // GetInformer implements Informers
-func (c *FakeInformers) GetInformer(obj runtime.Object) (cache.Informer, error) {
+func (c *FakeInformers) GetInformer(obj runtime.Object, opts ...client.ListOption) (cache.Informer, error) {
 	if c.Scheme == nil {
 		c.Scheme = scheme.Scheme
 	}

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // InformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
@@ -73,16 +75,16 @@ func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
-func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+func (m *InformersMap) Get(gvk schema.GroupVersionKind, obj runtime.Object, opts ...client.ListOption) (bool, *MapEntry, error) {
 	_, isUnstructured := obj.(*unstructured.Unstructured)
 	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
 	isUnstructured = isUnstructured || isUnstructuredList
 
 	if isUnstructured {
-		return m.unstructured.Get(gvk, obj)
+		return m.unstructured.Get(gvk, obj, opts...)
 	}
 
-	return m.structured.Get(gvk, obj)
+	return m.structured.Get(gvk, obj, opts...)
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -68,10 +68,10 @@ type multiNamespaceCache struct {
 var _ Cache = &multiNamespaceCache{}
 
 // Methods for multiNamespaceCache to conform to the Informers interface
-func (c *multiNamespaceCache) GetInformer(obj runtime.Object) (Informer, error) {
+func (c *multiNamespaceCache) GetInformer(obj runtime.Object, opts ...client.ListOption) (Informer, error) {
 	informers := map[string]Informer{}
 	for ns, cache := range c.namespaceToCache {
-		informer, err := cache.GetInformer(obj)
+		informer, err := cache.GetInformer(obj, opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -80,10 +80,10 @@ func (c *multiNamespaceCache) GetInformer(obj runtime.Object) (Informer, error) 
 	return &multiNamespaceInformer{namespaceToInformer: informers}, nil
 }
 
-func (c *multiNamespaceCache) GetInformerForKind(gvk schema.GroupVersionKind) (Informer, error) {
+func (c *multiNamespaceCache) GetInformerForKind(gvk schema.GroupVersionKind, opts ...client.ListOption) (Informer, error) {
 	informers := map[string]Informer{}
 	for ns, cache := range c.namespaceToCache {
-		informer, err := cache.GetInformerForKind(gvk)
+		informer, err := cache.GetInformerForKind(gvk, opts...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Another variant of #692 . Extend source.Kind with taking ListOptions, and pass these on to the informer map. In this PR, only namespace is used, but I think it could be extended to labels as well.

* If the informer cache is configured to handle all namespaces (i.e. "") - use it as key in all lookups to avoid cache duplication. This preserves existing lookup behavior.
* If the informer cache is configured to handle a specific namespace - create separate cache which will be used for lookups in those cases. This allows creating watches for multiple namespaces dynamically. 

I don't know yet if this works, its just a prototype of an API that I as a user would like to have supported. Will add an integration test, but early feedback is welcomed.