### PR TITLE
:bug: wait for cache start before returning from WaitForCacheSync

### DIFF
--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -68,6 +68,12 @@ func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
 	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)
 
+	if !m.structured.waitForStarted(stop) {
+		return false
+	}
+	if !m.unstructured.waitForStarted(stop) {
+		return false
+	}
 	return cache.WaitForCacheSync(stop, syncedFuncs...)
 }
 

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -63,7 +63,7 @@ func (m *InformersMap) Start(stop <-chan struct{}) error {
 	return nil
 }
 
-// WaitForCacheSync waits until all the caches have been synced.
+// WaitForCacheSync waits until all the caches have been started and synced.
 func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
 	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)


### PR DESCRIPTION
There is currently an unintuitive race condition between starting
a cache, waiting for it to sync, and using it the first time.

The crux of the problem is that WaitForCacheSync can return true
BEFORE the Start function has had a chance to set started to true.

This means that Get and List can return ErrCacheNotStarted even
after WaitForCacheSync has returned true.

This commit adds a channel and a wait function that is called from
WaitForCacheSync to ensure that started has been set to true before
returning.
