### PR TITLE
:sparkles: support restconfig to target the control plane

### DIFF
--- a/pkg/internal/testing/integration/control_plane.go
+++ b/pkg/internal/testing/integration/control_plane.go
@@ -3,6 +3,10 @@ package integration
 import (
 	"fmt"
 	"net/url"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
 // ControlPlane is a struct that knows how to start your test control plane.
@@ -56,4 +60,17 @@ func (f *ControlPlane) KubeCtl() *KubeCtl {
 	k := &KubeCtl{}
 	k.Opts = append(k.Opts, fmt.Sprintf("--server=%s", f.APIURL()))
 	return k
+}
+
+// RESTClientConfig returns a pre-configured restconfig, ready to connect to
+// this ControlPlane.
+func (f *ControlPlane) RESTClientConfig() (*rest.Config, error) {
+	c := &rest.Config{
+		Host: f.APIURL().String(),
+		ContentConfig: rest.ContentConfig{
+			NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: scheme.Codecs},
+		},
+	}
+	err := rest.SetKubernetesDefaults(c)
+	return c, err
 }


### PR DESCRIPTION
This PR is purely re-targeting https://github.com/kubernetes-sigs/testing_frameworks/pull/68 to controller-runtime.