### PR TITLE
:bug: When loading client config, check os/user.HomeDir if $HOME is unset

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"path"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -129,10 +130,9 @@ func loadConfig(context string) (*rest.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not get current user: %v", err)
 		}
-		if err := os.Setenv("HOME", u.HomeDir); err != nil {
-			return nil, fmt.Errorf("could not set HOME env var: %v", err)
-		}
-		defer func() { _ = os.Unsetenv("HOME") }()
+		oldRecommendedHomeFile := clientcmd.RecommendedHomeFile
+		clientcmd.RecommendedHomeFile = path.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName)
+		defer func() { clientcmd.RecommendedHomeFile = oldRecommendedHomeFile }()
 	}
 	if c, err := loadConfigWithContext(apiServerURL, clientcmd.NewDefaultClientConfigLoadingRules(), context); err == nil {
 		return c, nil


### PR DESCRIPTION
Following up on the regression introduced in #642 and discussed in #748, this PR detects if $HOME is empty and, if so, automatically sets $HOME to user.Current before using client-go's default loading rules, which only checks $HOME.

As a follow-on, we could submit an issue upstream to see if it makes sense for client-go to use user.Current as a fallback so that we don't have to do it here in controller-runtime.

Closes #748 