### PR TITLE
🐛 Integration test should close http body

### DIFF
--- a/hack/verify.sh
+++ b/hack/verify.sh
@@ -42,6 +42,7 @@ golangci-lint run --disable-all \
     --enable=lll \
     --enable=dupl \
     --enable=goimports \
+    --enable=bodyclose \
     ./pkg/... ./examples/... .
 
 # TODO: Enable these as we fix them to make them pass

--- a/pkg/internal/testing/integration/internal/process.go
+++ b/pkg/internal/testing/integration/internal/process.go
@@ -170,9 +170,12 @@ func pollURLUntilOK(url url.URL, interval time.Duration, ready chan bool, stopCh
 	}
 	for {
 		res, err := http.Get(url.String())
-		if err == nil && res.StatusCode == http.StatusOK {
-			ready <- true
-			return
+		if err == nil {
+			res.Body.Close()
+			if res.StatusCode == http.StatusOK {
+				ready <- true
+				return
+			}
 		}
 
 		select {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This PR makes sure the `pollURLUntilOK` function closes the body from `http.Get` if there is no error, and adds `bodyclose` linter to the enabled linters.