### PR TITLE
:running: Remove unused variable from IsConvertible

### DIFF
--- a/pkg/webhook/conversion/conversion.go
+++ b/pkg/webhook/conversion/conversion.go
@@ -264,10 +264,6 @@ func IsConvertible(scheme *runtime.Scheme, obj runtime.Object) (bool, error) {
 	}
 
 	if len(hubs) == 1 && len(nonSpokes) == 0 { // convertible
-		spokeVersions := []string{}
-		for _, sp := range spokes {
-			spokeVersions = append(spokeVersions, sp.GetObjectKind().GroupVersionKind().String())
-		}
 		return true, nil
 	}
 


### PR DESCRIPTION
The log message that used this was removed in this commit https://github.com/kubernetes-sigs/controller-runtime/commit/0f2e574d471454928fafffcaaafeed581ef89aae#r36915807
