### PR TITLE
✨ Define metrics.Registry as an interface

### DIFF
--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -18,6 +18,13 @@ package metrics
 
 import "github.com/prometheus/client_golang/prometheus"
 
+// RegistererGatherer combines both parts of the API of a Prometheus
+// registry, both the Registerer and the Gatherer interfaces.
+type RegistererGatherer interface {
+	prometheus.Registerer
+	prometheus.Gatherer
+}
+
 // Registry is a prometheus registry for storing metrics within the
 // controller-runtime
-var Registry = prometheus.NewRegistry()
+var Registry RegistererGatherer = prometheus.NewRegistry()


### PR DESCRIPTION
It's currently not possible to replace the predefined Registry with a custom implementation.

I need this because I re-create controllers with the same name at runtime and this causes the default registry to rightfully complain that the metrics for this label combination are already registered. When calling `controller.New()` I have no influence over the metrics creation and errors are always logged with a logger I can also not control.

With this PR I can register my own Registry implementation that silently drops the AlreadyRegistered errors.

We could have used a custom subset of the two predefined Registerer/Gatherer interfaces, but both are so short and only contain what we actually need, so it seemed not worth the effort to replicate the method definitions.

I can see that there are some long-standing intentions to migrate to both [non-global metrics definitions](https://github.com/kubernetes-sigs/controller-runtime/issues/210) and the [use of OpenTelemetry](https://github.com/kubernetes-sigs/controller-runtime/issues/305), but in the meantime this would make life easier [for me]. :-)