### PR TITLE
📖Replace NullLogger with a zap logger in the ExampleBuilder

### DIFF
--- a/pkg/builder/example_test.go
+++ b/pkg/builder/example_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -40,6 +41,8 @@ import (
 //
 // * Start the application.
 func ExampleBuilder() {
+	logf.SetLogger(zap.New())
+
 	var log = logf.Log.WithName("builder-examples")
 
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})


### PR DESCRIPTION
The `ExampleBuilder` uses the default logger, which is the `NullLogger`.  Since this example is (I assume) meant as a comprehensive example, it would be more helpful to print the actual logs.  This PR replaces the default null logger with a zap logger in the example. 