### PR TITLE
📖 docs: document the expected names of the TLS key and certificate

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -170,7 +170,8 @@ type Options struct {
 
 	// CertDir is the directory that contains the server key and certificate.
 	// if not set, webhook server would look up the server key and certificate in
-	// {TempDir}/k8s-webhook-server/serving-certs
+	// {TempDir}/k8s-webhook-server/serving-certs. The server key and certificate
+	// must be named tls.key and tls.crt, respectively.
 	CertDir string
 	// Functions to all for a user to customize the values that will be injected.
 

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -52,7 +52,9 @@ type Server struct {
 	// It will be defaulted to 443 if unspecified.
 	Port int
 
-	// CertDir is the directory that contains the server key and certificate.
+	// CertDir is the directory that contains the server key and certificate. The
+	// server key and certificate must be named tls.key and tls.crt,
+	// respectively.
 	CertDir string
 
 	// WebhookMux is the multiplexer that handles different webhooks.


### PR DESCRIPTION
Document the expected names of TLS key and certificate so that users don't have dig through code to discover it.