### PR TITLE
:running: Clean up OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,9 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-owners:
-  - directxman12
-  - droot
-  - pwittrock
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
 approvers:
   - controller-runtime-admins
-  - controller-runtime-maintainers
+  - controller-runtime-approvers
 reviewers:
   - controller-runtime-admins
-  - controller-runtime-maintainers
   - controller-runtime-reviewers
+  - controller-runtime-approvers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,11 +1,19 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 aliases:
+  # active folks who can be contacted to perform admin-related
+  # tasks on the repo, or otherwise approve any PRS.
   controller-runtime-admins:
   - directxman12
   - droot
-  - pwittrock
-  controller-runtime-maintainers: []
+  - mengqiy
+
+  # non-admin folks who can approve any PRs in the repo
+  controller-runtime-approvers: []
+
+  # folks who can review and LGTM any PRs in the repo (doesn't
+  # include approvers & admins -- those count too via the OWNERS
+  # file)
   controller-runtime-reviewers:
   - alvaroaleman
   - shawn-hurley
@@ -13,7 +21,15 @@ aliases:
   - joelanford
   - alenkacz
   - vincepri
-  testing-integration-admins:
+
+  # folks to can approve things in the directly-ported
+  # testing_frameworks portions of the codebase
+  testing-integration-approvers:
   - apelisse
   - hoegaarden
   - totherme
+
+  # folks who may have context on ancient history,
+  # but are no longer directly involved
+  controller-runtime-emeritus-maintainers:
+  - pwittrock

--- a/pkg/internal/testing/OWNERS
+++ b/pkg/internal/testing/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
 
 approvers:
-  - controller-runtime-admins
-  - testing-integration-admins
+  - testing-integration-approvers


### PR DESCRIPTION
This cleans up the owners file, making sure that only active members
will be assigned and bringing it in line with the latest docs on the
OWNERS file from the main k/community repo.
