### PR TITLE
:bug: Remove TotalRequests Prometheus metrics as it is not getting used

### DIFF
--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -23,16 +23,6 @@ import (
 )
 
 var (
-	// TotalRequests is a prometheus metric which counts the total number of requests that
-	// the webhook server has received.
-	TotalRequests = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "controller_runtime_webhook_requests_total",
-			Help: "Total number of admission requests",
-		},
-		[]string{"webhook", "succeeded"},
-	)
-
 	// RequestLatency is a prometheus metric which is a histogram of the latency
 	// of processing admission requests.
 	RequestLatency = prometheus.NewHistogramVec(
@@ -46,6 +36,5 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(
-		TotalRequests,
 		RequestLatency)
 }


### PR DESCRIPTION
This PR is for the issue #712 TotalRequests prometheus metrics is not getting used and hence it is removed in this PR.

Fixes #712 