### PR TITLE
:sparkles: client: Use dynamic RESTMapper by default

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -64,7 +64,7 @@ func New(config *rest.Config, options Options) (Client, error) {
 	// Init a Mapper if none provided
 	if options.Mapper == nil {
 		var err error
-		options.Mapper, err = apiutil.NewDiscoveryRESTMapper(config)
+		options.Mapper, err = apiutil.NewDynamicRESTMapper(config)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/734

This commit changes the client package to use the dynamic RESTMapper by
default.
The default RESTMapper caches the discovery endpoint results once and
never updates them.
Because of that, if an api-resource is added after the client is
started, the client will mistakenly think the api-resource doesn't exist.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>
