### PR TITLE
:running: Change the golint install to do it as recommended

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,4 @@ Please see https://git.k8s.io/community/CLA.md for more info
 
 ## Test locally
 
-1. Setup tools
-    ```bash
-    $ curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
-    ```
-1. Test
-    ```bash
-    GO111MODULE=on TRACE=1 ./hack/check-everything.sh
-    ```
-
+Run the command `make check-all` to test the changes locally.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#  Copyright 2019 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+#
+# Makefile with some common workflow for dev, build and test
+#
+
+##@ General
+
+# The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
+# The awk commands is responsable to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info over the usage of ANSI control characters for terminal formatting: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info over awk command: http://linuxcommand.org/lc3_adv_awk.php
+.PHONY: help
+help:  ## Display this help
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+##@ Tests
+
+.PHONY: check-all
+test: ## Run the script check-everything.sh which will check all
+	GO111MODULE=on TRACE=1 ./hack/check-everything.sh
+

--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -70,7 +70,7 @@ function fetch_go_tools {
   header_text "Checking for gometalinter.v2"
   if ! is_installed golangci-lint; then
     header_text "Installing golangci-lint"
-    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.17.1
+    curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.21.0
   fi
 }
 

--- a/hack/ci-check-everything.sh
+++ b/hack/ci-check-everything.sh
@@ -24,7 +24,7 @@ export PATH=$(go env GOPATH)/bin:$PATH
 mkdir -p $(go env GOPATH)/bin
 
 echo "Installing golangci-lint"
-curl --location --silent --retry 5 --fail  https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.17.1
+curl --location --silent --retry 5 --fail  https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.21.0
 echo "Finished installing golangci-lint"
 
 $(dirname ${BASH_SOURCE})/check-everything.sh


### PR DESCRIPTION
**Description of the change:**
- Install golangci-lint via curl as recommended by its docs. See: https://github.com/golangci/golangci-lint#go-get
- Add Makefile and create a target to check all.


