### PR TITLE
:running: Use scheme.Convert to convert unstructrured objects

### DIFF
--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -114,7 +114,7 @@ func defaultCRDOptions(o *CRDInstallOptions) {
 func WaitForCRDs(config *rest.Config, crds []runtime.Object, options CRDInstallOptions) error {
 	// Add each CRD to a map of GroupVersion to Resource
 	waitingFor := map[schema.GroupVersion]*sets.String{}
-	for _, crd := range runtimeListToUnstructured(crds) {
+	for _, crd := range runtimeCRDListToUnstructured(crds) {
 		gvs := []schema.GroupVersion{}
 		crdGroup, _, err := unstructured.NestedString(crd.Object, "spec", "group")
 		if err != nil {
@@ -230,7 +230,7 @@ func UninstallCRDs(config *rest.Config, options CRDInstallOptions) error {
 	}
 
 	// Uninstall each CRD
-	for _, crd := range runtimeListToUnstructured(options.CRDs) {
+	for _, crd := range runtimeCRDListToUnstructured(options.CRDs) {
 		log.V(1).Info("uninstalling CRD", "crd", crd.GetName())
 		if err := cs.Delete(context.TODO(), crd); err != nil {
 			// If CRD is not found, we can consider success
@@ -251,7 +251,7 @@ func CreateCRDs(config *rest.Config, crds []runtime.Object) error {
 	}
 
 	// Create each CRD
-	for _, crd := range runtimeListToUnstructured(crds) {
+	for _, crd := range runtimeCRDListToUnstructured(crds) {
 		log.V(1).Info("installing CRD", "crd", crd.GetName())
 		existingCrd := crd.DeepCopy()
 		err := cs.Get(context.TODO(), client.ObjectKey{Name: crd.GetName()}, existingCrd)
@@ -314,7 +314,7 @@ func renderCRDs(options *CRDInstallOptions) ([]runtime.Object, error) {
 		crds = append(crds, crdList...)
 	}
 
-	return unstructuredListToRuntime(crds), nil
+	return unstructuredCRDListToRuntime(crds), nil
 }
 
 // readCRDs reads the CRDs from files and Unmarshals them into structs

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Test", func() {
 
 	// Cleanup CRDs
 	AfterEach(func(done Done) {
-		for _, crd := range runtimeListToUnstructured(crds) {
+		for _, crd := range runtimeCRDListToUnstructured(crds) {
 			// Delete only if CRD exists.
 			crdObjectKey := client.ObjectKey{
 				Name: crd.GetName(),

--- a/pkg/envtest/helper.go
+++ b/pkg/envtest/helper.go
@@ -3,9 +3,21 @@ package envtest
 import (
 	"reflect"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 )
+
+var (
+	crdScheme = runtime.NewScheme()
+)
+
+// init is required to correctly initialize the crdScheme package variable.
+func init() {
+	_ = apiextensionsv1.AddToScheme(crdScheme)
+	_ = apiextensionsv1beta1.AddToScheme(crdScheme)
+}
 
 // mergePaths merges two string slices containing paths.
 // This function makes no guarantees about order of the merged slice.
@@ -30,10 +42,10 @@ func mergePaths(s1, s2 []string) []string {
 // This function makes no guarantees about order of the merged slice.
 func mergeCRDs(s1, s2 []runtime.Object) []runtime.Object {
 	m := make(map[string]*unstructured.Unstructured)
-	for _, obj := range runtimeListToUnstructured(s1) {
+	for _, obj := range runtimeCRDListToUnstructured(s1) {
 		m[obj.GetName()] = obj
 	}
-	for _, obj := range runtimeListToUnstructured(s2) {
+	for _, obj := range runtimeCRDListToUnstructured(s2) {
 		m[obj.GetName()] = obj
 	}
 	merged := make([]runtime.Object, len(m))
@@ -57,21 +69,20 @@ func existsUnstructured(s1, s2 []*unstructured.Unstructured) bool {
 	return false
 }
 
-func runtimeListToUnstructured(l []runtime.Object) []*unstructured.Unstructured {
+func runtimeCRDListToUnstructured(l []runtime.Object) []*unstructured.Unstructured {
 	res := []*unstructured.Unstructured{}
 	for _, obj := range l {
-		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())
-		if err != nil {
+		u := &unstructured.Unstructured{}
+		if err := crdScheme.Convert(obj, u, nil); err != nil {
+			log.Error(err, "error converting to unstructured object", "object-kind", obj.GetObjectKind())
 			continue
 		}
-		res = append(res, &unstructured.Unstructured{
-			Object: m,
-		})
+		res = append(res, u)
 	}
 	return res
 }
 
-func unstructuredListToRuntime(l []*unstructured.Unstructured) []runtime.Object {
+func unstructuredCRDListToRuntime(l []*unstructured.Unstructured) []runtime.Object {
 	res := []runtime.Object{}
 	for _, obj := range l {
 		res = append(res, obj.DeepCopy())


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This PR updates the envtest helper to use a local scheme and the `Convert` method, which should preserve the TypeMeta information.

`runtime.DefaultUnstructuredConverter` doesn't know how to populate `TypeMeta` information from the Go Struct, while `scheme.Convert` uses internal helper methods to figure that out. 

From a UX point of view, this change has the benefit that `envtest` users can use the Go structs without worrying about TypeMeta. If TypeMeta isn't present when we install CRDs, the installation will fail and `envtest` won't start.

