### PR TITLE
📖 (nit) fix grammar and spelling typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 ##@ General
 
 # The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
-# The awk commands is responsable to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
+# The awk commands is responsible to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
 # More info over the usage of ANSI control characters for terminal formatting: https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
 # More info over awk command: http://linuxcommand.org/lc3_adv_awk.php
 .PHONY: help

--- a/TMP-LOGGING.md
+++ b/TMP-LOGGING.md
@@ -11,7 +11,7 @@ need to adjust how you think about logging a bit.
 
 With structured logging, we associate a *constant* log message with some
 variable key-value pairs.  For instance, suppose we wanted to log that we
-were starting reconciliation on a pod.  In the Go standard libary logger,
+were starting reconciliation on a pod.  In the Go standard library logger,
 we might write:
 
 ```go

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -241,7 +241,7 @@ leads to API cruft.
 
 Since one of the goals of controller-runtime is to be a friendly and
 intuitive API, we want to avoid too much API cruft over time, and
-occaisonal breaking changes in major releases help accomplish that goal.
+occasional breaking changes in major releases help accomplish that goal.
 
 Furthermore, our dependency on Kubernetes libraries makes this difficult
 (see below)

--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -99,7 +99,7 @@ through the Watch API.
 
 EventHandler
 
-handler.EventHandler is a argument to Controller.Watch that enqueues reconcile.Requests in response to events.
+handler.EventHandler is an argument to Controller.Watch that enqueues reconcile.Requests in response to events.
 
 Example: a Pod Create event from a Source is provided to the eventhandler.EnqueueHandler, which enqueues a
 reconcile.Request containing the name / Namespace of the Pod.


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

Fixes grammar and spelling typos in various places (non-functional changes, not code)