### PR TITLE
:sparkles: ErrorIfCRDPathMissing on Environment

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -356,14 +356,14 @@ var _ = Describe("Test", func() {
 	})
 
 	Describe("Start", func() {
-		It("should raise an error", func(done Done) {
+		It("should raise an error on invalid dir when flag is enabled", func(done Done) {
 			env = &Environment{ErrorIfCRDPathMissing: true, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).To(HaveOccurred())
 			close(done)
 		}, 30)
 
-		It("should not raise an error", func(done Done) {
+		It("should not raise an error on invalid dir when flag is disabled", func(done Done) {
 			env = &Environment{ErrorIfCRDPathMissing: false, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -100,6 +100,11 @@ type Environment struct {
 	// CRDInstallOptions are the options for installing CRDs.
 	CRDInstallOptions CRDInstallOptions
 
+	// ErrorIfCRDPathMissing provides an interface for the underlying
+	// CRDInstallOptions.ErrorIfPathMissing. It prevents silent failures
+	// for missing CRD paths.
+	ErrorIfCRDPathMissing bool
+
 	// CRDs is a list of CRDs to install.
 	// If both this field and CRDs field in CRDInstallOptions are specified, the
 	// values are merged.
@@ -246,6 +251,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 	log.V(1).Info("installing CRDs")
 	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
 	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
+	te.CRDInstallOptions.ErrorIfPathMissing = te.ErrorIfCRDPathMissing
 	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
 	te.CRDs = crds
 	return te.Config, err


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

This PR overwrites the ErrorIfPathMissing from CRDInstallOptions via Environment.ErrorIfCRDPathMissing on Start() method.

Similar to PR #511 but propagates the flag and test the Start() with invalid directories.

Closes #481.

<!-- What does this do, and why do we need it? -->
