### PR TITLE
📖 Remove obsolete cert provisioner docs

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -53,10 +53,6 @@ type Server struct {
 	Port int
 
 	// CertDir is the directory that contains the server key and certificate.
-	// If using FSCertWriter in Provisioner, the server itself will provision the certificate and
-	// store it in this directory.
-	// If using SecretCertWriter in Provisioner, the server will provision the certificate in a secret,
-	// the user is responsible to mount the secret to the this location for the server to consume.
 	CertDir string
 
 	// WebhookMux is the multiplexer that handles different webhooks.


### PR DESCRIPTION
The provisioners were removed in #300 so this docs are no longer relevant.