### PR TITLE
🐛 (:bug:, patch) Fix panic in call to processState.Stop()

### DIFF
--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -125,7 +125,10 @@ func (s *APIServer) setProcessState() error {
 // Stop stops this process gracefully, waits for its termination, and cleans up
 // the CertDir if necessary.
 func (s *APIServer) Stop() error {
-	return s.processState.Stop()
+	if s.processState != nil {
+		return s.processState.Stop()
+	}
+	return nil
 }
 
 // APIServerDefaultArgs exposes the default args for the APIServer so that you


### PR DESCRIPTION
When start of controlplane fails, the call to Stop will panic b/c processState was never allocated. The fix just adds a simple non-nil check before calling `s.processState.Stop()`. 

See a failed run here: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api/1963/pull-cluster-api-test/1220713178762055683 