### PR TITLE
🏃 (:running:, other) Try to stabilize the flaky process_test

### DIFF
--- a/pkg/internal/testing/integration/internal/process_test.go
+++ b/pkg/internal/testing/integration/internal/process_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Start method", func() {
 
 			Context("when the polling interval is configured", func() {
 				BeforeEach(func() {
-					processState.HealthCheckPollInterval = time.Millisecond * 20
+					processState.HealthCheckPollInterval = time.Millisecond * 150
 				})
 
 				It("hits the endpoint in the configured interval", func() {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
The test is flaky, see https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-runtime/592/pull-controller-runtime-test-master/1220082018474266624 or https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-runtime/776/pull-controller-runtime-test-master/1220286274334625792

My hunch was that 20 millis is not enoughso I tried fixing the test by using much bigger poll interval.