### PR TITLE
 📖 (:book:, docs) Remove references to 'download-binaries.sh'

### DIFF
--- a/pkg/internal/testing/integration/assets/bin/.gitkeep
+++ b/pkg/internal/testing/integration/assets/bin/.gitkeep
@@ -1,1 +1,1 @@
-This directory will be the home of some binaries which are downloaded with `pkg/framework/test/scripts/download-binaries`.
+This directory will be the home of some binaries which are downloaded with `make test` or `.../hack/check-everything.sh`.

--- a/pkg/internal/testing/integration/doc.go
+++ b/pkg/internal/testing/integration/doc.go
@@ -8,9 +8,7 @@ needed to provide this API is managed by this framework.
 
 Quickstart
 
-If you want to test a kubernetes client against the latest kubernetes APIServer
-and Etcd, you can use `./scripts/download-binaries.sh` to download APIServer
-and Etcd binaries for your platform. Then add something like the following to
+Add something like the following to
 your tests:
 
 	cp := &integration.ControlPlane{}
@@ -70,11 +68,6 @@ APIServer, Etcd or KubeCtl.
 3. If neither the `Path` field, nor the environment variable is set, the
 framework tries to use the binaries `kube-apiserver`, `etcd` or `kubectl` in
 the directory `${FRAMEWORK_DIR}/assets/bin/`.
-
-For convenience this framework ships with
-`${FRAMEWORK_DIR}/scripts/download-binaries.sh` which can be used to download
-pre-compiled versions of the needed binaries and place them in the default
-location (`${FRAMEWORK_DIR}/assets/bin/`).
 
 Arguments for Etcd and APIServer
 


### PR DESCRIPTION
When bringing in the testing framework in #749 download-binaries.sh was not moved over but the references to it remain in the docs. This PR removes them.