### PR TITLE
🏃 (:running:, other) Fix makefile and docs for running tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,4 +16,4 @@ Please see https://git.k8s.io/community/CLA.md for more info
 
 ## Test locally
 
-Run the command `make check-all` to test the changes locally.
+Run the command `make test` to test the changes locally.

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:  ## Display this help
 
 ##@ Tests
 
-.PHONY: check-all
+.PHONY: test
 test: ## Run the script check-everything.sh which will check all
 	GO111MODULE=on TRACE=1 ./hack/check-everything.sh
 


### PR DESCRIPTION
Makefile target name was incorrect and running `make check-all` actually did not do anything.
