### PR TITLE
⚠ Bring in testing framework

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -11,3 +11,7 @@ aliases:
   - shawn-hurley
   - gerred
   - joelanford
+  testing-integration-admins:
+  - apelisse
+  - hoegaarden
+  - totherme

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,5 @@ require (
 	k8s.io/apimachinery v0.0.0-20190913080033-27d36303b655
 	k8s.io/client-go v0.0.0-20190918160344-1fbdaa4c8d90
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1
-	sigs.k8s.io/testing_frameworks v0.1.2
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -381,7 +381,5 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
-sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH+UQM=
-sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -48,7 +48,9 @@ SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 
 # fetch k8s API gen tools and make it available under kb_root_dir/bin.
 function fetch_kb_tools {
-  header_text "fetching tools"
+  local dest_dir="${1}"
+
+  header_text "fetching tools (into '${dest_dir}')"
   kb_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
   kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$kb_tools_archive_name"
 
@@ -56,7 +58,9 @@ function fetch_kb_tools {
   if [ ! -f $kb_tools_archive_path ]; then
     curl -sL ${kb_tools_download_url} -o "$kb_tools_archive_path"
   fi
-  tar -zvxf "$kb_tools_archive_path" -C "$tmp_root/"
+
+  mkdir -p "${dest_dir}"
+  tar -C "${dest_dir}" --strip-components=1 -zvxf "$kb_tools_archive_path"
 }
 
 function is_installed {
@@ -78,7 +82,8 @@ header_text "using tools"
 
 if [ -z "$SKIP_FETCH_TOOLS" ]; then
   fetch_go_tools
-  fetch_kb_tools
+  fetch_kb_tools "$kb_root_dir"
+  fetch_kb_tools "${hack_dir}/../pkg/internal/testing/integration/assets"
 fi
 
 setup_envs

--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -28,11 +28,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/testing_frameworks/integration/addr"
 )
 
 func TestBuilder(t *testing.T) {

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -26,7 +26,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/testing_frameworks/integration"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 )

--- a/pkg/internal/testing/OWNERS
+++ b/pkg/internal/testing/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+
+approvers:
+  - controller-runtime-admins
+  - testing-integration-admins

--- a/pkg/internal/testing/integration/.gitignore
+++ b/pkg/internal/testing/integration/.gitignore
@@ -1,0 +1,1 @@
+assets/bin

--- a/pkg/internal/testing/integration/README.md
+++ b/pkg/internal/testing/integration/README.md
@@ -1,0 +1,10 @@
+# Integration Testing Framework
+
+This package has been moved from [https://github.com/kubernetes-sigs/testing_frameworks/tree/master/integration](https://github.com/kubernetes-sigs/testing_frameworks/tree/master/integration).
+
+A framework for integration testing components of kubernetes. This framework is
+intended to work properly both in CI, and on a local dev machine. It therefore
+explicitly supports both Linux and Darwin.
+
+For detailed documentation see the
+[![GoDoc](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/internal/testing/integration?status.svg)](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/internal/testing/integration).

--- a/pkg/internal/testing/integration/addr/addr_suite_test.go
+++ b/pkg/internal/testing/integration/addr/addr_suite_test.go
@@ -1,0 +1,14 @@
+package addr_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestAddr(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Addr Suite")
+}

--- a/pkg/internal/testing/integration/addr/manager.go
+++ b/pkg/internal/testing/integration/addr/manager.go
@@ -1,0 +1,74 @@
+package addr
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"time"
+)
+
+const (
+	portReserveTime   = 1 * time.Minute
+	portConflictRetry = 100
+)
+
+type portCache struct {
+	lock  sync.Mutex
+	ports map[int]time.Time
+}
+
+func (c *portCache) add(port int) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	// remove outdated port
+	for p, t := range c.ports {
+		if time.Since(t) > portReserveTime {
+			delete(c.ports, p)
+		}
+	}
+	// try allocating new port
+	if _, ok := c.ports[port]; ok {
+		return false
+	}
+	c.ports[port] = time.Now()
+	return true
+}
+
+var cache = &portCache{
+	ports: make(map[int]time.Time),
+}
+
+func suggest() (port int, resolvedHost string, err error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return
+	}
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return
+	}
+	port = l.Addr().(*net.TCPAddr).Port
+	defer func() {
+		err = l.Close()
+	}()
+	resolvedHost = addr.IP.String()
+	return
+}
+
+// Suggest suggests an address a process can listen on. It returns
+// a tuple consisting of a free port and the hostname resolved to its IP.
+// It makes sure that new port allocated does not conflict with old ports
+// allocated within 1 minute.
+func Suggest() (port int, resolvedHost string, err error) {
+	for i := 0; i < portConflictRetry; i++ {
+		port, resolvedHost, err = suggest()
+		if err != nil {
+			return
+		}
+		if cache.add(port) {
+			return
+		}
+	}
+	err = fmt.Errorf("no free ports found after %d retries", portConflictRetry)
+	return
+}

--- a/pkg/internal/testing/integration/addr/manager_test.go
+++ b/pkg/internal/testing/integration/addr/manager_test.go
@@ -1,0 +1,29 @@
+package addr_test
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
+
+	"net"
+	"strconv"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SuggestAddress", func() {
+	It("returns a free port and an address to bind to", func() {
+		port, host, err := addr.Suggest()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(host).To(Or(Equal("127.0.0.1"), Equal("::1")))
+		Expect(port).NotTo(Equal(0))
+
+		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		Expect(err).NotTo(HaveOccurred())
+		l, err := net.ListenTCP("tcp", addr)
+		defer func() {
+			Expect(l.Close()).To(Succeed())
+		}()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -1,0 +1,136 @@
+package integration
+
+import (
+	"fmt"
+	"io"
+	"net/url"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+// APIServer knows how to run a kubernetes apiserver.
+type APIServer struct {
+	// URL is the address the ApiServer should listen on for client connections.
+	//
+	// If this is not specified, we default to a random free port on localhost.
+	URL *url.URL
+
+	// SecurePort is the additional secure port that the APIServer should listen on.
+	SecurePort int
+
+	// Path is the path to the apiserver binary.
+	//
+	// If this is left as the empty string, we will attempt to locate a binary,
+	// by checking for the TEST_ASSET_KUBE_APISERVER environment variable, and
+	// the default test assets directory. See the "Binaries" section above (in
+	// doc.go) for details.
+	Path string
+
+	// Args is a list of arguments which will passed to the APIServer binary.
+	// Before they are passed on, they will be evaluated as go-template strings.
+	// This means you can use fields which are defined and exported on this
+	// APIServer struct (e.g. "--cert-dir={{ .Dir }}").
+	// Those templates will be evaluated after the defaulting of the APIServer's
+	// fields has already happened and just before the binary actually gets
+	// started. Thus you have access to calculated fields like `URL` and others.
+	//
+	// If not specified, the minimal set of arguments to run the APIServer will
+	// be used.
+	Args []string
+
+	// CertDir is a path to a directory containing whatever certificates the
+	// APIServer will need.
+	//
+	// If left unspecified, then the Start() method will create a fresh temporary
+	// directory, and the Stop() method will clean it up.
+	CertDir string
+
+	// EtcdURL is the URL of the Etcd the APIServer should use.
+	//
+	// If this is not specified, the Start() method will return an error.
+	EtcdURL *url.URL
+
+	// StartTimeout, StopTimeout specify the time the APIServer is allowed to
+	// take when starting and stoppping before an error is emitted.
+	//
+	// If not specified, these default to 20 seconds.
+	StartTimeout time.Duration
+	StopTimeout  time.Duration
+
+	// Out, Err specify where APIServer should write its StdOut, StdErr to.
+	//
+	// If not specified, the output will be discarded.
+	Out io.Writer
+	Err io.Writer
+
+	processState *internal.ProcessState
+}
+
+// Start starts the apiserver, waits for it to come up, and returns an error,
+// if occurred.
+func (s *APIServer) Start() error {
+	if s.processState == nil {
+		if err := s.setProcessState(); err != nil {
+			return err
+		}
+	}
+	return s.processState.Start(s.Out, s.Err)
+}
+
+func (s *APIServer) setProcessState() error {
+	if s.EtcdURL == nil {
+		return fmt.Errorf("expected EtcdURL to be configured")
+	}
+
+	var err error
+
+	s.processState = &internal.ProcessState{}
+
+	s.processState.DefaultedProcessInput, err = internal.DoDefaulting(
+		"kube-apiserver",
+		s.URL,
+		s.CertDir,
+		s.Path,
+		s.StartTimeout,
+		s.StopTimeout,
+	)
+	if err != nil {
+		return err
+	}
+
+	// Defaulting the secure port
+	if s.SecurePort == 0 {
+		s.SecurePort, _, err = addr.Suggest()
+		if err != nil {
+			return err
+		}
+	}
+
+	s.processState.HealthCheckEndpoint = "/healthz"
+
+	s.URL = &s.processState.URL
+	s.CertDir = s.processState.Dir
+	s.Path = s.processState.Path
+	s.StartTimeout = s.processState.StartTimeout
+	s.StopTimeout = s.processState.StopTimeout
+
+	s.processState.Args, err = internal.RenderTemplates(
+		internal.DoAPIServerArgDefaulting(s.Args), s,
+	)
+	return err
+}
+
+// Stop stops this process gracefully, waits for its termination, and cleans up
+// the CertDir if necessary.
+func (s *APIServer) Stop() error {
+	return s.processState.Stop()
+}
+
+// APIServerDefaultArgs exposes the default args for the APIServer so that you
+// can use those to append your own additional arguments.
+//
+// The internal default arguments are explicitly copied here, we don't want to
+// allow users to change the internal ones.
+var APIServerDefaultArgs = append([]string{}, internal.APIServerDefaultArgs...)

--- a/pkg/internal/testing/integration/assets/bin/.gitkeep
+++ b/pkg/internal/testing/integration/assets/bin/.gitkeep
@@ -1,0 +1,1 @@
+This directory will be the home of some binaries which are downloaded with `pkg/framework/test/scripts/download-binaries`.

--- a/pkg/internal/testing/integration/control_plane.go
+++ b/pkg/internal/testing/integration/control_plane.go
@@ -1,0 +1,59 @@
+package integration
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ControlPlane is a struct that knows how to start your test control plane.
+//
+// Right now, that means Etcd and your APIServer. This is likely to increase in
+// future.
+type ControlPlane struct {
+	APIServer *APIServer
+	Etcd      *Etcd
+}
+
+// Start will start your control plane processes. To stop them, call Stop().
+func (f *ControlPlane) Start() error {
+	if f.Etcd == nil {
+		f.Etcd = &Etcd{}
+	}
+	if err := f.Etcd.Start(); err != nil {
+		return err
+	}
+
+	if f.APIServer == nil {
+		f.APIServer = &APIServer{}
+	}
+	f.APIServer.EtcdURL = f.Etcd.URL
+	return f.APIServer.Start()
+}
+
+// Stop will stop your control plane processes, and clean up their data.
+func (f *ControlPlane) Stop() error {
+	if f.APIServer != nil {
+		if err := f.APIServer.Stop(); err != nil {
+			return err
+		}
+	}
+	if f.Etcd != nil {
+		if err := f.Etcd.Stop(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// APIURL returns the URL you should connect to to talk to your API.
+func (f *ControlPlane) APIURL() *url.URL {
+	return f.APIServer.URL
+}
+
+// KubeCtl returns a pre-configured KubeCtl, ready to connect to this
+// ControlPlane.
+func (f *ControlPlane) KubeCtl() *KubeCtl {
+	k := &KubeCtl{}
+	k.Opts = append(k.Opts, fmt.Sprintf("--server=%s", f.APIURL()))
+	return k
+}

--- a/pkg/internal/testing/integration/doc.go
+++ b/pkg/internal/testing/integration/doc.go
@@ -1,0 +1,119 @@
+/*
+
+Package integration implements an integration testing framework for kubernetes.
+
+It provides components for standing up a kubernetes API, against which you can test a
+kubernetes client, or other kubernetes components. The lifecycle of the components
+needed to provide this API is managed by this framework.
+
+Quickstart
+
+If you want to test a kubernetes client against the latest kubernetes APIServer
+and Etcd, you can use `./scripts/download-binaries.sh` to download APIServer
+and Etcd binaries for your platform. Then add something like the following to
+your tests:
+
+	cp := &integration.ControlPlane{}
+	cp.Start()
+	kubeCtl := cp.KubeCtl()
+	stdout, stderr, err := kubeCtl.Run("get", "pods")
+	// You can check on err, stdout & stderr and build up
+	// your tests
+	cp.Stop()
+
+Components
+
+Currently the framework provides the following components:
+
+ControlPlane: The ControlPlane wraps Etcd & APIServer (see below) and wires
+them together correctly. A ControlPlane can be stopped & started and can
+provide the URL to connect to the API. The ControlPlane can also be asked for a
+KubeCtl which is already correctly configured for this ControlPlane. The
+ControlPlane is a good entry point for default setups.
+
+Etcd: Manages an Etcd binary, which can be started, stopped and connected to.
+By default Etcd will listen on a random port for http connections and will
+create a temporary directory for its data. To configure it differently, see the
+Etcd type documentation below.
+
+APIServer: Manages an Kube-APIServer binary, which can be started, stopped and
+connected to. By default APIServer will listen on a random port for http
+connections and will create a temporary directory to store the (auto-generated)
+certificates.  To configure it differently, see the APIServer type
+documentation below.
+
+KubeCtl: Wraps around a `kubectl` binary and can `Run(...)` arbitrary commands
+against a kubernetes control plane.
+
+Binaries
+
+Etcd, APIServer & KubeCtl use the same mechanism to determine which binaries to
+use when they get started.
+
+1. If the component is configured with a `Path` the framework tries to run that
+binary.
+For example:
+
+	myEtcd := &Etcd{
+		Path: "/some/other/etcd",
+	}
+	cp := &integration.ControlPlane{
+		Etcd: myEtcd,
+	}
+	cp.Start()
+
+2. If the Path field on APIServer, Etcd or KubeCtl is left unset and an
+environment variable named `TEST_ASSET_KUBE_APISERVER`, `TEST_ASSET_ETCD` or
+`TEST_ASSET_KUBECTL` is set, its value is used as a path to the binary for the
+APIServer, Etcd or KubeCtl.
+
+3. If neither the `Path` field, nor the environment variable is set, the
+framework tries to use the binaries `kube-apiserver`, `etcd` or `kubectl` in
+the directory `${FRAMEWORK_DIR}/assets/bin/`.
+
+For convenience this framework ships with
+`${FRAMEWORK_DIR}/scripts/download-binaries.sh` which can be used to download
+pre-compiled versions of the needed binaries and place them in the default
+location (`${FRAMEWORK_DIR}/assets/bin/`).
+
+Arguments for Etcd and APIServer
+
+Those components will start without any configuration. However, if you want or
+need to, you can override certain configuration -- one of which are the
+arguments used when calling the binary.
+
+When you choose to specify your own set of arguments, those won't be appended
+to the default set of arguments, it is your responsibility to provide all the
+arguments needed for the binary to start successfully.
+
+However, the default arguments for APIServer and Etcd are exported as
+`APIServerDefaultArgs` and `EtcdDefaultArgs` from this package. Treat those
+variables as read-only constants. Internally we have a set of default
+arguments for defaulting, the `APIServerDefaultArgs` and `EtcdDefaultArgs` are
+just copies of those. So when you override them you loose access to the actual
+internal default arguments, but your override won't affect the defaulting.
+
+All arguments are interpreted as go templates. Those templates have access to
+all exported fields of the `APIServer`/`Etcd` struct. It does not matter if
+those fields where explicitly set up or if they were defaulted by calling the
+`Start()` method, the template evaluation runs just before the binary is
+executed and right after the defaulting of all the struct's fields has
+happened.
+
+	// When you want to append additional arguments ...
+	etcd := &Etcd{
+		// Additional custom arguments will appended to the set of default
+		// arguments
+		Args:    append(EtcdDefaultArgs, "--additional=arg"),
+		DataDir: "/my/special/data/dir",
+	}
+
+	// When you want to use a custom set of arguments ...
+	etcd := &Etcd{
+		// Only custom arguments will be passed to the binary
+		Args:    []string{"--one=1", "--two=2", "--three=3"},
+		DataDir: "/my/special/data/dir",
+	}
+
+*/
+package integration

--- a/pkg/internal/testing/integration/etcd.go
+++ b/pkg/internal/testing/integration/etcd.go
@@ -1,0 +1,114 @@
+package integration
+
+import (
+	"io"
+	"time"
+
+	"net/url"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+// Etcd knows how to run an etcd server.
+type Etcd struct {
+	// URL is the address the Etcd should listen on for client connections.
+	//
+	// If this is not specified, we default to a random free port on localhost.
+	URL *url.URL
+
+	// Path is the path to the etcd binary.
+	//
+	// If this is left as the empty string, we will attempt to locate a binary,
+	// by checking for the TEST_ASSET_ETCD environment variable, and the default
+	// test assets directory. See the "Binaries" section above (in doc.go) for
+	// details.
+	Path string
+
+	// Args is a list of arguments which will passed to the Etcd binary. Before
+	// they are passed on, the`y will be evaluated as go-template strings. This
+	// means you can use fields which are defined and exported on this Etcd
+	// struct (e.g. "--data-dir={{ .Dir }}").
+	// Those templates will be evaluated after the defaulting of the Etcd's
+	// fields has already happened and just before the binary actually gets
+	// started. Thus you have access to calculated fields like `URL` and others.
+	//
+	// If not specified, the minimal set of arguments to run the Etcd will be
+	// used.
+	Args []string
+
+	// DataDir is a path to a directory in which etcd can store its state.
+	//
+	// If left unspecified, then the Start() method will create a fresh temporary
+	// directory, and the Stop() method will clean it up.
+	DataDir string
+
+	// StartTimeout, StopTimeout specify the time the Etcd is allowed to
+	// take when starting and stopping before an error is emitted.
+	//
+	// If not specified, these default to 20 seconds.
+	StartTimeout time.Duration
+	StopTimeout  time.Duration
+
+	// Out, Err specify where Etcd should write its StdOut, StdErr to.
+	//
+	// If not specified, the output will be discarded.
+	Out io.Writer
+	Err io.Writer
+
+	processState *internal.ProcessState
+}
+
+// Start starts the etcd, waits for it to come up, and returns an error, if one
+// occoured.
+func (e *Etcd) Start() error {
+	if e.processState == nil {
+		if err := e.setProcessState(); err != nil {
+			return err
+		}
+	}
+	return e.processState.Start(e.Out, e.Err)
+}
+
+func (e *Etcd) setProcessState() error {
+	var err error
+
+	e.processState = &internal.ProcessState{}
+
+	e.processState.DefaultedProcessInput, err = internal.DoDefaulting(
+		"etcd",
+		e.URL,
+		e.DataDir,
+		e.Path,
+		e.StartTimeout,
+		e.StopTimeout,
+	)
+	if err != nil {
+		return err
+	}
+
+	e.processState.StartMessage = internal.GetEtcdStartMessage(e.processState.URL)
+
+	e.URL = &e.processState.URL
+	e.DataDir = e.processState.Dir
+	e.Path = e.processState.Path
+	e.StartTimeout = e.processState.StartTimeout
+	e.StopTimeout = e.processState.StopTimeout
+
+	e.processState.Args, err = internal.RenderTemplates(
+		internal.DoEtcdArgDefaulting(e.Args), e,
+	)
+	return err
+}
+
+// Stop stops this process gracefully, waits for its termination, and cleans up
+// the DataDir if necessary.
+func (e *Etcd) Stop() error {
+	return e.processState.Stop()
+}
+
+// EtcdDefaultArgs exposes the default args for Etcd so that you
+// can use those to append your own additional arguments.
+//
+// The internal default arguments are explicitly copied here, we don't want to
+// allow users to change the internal ones.
+var EtcdDefaultArgs = append([]string{}, internal.EtcdDefaultArgs...)

--- a/pkg/internal/testing/integration/integration_suite_test.go
+++ b/pkg/internal/testing/integration/integration_suite_test.go
@@ -1,0 +1,14 @@
+package integration_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Framework Unit Tests")
+}

--- a/pkg/internal/testing/integration/internal/apiserver.go
+++ b/pkg/internal/testing/integration/internal/apiserver.go
@@ -1,0 +1,17 @@
+package internal
+
+var APIServerDefaultArgs = []string{
+	"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
+	"--cert-dir={{ .CertDir }}",
+	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
+	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
+	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
+}
+
+func DoAPIServerArgDefaulting(args []string) []string {
+	if len(args) != 0 {
+		return args
+	}
+
+	return APIServerDefaultArgs
+}

--- a/pkg/internal/testing/integration/internal/apiserver_test.go
+++ b/pkg/internal/testing/integration/internal/apiserver_test.go
@@ -1,0 +1,23 @@
+package internal_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+var _ = Describe("Apiserver", func() {
+	It("defaults Args if they are empty", func() {
+		initialArgs := []string{}
+		defaultedArgs := DoAPIServerArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo(APIServerDefaultArgs))
+	})
+
+	It("keeps Args as is if they are not empty", func() {
+		initialArgs := []string{"--one", "--two=2"}
+		defaultedArgs := DoAPIServerArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo([]string{
+			"--one", "--two=2",
+		}))
+	})
+})

--- a/pkg/internal/testing/integration/internal/arguments.go
+++ b/pkg/internal/testing/integration/internal/arguments.go
@@ -1,0 +1,28 @@
+package internal
+
+import (
+	"bytes"
+	"html/template"
+)
+
+func RenderTemplates(argTemplates []string, data interface{}) (args []string, err error) {
+	var t *template.Template
+
+	for _, arg := range argTemplates {
+		t, err = template.New(arg).Parse(arg)
+		if err != nil {
+			args = nil
+			return
+		}
+
+		buf := &bytes.Buffer{}
+		err = t.Execute(buf, data)
+		if err != nil {
+			args = nil
+			return
+		}
+		args = append(args, buf.String())
+	}
+
+	return
+}

--- a/pkg/internal/testing/integration/internal/arguments_test.go
+++ b/pkg/internal/testing/integration/internal/arguments_test.go
@@ -1,0 +1,95 @@
+package internal_test
+
+import (
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+var _ = Describe("Arguments", func() {
+	It("templates URLs", func() {
+		templates := []string{
+			"plain URL: {{ .SomeURL }}",
+			"method on URL: {{ .SomeURL.Hostname }}",
+			"empty URL: {{ .EmptyURL }}",
+			"handled empty URL: {{- if .EmptyURL }}{{ .EmptyURL }}{{ end }}",
+		}
+		data := struct {
+			SomeURL  *url.URL
+			EmptyURL *url.URL
+		}{
+			&url.URL{Scheme: "https", Host: "the.host.name:3456"},
+			nil,
+		}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"plain URL: https://the.host.name:3456",
+			"method on URL: the.host.name",
+			"empty URL: &lt;nil&gt;",
+			"handled empty URL:",
+		}))
+	})
+
+	It("templates strings", func() {
+		templates := []string{
+			"a string: {{ .SomeString }}",
+			"empty string: {{- .EmptyString }}",
+		}
+		data := struct {
+			SomeString  string
+			EmptyString string
+		}{
+			"this is some random string",
+			"",
+		}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"a string: this is some random string",
+			"empty string:",
+		}))
+	})
+
+	It("has no access to unexported fields", func() {
+		templates := []string{
+			"this is just a string",
+			"this blows up {{ .test }}",
+		}
+		data := struct{ test string }{"ooops private"}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("is an unexported field of struct"),
+		))
+	})
+
+	It("errors when field cannot be found", func() {
+		templates := []string{"this does {{ .NotExist }}"}
+		data := struct{ Unused string }{"unused"}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("can't evaluate field"),
+		))
+	})
+
+	Context("When overriding external default args", func() {
+		It("does not change the internal default args for APIServer", func() {
+			integration.APIServerDefaultArgs[0] = "oh no!"
+			Expect(APIServerDefaultArgs).NotTo(BeEquivalentTo(integration.APIServerDefaultArgs))
+		})
+		It("does not change the internal default args for Etcd", func() {
+			integration.EtcdDefaultArgs[0] = "oh no!"
+			Expect(EtcdDefaultArgs).NotTo(BeEquivalentTo(integration.EtcdDefaultArgs))
+		})
+	})
+})

--- a/pkg/internal/testing/integration/internal/bin_path_finder.go
+++ b/pkg/internal/testing/integration/internal/bin_path_finder.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var assetsPath string
+
+func init() {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("Could not determine the path of the BinPathFinder")
+	}
+	assetsPath = filepath.Join(filepath.Dir(thisFile), "..", "assets", "bin")
+}
+
+// BinPathFinder checks the an environment variable, derived from the symbolic name,
+// and falls back to a default assets location when this variable is not set
+func BinPathFinder(symbolicName string) (binPath string) {
+	punctuationPattern := regexp.MustCompile("[^A-Z0-9]+")
+	sanitizedName := punctuationPattern.ReplaceAllString(strings.ToUpper(symbolicName), "_")
+	leadingNumberPattern := regexp.MustCompile("^[0-9]+")
+	sanitizedName = leadingNumberPattern.ReplaceAllString(sanitizedName, "")
+	envVar := "TEST_ASSET_" + sanitizedName
+
+	if val, ok := os.LookupEnv(envVar); ok {
+		return val
+	}
+
+	return filepath.Join(assetsPath, symbolicName)
+}

--- a/pkg/internal/testing/integration/internal/bin_path_finder_test.go
+++ b/pkg/internal/testing/integration/internal/bin_path_finder_test.go
@@ -1,0 +1,66 @@
+package internal
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BinPathFinder", func() {
+	Context("when relying on the default assets path", func() {
+		var (
+			previousAssetsPath string
+		)
+		BeforeEach(func() {
+			previousAssetsPath = assetsPath
+			assetsPath = "/some/path/assets/bin"
+		})
+		AfterEach(func() {
+			assetsPath = previousAssetsPath
+		})
+		It("returns the default path when no env var is configured", func() {
+			binPath := BinPathFinder("some_bin")
+			Expect(binPath).To(Equal("/some/path/assets/bin/some_bin"))
+		})
+	})
+
+	Context("when environment is configured", func() {
+		var (
+			previousValue string
+			wasSet        bool
+		)
+		BeforeEach(func() {
+			envVarName := "TEST_ASSET_ANOTHER_SYMBOLIC_NAME"
+			if val, ok := os.LookupEnv(envVarName); ok {
+				previousValue = val
+				wasSet = true
+			}
+			os.Setenv(envVarName, "/path/to/some_bin.exe")
+		})
+		AfterEach(func() {
+			if wasSet {
+				os.Setenv("TEST_ASSET_ANOTHER_SYMBOLIC_NAME", previousValue)
+			} else {
+				os.Unsetenv("TEST_ASSET_ANOTHER_SYMBOLIC_NAME")
+			}
+		})
+		It("returns the path from the env", func() {
+			binPath := BinPathFinder("another_symbolic_name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+		})
+
+		It("sanitizes the environment variable name", func() {
+			By("cleaning all non-underscore punctuation")
+			binPath := BinPathFinder("another-symbolic name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			binPath = BinPathFinder("another+symbolic\\name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			binPath = BinPathFinder("another=symbolic.name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+			By("removing numbers from the beginning of the name")
+			binPath = BinPathFinder("12another_symbolic_name")
+			Expect(binPath).To(Equal("/path/to/some_bin.exe"))
+		})
+	})
+})

--- a/pkg/internal/testing/integration/internal/etcd.go
+++ b/pkg/internal/testing/integration/internal/etcd.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"net/url"
+)
+
+var EtcdDefaultArgs = []string{
+	"--listen-peer-urls=http://localhost:0",
+	"--advertise-client-urls={{ if .URL }}{{ .URL.String }}{{ end }}",
+	"--listen-client-urls={{ if .URL }}{{ .URL.String }}{{ end }}",
+	"--data-dir={{ .DataDir }}",
+}
+
+func DoEtcdArgDefaulting(args []string) []string {
+	if len(args) != 0 {
+		return args
+	}
+
+	return EtcdDefaultArgs
+}
+
+func isSecureScheme(scheme string) bool {
+	// https://github.com/coreos/etcd/blob/d9deeff49a080a88c982d328ad9d33f26d1ad7b6/pkg/transport/listener.go#L53
+	if scheme == "https" || scheme == "unixs" {
+		return true
+	}
+	return false
+}
+
+func GetEtcdStartMessage(listenURL url.URL) string {
+	if isSecureScheme(listenURL.Scheme) {
+		// https://github.com/coreos/etcd/blob/a7f1fbe00ec216fcb3a1919397a103b41dca8413/embed/serve.go#L167
+		return "serving client requests on "
+	}
+
+	// https://github.com/coreos/etcd/blob/a7f1fbe00ec216fcb3a1919397a103b41dca8413/embed/serve.go#L124
+	return "serving insecure client requests on "
+}

--- a/pkg/internal/testing/integration/internal/etcd_test.go
+++ b/pkg/internal/testing/integration/internal/etcd_test.go
@@ -1,0 +1,49 @@
+package internal_test
+
+import (
+	"net/url"
+
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Etcd", func() {
+	It("defaults Args if they are empty", func() {
+		initialArgs := []string{}
+		defaultedArgs := DoEtcdArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo(EtcdDefaultArgs))
+	})
+
+	It("keeps Args as is if they are not empty", func() {
+		initialArgs := []string{"--eins", "--zwei=2"}
+		defaultedArgs := DoEtcdArgDefaulting(initialArgs)
+		Expect(defaultedArgs).To(BeEquivalentTo([]string{
+			"--eins", "--zwei=2",
+		}))
+	})
+})
+
+var _ = Describe("GetEtcdStartMessage()", func() {
+	Context("when using a non tls URL", func() {
+		It("generates valid start message", func() {
+			url := url.URL{
+				Scheme: "http",
+				Host:   "some.insecure.host:1234",
+			}
+			message := GetEtcdStartMessage(url)
+			Expect(message).To(Equal("serving insecure client requests on "))
+		})
+	})
+	Context("when using a tls URL", func() {
+		It("generates valid start message", func() {
+			url := url.URL{
+				Scheme: "https",
+				Host:   "some.secure.host:8443",
+			}
+			message := GetEtcdStartMessage(url)
+			Expect(message).To(Equal("serving client requests on "))
+		})
+	})
+})

--- a/pkg/internal/testing/integration/internal/integration_tests/apiserver_integration_test.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/apiserver_integration_test.go
@@ -1,0 +1,24 @@
+package integrationtests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+)
+
+var _ = Describe("APIServer", func() {
+	Context("when no EtcdURL is provided", func() {
+		It("does not panic", func() {
+			apiServer := &APIServer{}
+
+			starter := func() {
+				Expect(apiServer.Start()).To(
+					MatchError(ContainSubstring("expected EtcdURL to be configured")),
+				)
+			}
+
+			Expect(starter).NotTo(Panic())
+		})
+	})
+})

--- a/pkg/internal/testing/integration/internal/integration_tests/doc.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/doc.go
@@ -1,0 +1,7 @@
+/*
+Package integrariontests is holding the integration tests to run against the
+framework.
+
+This file's only purpose is to make godep happy.
+*/
+package integrationtests

--- a/pkg/internal/testing/integration/internal/integration_tests/etcd_integration_test.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/etcd_integration_test.go
@@ -1,0 +1,66 @@
+package integrationtests
+
+import (
+	"bytes"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+)
+
+var _ = Describe("Etcd", func() {
+	It("sets the properties after defaulting", func() {
+		etcd := &Etcd{}
+
+		Expect(etcd.URL).To(BeZero())
+		Expect(etcd.DataDir).To(BeZero())
+		Expect(etcd.Path).To(BeZero())
+		Expect(etcd.StartTimeout).To(BeZero())
+		Expect(etcd.StopTimeout).To(BeZero())
+
+		Expect(etcd.Start()).To(Succeed())
+		defer func() {
+			Expect(etcd.Stop()).To(Succeed())
+		}()
+
+		Expect(etcd.URL).NotTo(BeZero())
+		Expect(etcd.DataDir).NotTo(BeZero())
+		Expect(etcd.Path).NotTo(BeZero())
+		Expect(etcd.StartTimeout).NotTo(BeZero())
+		Expect(etcd.StopTimeout).NotTo(BeZero())
+	})
+
+	It("can inspect IO", func() {
+		stderr := &bytes.Buffer{}
+		etcd := &Etcd{
+			Err: stderr,
+		}
+
+		Expect(etcd.Start()).To(Succeed())
+		defer func() {
+			Expect(etcd.Stop()).To(Succeed())
+		}()
+
+		Expect(stderr.String()).NotTo(BeEmpty())
+	})
+
+	It("can use user specified Args", func() {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		etcd := &Etcd{
+			Args:         []string{"--help"},
+			Out:          stdout,
+			Err:          stderr,
+			StartTimeout: 500 * time.Millisecond,
+		}
+
+		// it will timeout, as we'll never see the "startup message" we are waiting
+		// for on StdErr
+		Expect(etcd.Start()).To(MatchError(ContainSubstring("timeout")))
+
+		Expect(stdout.String()).To(ContainSubstring("member flags"))
+		Expect(stderr.String()).To(ContainSubstring("usage: etcd"))
+	})
+})

--- a/pkg/internal/testing/integration/internal/integration_tests/integration_suite_test.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/integration_suite_test.go
@@ -1,0 +1,14 @@
+package integrationtests
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIntegration(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Framework Integration Tests")
+}

--- a/pkg/internal/testing/integration/internal/integration_tests/integration_test.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/integration_test.go
@@ -1,0 +1,190 @@
+package integrationtests
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+)
+
+var _ = Describe("The Testing Framework", func() {
+	var controlPlane *integration.ControlPlane
+
+	AfterEach(func() {
+		Expect(controlPlane.Stop()).To(Succeed())
+	})
+
+	It("Successfully manages the control plane lifecycle", func() {
+		var err error
+
+		controlPlane = &integration.ControlPlane{}
+
+		By("Starting all the control plane processes")
+		err = controlPlane.Start()
+		Expect(err).NotTo(HaveOccurred(), "Expected controlPlane to start successfully")
+
+		apiServerURL := controlPlane.APIURL()
+		etcdClientURL := controlPlane.APIServer.EtcdURL
+
+		isEtcdListeningForClients := isSomethingListeningOnPort(etcdClientURL.Host)
+		isAPIServerListening := isSomethingListeningOnPort(apiServerURL.Host)
+
+		By("Ensuring Etcd is listening")
+		Expect(isEtcdListeningForClients()).To(BeTrue(),
+			fmt.Sprintf("Expected Etcd to listen for clients on %s,", etcdClientURL.Host))
+
+		By("Ensuring APIServer is listening")
+		CheckAPIServerIsReady(controlPlane.KubeCtl())
+
+		By("getting a kubectl & run it against the control plane")
+		kubeCtl := controlPlane.KubeCtl()
+		stdout, stderr, err := kubeCtl.Run("get", "pods")
+		Expect(err).NotTo(HaveOccurred())
+		bytes, err := ioutil.ReadAll(stdout)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes).To(BeEmpty())
+		Expect(stderr).To(ContainSubstring("No resources found"))
+
+		By("Stopping all the control plane processes")
+		err = controlPlane.Stop()
+		Expect(err).NotTo(HaveOccurred(), "Expected controlPlane to stop successfully")
+
+		By("Ensuring Etcd is not listening anymore")
+		Expect(isEtcdListeningForClients()).To(BeFalse(), "Expected Etcd not to listen for clients anymore")
+
+		By("Ensuring APIServer is not listening anymore")
+		Expect(isAPIServerListening()).To(BeFalse(), "Expected APIServer not to listen anymore")
+
+		By("Not erroring when stopping a stopped ControlPlane")
+		Expect(func() {
+			Expect(controlPlane.Stop()).To(Succeed())
+		}).NotTo(Panic())
+	})
+
+	Context("when Stop() is called on the control plane", func() {
+		Context("but the control plane is not started yet", func() {
+			It("does not error", func() {
+				controlPlane = &integration.ControlPlane{}
+
+				stoppingTheControlPlane := func() {
+					Expect(controlPlane.Stop()).To(Succeed())
+				}
+
+				Expect(stoppingTheControlPlane).NotTo(Panic())
+			})
+		})
+	})
+
+	Context("when the control plane is configured with its components", func() {
+		It("it does not default them", func() {
+			myEtcd, myAPIServer :=
+				&integration.Etcd{StartTimeout: 15 * time.Second},
+				&integration.APIServer{StopTimeout: 16 * time.Second}
+
+			controlPlane = &integration.ControlPlane{
+				Etcd:      myEtcd,
+				APIServer: myAPIServer,
+			}
+
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Etcd).To(BeIdenticalTo(myEtcd))
+			Expect(controlPlane.APIServer).To(BeIdenticalTo(myAPIServer))
+			Expect(controlPlane.Etcd.StartTimeout).To(Equal(15 * time.Second))
+			Expect(controlPlane.APIServer.StopTimeout).To(Equal(16 * time.Second))
+		})
+	})
+
+	Context("when etcd already started", func() {
+		It("starts the control plane successfully", func() {
+			myEtcd := &integration.Etcd{}
+			Expect(myEtcd.Start()).To(Succeed())
+
+			controlPlane = &integration.ControlPlane{
+				Etcd: myEtcd,
+			}
+
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
+	Context("when control plane is already started", func() {
+		It("can attempt to start again without errors", func() {
+			controlPlane = &integration.ControlPlane{}
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
+	Context("when control plane starts and stops", func() {
+		It("can attempt to start again without errors", func() {
+			controlPlane = &integration.ControlPlane{}
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Stop()).To(Succeed())
+			Expect(controlPlane.Start()).To(Succeed())
+		})
+	})
+
+	Measure("It should be fast to bring up and tear down the control plane", func(b Benchmarker) {
+		b.Time("lifecycle", func() {
+			controlPlane = &integration.ControlPlane{}
+
+			Expect(controlPlane.Start()).To(Succeed())
+			Expect(controlPlane.Stop()).To(Succeed())
+		})
+	}, 10)
+})
+
+type portChecker func() bool
+
+func isSomethingListeningOnPort(hostAndPort string) portChecker {
+	return func() bool {
+		conn, err := net.DialTimeout("tcp", hostAndPort, 1*time.Second)
+
+		if err != nil {
+			return false
+		}
+		conn.Close()
+		return true
+	}
+}
+
+// CheckAPIServerIsReady checks if the APIServer is really ready and not only
+// listening.
+//
+// While porting some tests in k/k
+// (https://github.com/hoegaarden/kubernetes/blob/287fdef1bd98646bc521f4433c1009936d5cf7a2/hack/make-rules/test-cmd-util.sh#L1524-L1535)
+// we found, that the APIServer was
+// listening but not serving certain APIs yet.
+//
+// We changed the readiness detection in the PR at
+// https://github.com/kubernetes-sigs/testing_frameworks/pull/48. To confirm
+// this changed behaviour does what it should do, we used the same test as in
+// k/k's test-cmd (see link above) and test if certain well-known known APIs
+// are actually available.
+func CheckAPIServerIsReady(kubeCtl *integration.KubeCtl) {
+	expectedAPIS := []string{
+		"/api/v1/namespaces/default/pods 200 OK",
+		"/api/v1/namespaces/default/replicationcontrollers 200 OK",
+		"/api/v1/namespaces/default/services 200 OK",
+		"/apis/apps/v1/namespaces/default/daemonsets 200 OK",
+		"/apis/apps/v1/namespaces/default/deployments 200 OK",
+		"/apis/apps/v1/namespaces/default/replicasets 200 OK",
+		"/apis/apps/v1/namespaces/default/statefulsets 200 OK",
+		"/apis/autoscaling/v1/namespaces/default/horizontalpodautoscalers 200",
+		"/apis/batch/v1/namespaces/default/jobs 200 OK",
+	}
+
+	_, output, err := kubeCtl.Run("--v=6", "--namespace", "default", "get", "all", "--chunk-size=0")
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	stdoutBytes, err := ioutil.ReadAll(output)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+	for _, api := range expectedAPIS {
+		ExpectWithOffset(1, string(stdoutBytes)).To(ContainSubstring(api))
+	}
+}

--- a/pkg/internal/testing/integration/internal/internal_suite_test.go
+++ b/pkg/internal/testing/integration/internal/internal_suite_test.go
@@ -1,0 +1,14 @@
+package internal_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestInternal(t *testing.T) {
+	t.Parallel()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Internal Suite")
+}

--- a/pkg/internal/testing/integration/internal/process.go
+++ b/pkg/internal/testing/integration/internal/process.go
@@ -1,0 +1,214 @@
+package internal
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
+)
+
+type ProcessState struct {
+	DefaultedProcessInput
+	Session *gexec.Session
+	// Healthcheck Endpoint. If we get http.StatusOK from this endpoint, we
+	// assume the process is ready to operate. E.g. "/healthz". If this is set,
+	// we ignore StartMessage.
+	HealthCheckEndpoint string
+	// HealthCheckPollInterval is the interval which will be used for polling the
+	// HealthCheckEndpoint.
+	// If left empty it will default to 100 Milliseconds.
+	HealthCheckPollInterval time.Duration
+	// StartMessage is the message to wait for on stderr. If we receive this
+	// message, we assume the process is ready to operate. Ignored if
+	// HealthCheckEndpoint is specified.
+	//
+	// The usage of StartMessage is discouraged, favour HealthCheckEndpoint
+	// instead!
+	//
+	// Deprecated: Use HealthCheckEndpoint in favour of StartMessage
+	StartMessage string
+	Args         []string
+
+	// ready holds wether the process is currently in ready state (hit the ready condition) or not.
+	// It will be set to true on a successful `Start()` and set to false on a successful `Stop()`
+	ready bool
+}
+
+type DefaultedProcessInput struct {
+	URL              url.URL
+	Dir              string
+	DirNeedsCleaning bool
+	Path             string
+	StopTimeout      time.Duration
+	StartTimeout     time.Duration
+}
+
+func DoDefaulting(
+	name string,
+	listenURL *url.URL,
+	dir string,
+	path string,
+	startTimeout time.Duration,
+	stopTimeout time.Duration,
+) (DefaultedProcessInput, error) {
+	defaults := DefaultedProcessInput{
+		Dir:          dir,
+		Path:         path,
+		StartTimeout: startTimeout,
+		StopTimeout:  stopTimeout,
+	}
+
+	if listenURL == nil {
+		port, host, err := addr.Suggest()
+		if err != nil {
+			return DefaultedProcessInput{}, err
+		}
+		defaults.URL = url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+		}
+	} else {
+		defaults.URL = *listenURL
+	}
+
+	if dir == "" {
+		newDir, err := ioutil.TempDir("", "k8s_test_framework_")
+		if err != nil {
+			return DefaultedProcessInput{}, err
+		}
+		defaults.Dir = newDir
+		defaults.DirNeedsCleaning = true
+	}
+
+	if path == "" {
+		if name == "" {
+			return DefaultedProcessInput{}, fmt.Errorf("must have at least one of name or path")
+		}
+		defaults.Path = BinPathFinder(name)
+	}
+
+	if startTimeout == 0 {
+		defaults.StartTimeout = 20 * time.Second
+	}
+
+	if stopTimeout == 0 {
+		defaults.StopTimeout = 20 * time.Second
+	}
+
+	return defaults, nil
+}
+
+type stopChannel chan struct{}
+
+func (ps *ProcessState) Start(stdout, stderr io.Writer) (err error) {
+	if ps.ready {
+		return nil
+	}
+
+	command := exec.Command(ps.Path, ps.Args...)
+
+	ready := make(chan bool)
+	timedOut := time.After(ps.StartTimeout)
+	var pollerStopCh stopChannel
+
+	if ps.HealthCheckEndpoint != "" {
+		healthCheckURL := ps.URL
+		healthCheckURL.Path = ps.HealthCheckEndpoint
+		pollerStopCh = make(stopChannel)
+		go pollURLUntilOK(healthCheckURL, ps.HealthCheckPollInterval, ready, pollerStopCh)
+	} else {
+		startDetectStream := gbytes.NewBuffer()
+		ready = startDetectStream.Detect(ps.StartMessage)
+		stderr = safeMultiWriter(stderr, startDetectStream)
+	}
+
+	ps.Session, err = gexec.Start(command, stdout, stderr)
+	if err != nil {
+		return err
+	}
+
+	select {
+	case <-ready:
+		ps.ready = true
+		return nil
+	case <-timedOut:
+		if pollerStopCh != nil {
+			close(pollerStopCh)
+		}
+		if ps.Session != nil {
+			ps.Session.Terminate()
+		}
+		return fmt.Errorf("timeout waiting for process %s to start", path.Base(ps.Path))
+	}
+}
+
+func safeMultiWriter(writers ...io.Writer) io.Writer {
+	safeWriters := []io.Writer{}
+	for _, w := range writers {
+		if w != nil {
+			safeWriters = append(safeWriters, w)
+		}
+	}
+	return io.MultiWriter(safeWriters...)
+}
+
+func pollURLUntilOK(url url.URL, interval time.Duration, ready chan bool, stopCh stopChannel) {
+	if interval <= 0 {
+		interval = 100 * time.Millisecond
+	}
+	for {
+		res, err := http.Get(url.String())
+		if err == nil && res.StatusCode == http.StatusOK {
+			ready <- true
+			return
+		}
+
+		select {
+		case <-stopCh:
+			return
+		default:
+			time.Sleep(interval)
+		}
+	}
+}
+
+func (ps *ProcessState) Stop() error {
+	if ps.Session == nil {
+		return nil
+	}
+
+	// gexec's Session methods (Signal, Kill, ...) do not check if the Process is
+	// nil, so we are doing this here for now.
+	// This should probably be fixed in gexec.
+	if ps.Session.Command.Process == nil {
+		return nil
+	}
+
+	detectedStop := ps.Session.Terminate().Exited
+	timedOut := time.After(ps.StopTimeout)
+
+	select {
+	case <-detectedStop:
+		break
+	case <-timedOut:
+		return fmt.Errorf("timeout waiting for process %s to stop", path.Base(ps.Path))
+	}
+	ps.ready = false
+	if ps.DirNeedsCleaning {
+		return os.RemoveAll(ps.Dir)
+	}
+
+	return nil
+}

--- a/pkg/internal/testing/integration/internal/process_test.go
+++ b/pkg/internal/testing/integration/internal/process_test.go
@@ -1,0 +1,373 @@
+package internal_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/ghttp"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+const (
+	healthURLPath = "/healthz"
+)
+
+var _ = Describe("Start method", func() {
+	var (
+		processState *ProcessState
+	)
+	BeforeEach(func() {
+		processState = &ProcessState{}
+		processState.Path = "bash"
+		processState.Args = simpleBashScript
+	})
+
+	It("can start a process", func() {
+		processState.StartTimeout = 10 * time.Second
+		processState.StartMessage = "loop 5"
+
+		err := processState.Start(nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
+	})
+
+	Context("when a health check endpoint is provided", func() {
+		var server *ghttp.Server
+		BeforeEach(func() {
+			server = ghttp.NewServer()
+		})
+		AfterEach(func() {
+			server.Close()
+		})
+
+		Context("when the healthcheck returns ok", func() {
+			BeforeEach(func() {
+				server.RouteToHandler("GET", healthURLPath, ghttp.RespondWith(http.StatusOK, ""))
+			})
+
+			It("hits the endpoint, and successfully starts", func() {
+				processState.HealthCheckEndpoint = healthURLPath
+				processState.StartTimeout = 100 * time.Millisecond
+				processState.URL = getServerURL(server)
+
+				err := processState.Start(nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(server.ReceivedRequests()).To(HaveLen(1))
+				Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
+			})
+		})
+
+		Context("when the healthcheck always returns failure", func() {
+			BeforeEach(func() {
+				server.RouteToHandler("GET", healthURLPath, ghttp.RespondWith(http.StatusInternalServerError, ""))
+			})
+			It("returns a timeout error and stops health API checker", func() {
+				processState.HealthCheckEndpoint = healthURLPath
+				processState.StartTimeout = 500 * time.Millisecond
+				processState.URL = getServerURL(server)
+
+				err := processState.Start(nil, nil)
+				Expect(err).To(MatchError(ContainSubstring("timeout")))
+
+				nrReceivedRequests := len(server.ReceivedRequests())
+				Expect(nrReceivedRequests).To(Equal(5))
+				time.Sleep(200 * time.Millisecond)
+				Expect(nrReceivedRequests).To(Equal(5))
+			})
+		})
+
+		Context("when the healthcheck isn't even listening", func() {
+			BeforeEach(func() {
+				server.Close()
+			})
+
+			It("returns a timeout error", func() {
+				processState.HealthCheckEndpoint = healthURLPath
+				processState.StartTimeout = 500 * time.Millisecond
+
+				port, host, err := addr.Suggest()
+				Expect(err).NotTo(HaveOccurred())
+
+				processState.URL = url.URL{
+					Scheme: "http",
+					Host:   net.JoinHostPort(host, strconv.Itoa(port)),
+				}
+
+				err = processState.Start(nil, nil)
+				Expect(err).To(MatchError(ContainSubstring("timeout")))
+			})
+		})
+
+		Context("when the healthcheck fails initially but succeeds eventually", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(
+					ghttp.RespondWith(http.StatusInternalServerError, ""),
+					ghttp.RespondWith(http.StatusInternalServerError, ""),
+					ghttp.RespondWith(http.StatusInternalServerError, ""),
+					ghttp.RespondWith(http.StatusOK, ""),
+				)
+			})
+
+			It("hits the endpoint repeatedly, and successfully starts", func() {
+				processState.HealthCheckEndpoint = healthURLPath
+				processState.StartTimeout = 20 * time.Second
+				processState.URL = getServerURL(server)
+
+				err := processState.Start(nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(server.ReceivedRequests()).To(HaveLen(4))
+				Consistently(processState.Session.ExitCode).Should(BeNumerically("==", -1))
+			})
+
+			Context("when the polling interval is not configured", func() {
+				It("uses the default interval for polling", func() {
+					processState.HealthCheckEndpoint = "/helathz"
+					processState.StartTimeout = 300 * time.Millisecond
+					processState.URL = getServerURL(server)
+
+					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+				})
+			})
+
+			Context("when the polling interval is configured", func() {
+				BeforeEach(func() {
+					processState.HealthCheckPollInterval = time.Millisecond * 20
+				})
+
+				It("hits the endpoint in the configured interval", func() {
+					processState.HealthCheckEndpoint = healthURLPath
+					processState.StartTimeout = 3 * processState.HealthCheckPollInterval
+					processState.URL = getServerURL(server)
+
+					Expect(processState.Start(nil, nil)).To(MatchError(ContainSubstring("timeout")))
+					Expect(server.ReceivedRequests()).To(HaveLen(3))
+				})
+			})
+		})
+	})
+
+	Context("when a health check endpoint is not provided", func() {
+
+		Context("when process takes too long to start", func() {
+			It("returns a timeout error", func() {
+				processState.StartTimeout = 200 * time.Millisecond
+				processState.StartMessage = "loop 5000"
+
+				err := processState.Start(nil, nil)
+				Expect(err).To(MatchError(ContainSubstring("timeout")))
+
+				Eventually(processState.Session.ExitCode).Should(Equal(143))
+			})
+		})
+
+		Context("when the command cannot be started", func() {
+			var err error
+
+			BeforeEach(func() {
+				processState = &ProcessState{}
+				processState.Path = "/nonexistent"
+
+				err = processState.Start(nil, nil)
+			})
+
+			It("propagates the error", func() {
+				Expect(os.IsNotExist(err)).To(BeTrue())
+			})
+
+			Context("but Stop() is called on it", func() {
+				It("does not panic", func() {
+					stoppingFailedProcess := func() {
+						Expect(processState.Stop()).To(Succeed())
+					}
+
+					Expect(stoppingFailedProcess).NotTo(Panic())
+				})
+			})
+		})
+	})
+
+	Context("when IO is configured", func() {
+		It("can inspect stdout & stderr", func() {
+			stdout := &bytes.Buffer{}
+			stderr := &bytes.Buffer{}
+
+			processState.Args = []string{
+				"-c",
+				`
+					echo 'this is stderr' >&2
+					echo 'that is stdout'
+					echo 'i started' >&2
+				`,
+			}
+			processState.StartMessage = "i started"
+			processState.StartTimeout = 1 * time.Second
+
+			Expect(processState.Start(stdout, stderr)).To(Succeed())
+
+			Expect(stdout.String()).To(Equal("that is stdout\n"))
+			Expect(stderr.String()).To(Equal("this is stderr\ni started\n"))
+		})
+	})
+})
+
+var _ = Describe("Stop method", func() {
+	Context("when Stop() is called", func() {
+		var (
+			processState *ProcessState
+		)
+		BeforeEach(func() {
+			var err error
+			processState = &ProcessState{}
+			processState.Session, err = gexec.Start(getSimpleCommand(), nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			processState.StopTimeout = 10 * time.Second
+		})
+
+		It("stops the process", func() {
+			Expect(processState.Stop()).To(Succeed())
+		})
+
+		Context("multiple times", func() {
+			It("does not error or panic on consecutive calls", func() {
+				stoppingTheProcess := func() {
+					Expect(processState.Stop()).To(Succeed())
+				}
+				Expect(stoppingTheProcess).NotTo(Panic())
+				Expect(stoppingTheProcess).NotTo(Panic())
+				Expect(stoppingTheProcess).NotTo(Panic())
+			})
+		})
+	})
+
+	Context("when the command cannot be stopped", func() {
+		It("returns a timeout error", func() {
+			var err error
+
+			processState := &ProcessState{}
+			processState.Session, err = gexec.Start(getSimpleCommand(), nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			processState.Session.Exited = make(chan struct{})
+			processState.StopTimeout = 200 * time.Millisecond
+
+			Expect(processState.Stop()).To(MatchError(ContainSubstring("timeout")))
+		})
+	})
+
+	Context("when the directory needs to be cleaned up", func() {
+		It("removes the directory", func() {
+			var err error
+
+			processState := &ProcessState{}
+			processState.Session, err = gexec.Start(getSimpleCommand(), nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			processState.Dir, err = ioutil.TempDir("", "k8s_test_framework_")
+			Expect(err).NotTo(HaveOccurred())
+			processState.DirNeedsCleaning = true
+			processState.StopTimeout = 400 * time.Millisecond
+
+			Expect(processState.Stop()).To(Succeed())
+			Expect(processState.Dir).NotTo(BeAnExistingFile())
+		})
+	})
+})
+
+var _ = Describe("DoDefaulting", func() {
+	Context("when all inputs are provided", func() {
+		It("passes them through", func() {
+			defaults, err := DoDefaulting(
+				"some name",
+				&url.URL{Host: "some.host.to.listen.on"},
+				"/some/dir",
+				"/some/path/to/some/bin",
+				20*time.Hour,
+				65537*time.Millisecond,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(defaults.URL).To(Equal(url.URL{Host: "some.host.to.listen.on"}))
+			Expect(defaults.Dir).To(Equal("/some/dir"))
+			Expect(defaults.DirNeedsCleaning).To(BeFalse())
+			Expect(defaults.Path).To(Equal("/some/path/to/some/bin"))
+			Expect(defaults.StartTimeout).To(Equal(20 * time.Hour))
+			Expect(defaults.StopTimeout).To(Equal(65537 * time.Millisecond))
+		})
+	})
+
+	Context("when inputs are empty", func() {
+		It("defaults them", func() {
+			defaults, err := DoDefaulting(
+				"some name",
+				nil,
+				"",
+				"",
+				0,
+				0,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(defaults.Dir).To(BeADirectory())
+			Expect(os.RemoveAll(defaults.Dir)).To(Succeed())
+			Expect(defaults.DirNeedsCleaning).To(BeTrue())
+
+			Expect(defaults.URL).NotTo(BeZero())
+			Expect(defaults.URL.Scheme).To(Equal("http"))
+			Expect(defaults.URL.Hostname()).NotTo(BeEmpty())
+			Expect(defaults.URL.Port()).NotTo(BeEmpty())
+
+			Expect(defaults.Path).NotTo(BeEmpty())
+
+			Expect(defaults.StartTimeout).NotTo(BeZero())
+			Expect(defaults.StopTimeout).NotTo(BeZero())
+		})
+	})
+
+	Context("when neither name nor path are provided", func() {
+		It("returns an error", func() {
+			_, err := DoDefaulting(
+				"",
+				nil,
+				"",
+				"",
+				0,
+				0,
+			)
+			Expect(err).To(MatchError("must have at least one of name or path"))
+		})
+	})
+})
+
+var simpleBashScript = []string{
+	"-c",
+	`
+		i=0
+		while true
+		do
+			echo "loop $i" >&2
+			let 'i += 1'
+			sleep 0.2
+		done
+	`,
+}
+
+func getSimpleCommand() *exec.Cmd {
+	return exec.Command("bash", simpleBashScript...)
+}
+
+func getServerURL(server *ghttp.Server) url.URL {
+	url, err := url.Parse(server.URL())
+	Expect(err).NotTo(HaveOccurred())
+	return *url
+}

--- a/pkg/internal/testing/integration/kubectl.go
+++ b/pkg/internal/testing/integration/kubectl.go
@@ -1,0 +1,47 @@
+package integration
+
+import (
+	"bytes"
+	"io"
+	"os/exec"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
+)
+
+// KubeCtl is a wrapper around the kubectl binary.
+type KubeCtl struct {
+	// Path where the kubectl binary can be found.
+	//
+	// If this is left empty, we will attempt to locate a binary, by checking for
+	// the TEST_ASSET_KUBECTL environment variable, and the default test assets
+	// directory. See the "Binaries" section above (in doc.go) for details.
+	Path string
+
+	// Opts can be used to configure additional flags which will be used each
+	// time the wrapped binary is called.
+	//
+	// For example, you might want to use this to set the URL of the APIServer to
+	// connect to.
+	Opts []string
+}
+
+// Run executes the wrapped binary with some preconfigured options and the
+// arguments given to this method. It returns Readers for the stdout and
+// stderr.
+func (k *KubeCtl) Run(args ...string) (stdout, stderr io.Reader, err error) {
+	if k.Path == "" {
+		k.Path = internal.BinPathFinder("kubectl")
+	}
+
+	stdoutBuffer := &bytes.Buffer{}
+	stderrBuffer := &bytes.Buffer{}
+	allArgs := append(k.Opts, args...)
+
+	cmd := exec.Command(k.Path, allArgs...)
+	cmd.Stdout = stdoutBuffer
+	cmd.Stderr = stderrBuffer
+
+	err = cmd.Run()
+
+	return stdoutBuffer, stderrBuffer, err
+}

--- a/pkg/internal/testing/integration/kubectl_test.go
+++ b/pkg/internal/testing/integration/kubectl_test.go
@@ -1,0 +1,39 @@
+package integration_test
+
+import (
+	"io/ioutil"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+)
+
+var _ = Describe("Kubectl", func() {
+	It("runs kubectl", func() {
+		k := &KubeCtl{Path: "bash"}
+		args := []string{"-c", "echo 'something'"}
+		stdout, stderr, err := k.Run(args...)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stdout).To(ContainSubstring("something"))
+		bytes, err := ioutil.ReadAll(stderr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(bytes).To(BeEmpty())
+	})
+
+	Context("when the command returns a non-zero exit code", func() {
+		It("returns an error", func() {
+			k := &KubeCtl{Path: "bash"}
+			args := []string{
+				"-c", "echo 'this is StdErr' >&2; echo 'but this is StdOut' >&1; exit 66",
+			}
+
+			stdout, stderr, err := k.Run(args...)
+
+			Expect(err).To(MatchError(ContainSubstring("exit status 66")))
+
+			Expect(stdout).To(ContainSubstring("but this is StdOut"))
+			Expect(stderr).To(ContainSubstring("this is StdErr"))
+		})
+	})
+})


### PR DESCRIPTION
This is bringing in https://github.com/kubernetes-sigs/testing_frameworks/tree/694245ac7b60bff90cc8b159fbd8ddb7efe3f218.

The package is fully integrated into the local tooling, e.g.:
- updated import path
- uses the same binary assets for testing
- runs its tests as part of `make test` and on prow
- updated OWNERS

In the original repo the CLA bot was enabled, thus all commits that have been
squashed here should be fine regarding the CLA.
All authors and committers of the squashed commits have been added here as
co-authors.

Superseds https://github.com/kubernetes-sigs/controller-runtime/pull/714 (see: https://github.com/kubernetes-sigs/controller-runtime/pull/714#issuecomment-564578313) 
/assign @DirectXMan12 @gerred