### PR TITLE
✨ Enable signal handler to close channel after sleeping for some seconds

### DIFF
--- a/pkg/manager/signals/doc.go
+++ b/pkg/manager/signals/doc.go
@@ -18,3 +18,9 @@ limitations under the License.
 // shutdown the manager in combination with Kubernetes pod graceful termination
 // policy.
 package signals
+
+import (
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+)
+
+var log = logf.RuntimeLog.WithName("signal")


### PR DESCRIPTION
This PR is an implementation of https://github.com/kubernetes-sigs/controller-runtime/issues/764.
By inserting sleep just after the signal handler, we can wait for the endpoint of a k8s pod to be deleted without `/bin/sleep` in `preStop` hook.

The default sleeping period is 0sec, so this PR does not change the current behavior as long as the environment variable is not set.
