### PR TITLE
✨ envtest: surface merged crds

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -240,7 +240,8 @@ func (te *Environment) Start() (*rest.Config, error) {
 	log.V(1).Info("installing CRDs")
 	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
 	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
-	_, err := InstallCRDs(te.Config, te.CRDInstallOptions)
+	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
+	te.CRDs = crds
 	return te.Config, err
 }
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes #691 by setting the `Environment` CRDs field to contain all installed CRDs whether provided as CRD object types or by path.