### PR TITLE
:bug: Fix SetControllerReference to consider multiple CRD versions

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -111,7 +111,7 @@ func referSameObject(a, b metav1.OwnerReference) bool {
 		return false
 	}
 
-	return aGV == bGV && a.Kind == b.Kind && a.Name == b.Name
+	return aGV.Group == bGV.Group && a.Kind == b.Kind && a.Name == b.Name
 }
 
 // OperationResult is the action result of a CreateOrUpdate call

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -134,7 +134,6 @@ var _ = Describe("Controllerutil", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-
 		It("should not return any error if the existing owner has a different version", func() {
 			f := false
 			t := true
@@ -153,8 +152,8 @@ var _ = Describe("Controllerutil", func() {
 
 			Expect(controllerutil.SetControllerReference(dep, rs, scheme.Scheme)).NotTo(HaveOccurred())
 			Expect(rs.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
-				Name:               "foo",
-				Kind:               "Deployment",
+				Name: "foo",
+				Kind: "Deployment",
 				// APIVersion is the new owner's one
 				APIVersion:         "extensions/v1beta1",
 				UID:                "foo-uid",

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -133,6 +133,35 @@ var _ = Describe("Controllerutil", func() {
 
 			Expect(err).To(HaveOccurred())
 		})
+
+
+		It("should not return any error if the existing owner has a different version", func() {
+			f := false
+			t := true
+			rsOwners := []metav1.OwnerReference{
+				{
+					Name:               "foo",
+					Kind:               "Deployment",
+					APIVersion:         "extensions/v1alpha1",
+					UID:                "foo-uid",
+					Controller:         &f,
+					BlockOwnerDeletion: &t,
+				},
+			}
+			rs := &appsv1.ReplicaSet{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", OwnerReferences: rsOwners}}
+			dep := &extensionsv1beta1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default", UID: "foo-uid"}}
+
+			Expect(controllerutil.SetControllerReference(dep, rs, scheme.Scheme)).NotTo(HaveOccurred())
+			Expect(rs.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
+				Name:               "foo",
+				Kind:               "Deployment",
+				// APIVersion is the new owner's one
+				APIVersion:         "extensions/v1beta1",
+				UID:                "foo-uid",
+				Controller:         &t,
+				BlockOwnerDeletion: &t,
+			}))
+		})
 	})
 
 	Describe("CreateOrUpdate", func() {


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/699.

An error was returned by the call to `SetControllerReference` if the owner
is already set, but with a different apiVersion (eg. `group/v1beta1`
instead of `group/v1`).

This commit fixes it by ignoring the version in the ref comparison. It
still considers the group though. Having an owner with a different
version does not return an error, but the call to
`SetControllerReference` effectively changes the owner to match the
newer apiVersion.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
