### PR TITLE
:bug: Envtest: Allow creating objects with privileged container specs

### DIFF
--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -100,6 +100,9 @@ var _ = Describe("controller", func() {
 								{
 									Name:  "nginx",
 									Image: "nginx",
+									SecurityContext: &corev1.SecurityContext{
+										Privileged: truePtr(),
+									},
 								},
 							},
 						},
@@ -168,3 +171,8 @@ var _ = Describe("controller", func() {
 		}, 5)
 	})
 })
+
+func truePtr() *bool {
+	t := true
+	return &t
+}

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -84,6 +84,7 @@ var DefaultKubeAPIServerFlags = []string{
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
 	"--admission-control=AlwaysAdmit",
 	"--service-cluster-ip-range=10.0.0.0/24",
+	"--allow-privileged=true",
 }
 
 // Environment creates a Kubernetes test environment that will start / stop the Kubernetes control plane and


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Currently it is not possible to use envtest to create things with privileged containers in them, because the `--allow-privileged` flag on the kube-apiserver defaults to false. Attempting to do so causes a `Deployment.apps \"deployment-name\" is invalid: spec.template.spec.containers[0].securityContext.privileged: Forbidden: disallowed by cluster policy"`.

This PR changes that.
