### PR TITLE
:running: Remove usage of deprecated MatchingField list option

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -560,8 +560,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("listing Pods with restartPolicyOnFailure")
 					listObj := &kcorev1.PodList{}
 					Expect(informer.List(context.Background(), listObj,
-						client.MatchingField("spec.restartPolicy", "OnFailure"))).To(Succeed())
-
+						client.MatchingFields{"spec.restartPolicy": "OnFailure"})).To(Succeed())
 					By("verifying that the returned pods have correct restart policy")
 					Expect(listObj.Items).NotTo(BeEmpty())
 					Expect(listObj.Items).Should(HaveLen(1))
@@ -655,7 +654,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "PodList",
 					})
 					err = informer.List(context.Background(), listObj,
-						client.MatchingField("spec.restartPolicy", "OnFailure"))
+						client.MatchingFields{"spec.restartPolicy": "OnFailure"})
 					Expect(err).To(Succeed())
 
 					By("verifying that the returned pods have correct restart policy")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1794,7 +1794,7 @@ var _ = Describe("Client", func() {
 				By("listing all Deployments with field metadata.name=deployment-backend")
 				deps := &appsv1.DeploymentList{}
 				err = cl.List(context.Background(), deps,
-					client.MatchingField("metadata.name", "deployment-backend"))
+					client.MatchingFields{"metadata.name": "deployment-backend"})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("only the Deployment with the backend field is returned")
@@ -2160,7 +2160,7 @@ var _ = Describe("Client", func() {
 					Version: "v1",
 				})
 				err = cl.List(context.Background(), deps,
-					client.MatchingField("metadata.name", "deployment-backend"))
+					client.MatchingFields{"metadata.name": "deployment-backend"})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("only the Deployment with the backend field is returned")
@@ -2389,7 +2389,7 @@ var _ = Describe("Client", func() {
 	Describe("ListOptions", func() {
 		It("should be convertable to metav1.ListOptions", func() {
 			lo := (&client.ListOptions{}).ApplyOptions([]client.ListOption{
-				client.MatchingField("field1", "bar"),
+				client.MatchingFields{"field1": "bar"},
 				client.InNamespace("test-namespace"),
 				client.MatchingLabels{"foo": "bar"},
 				client.Limit(1),
@@ -2412,7 +2412,7 @@ var _ = Describe("Client", func() {
 
 		It("should be populated by MatchingField", func() {
 			lo := &client.ListOptions{}
-			client.MatchingField("field1", "bar").ApplyToList(lo)
+			client.MatchingFields{"field1": "bar"}.ApplyToList(lo)
 			Expect(lo).NotTo(BeNil())
 			Expect(lo.FieldSelector.String()).To(Equal("field1=bar"))
 		})

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -231,5 +231,5 @@ func ExampleFieldIndexer_secretName() {
 	// elsewhere (e.g. in your reconciler)
 	mySecretName := "someSecret" // derived from the reconcile.Request, for instance
 	var podsWithSecrets corev1.PodList
-	_ = c.List(context.Background(), &podsWithSecrets, client.MatchingField("spec.volumes.secret.secretName", mySecretName))
+	_ = c.List(context.Background(), &podsWithSecrets, client.MatchingFields{"spec.volumes.secret.secretName": mySecretName})
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -411,13 +411,13 @@ func MatchingField(name, val string) MatchingFields {
 	return MatchingFields{name: val}
 }
 
-// MatchingField filters the list/delete operation on the given field Set
+// MatchingFields filters the list/delete operation on the given field Set
 // (or index in the case of cached lists).
 type MatchingFields fields.Set
 
 func (m MatchingFields) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid re-serializing this?
-	sel := fields.SelectorFromSet(fields.Set(m))
+	sel := fields.Set(m).AsSelector()
 	opts.FieldSelector = sel
 }
 


### PR DESCRIPTION
Replaces usage of deprecated `MatchingField` list option in tests with
`MatchingFields`.
