### PR TITLE
⚠ (:warning:, major) Webhook support in envtest

### DIFF
--- a/pkg/envtest/envtest_suite_test.go
+++ b/pkg/envtest/envtest_suite_test.go
@@ -21,6 +21,10 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
+	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
@@ -35,11 +39,100 @@ var env *Environment
 var _ = BeforeSuite(func(done Done) {
 	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))
 	env = &Environment{}
+	// we're initializing webhook here and not in webhook.go to also test the envtest install code via WebhookOptions
+	initializeWebhookInEnvironment()
 	_, err := env.Start()
 	Expect(err).NotTo(HaveOccurred())
 
 	close(done)
 }, StartTimeout)
+
+func initializeWebhookInEnvironment() {
+	namespacedScopeV1Beta1 := admissionv1beta1.NamespacedScope
+	namespacedScopeV1 := admissionv1.NamespacedScope
+	failedTypeV1Beta1 := admissionv1beta1.Fail
+	failedTypeV1 := admissionv1.Fail
+	equivalentTypeV1Beta1 := admissionv1beta1.Equivalent
+	equivalentTypeV1 := admissionv1.Equivalent
+	noSideEffectsV1Beta1 := admissionv1beta1.SideEffectClassNone
+	noSideEffectsV1 := admissionv1.SideEffectClassNone
+	webhookPathV1 := "/failing"
+
+	env.WebhookInstallOptions = WebhookInstallOptions{
+		ValidatingWebhooks: []runtime.Object{
+			&admissionv1beta1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment-validation-webhook-config",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ValidatingWebhookConfiguration",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
+				},
+				Webhooks: []admissionv1beta1.ValidatingWebhook{
+					{
+						Name: "deployment-validation.kubebuilder.io",
+						Rules: []admissionv1beta1.RuleWithOperations{
+							{
+								Operations: []admissionv1beta1.OperationType{"CREATE", "UPDATE"},
+								Rule: admissionv1beta1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"deployments"},
+									Scope:       &namespacedScopeV1Beta1,
+								},
+							},
+						},
+						FailurePolicy: &failedTypeV1Beta1,
+						MatchPolicy:   &equivalentTypeV1Beta1,
+						SideEffects:   &noSideEffectsV1Beta1,
+						ClientConfig: admissionv1beta1.WebhookClientConfig{
+							Service: &admissionv1beta1.ServiceReference{
+								Name:      "deployment-validation-service",
+								Namespace: "default",
+								Path:      &webhookPathV1,
+							},
+						},
+					},
+				},
+			},
+			&admissionv1.ValidatingWebhookConfiguration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deployment-validation-webhook-config",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ValidatingWebhookConfiguration",
+					APIVersion: "admissionregistration.k8s.io/v1beta1",
+				},
+				Webhooks: []admissionv1.ValidatingWebhook{
+					{
+						Name: "deployment-validation.kubebuilder.io",
+						Rules: []admissionv1.RuleWithOperations{
+							{
+								Operations: []admissionv1.OperationType{"CREATE", "UPDATE"},
+								Rule: admissionv1.Rule{
+									APIGroups:   []string{"apps"},
+									APIVersions: []string{"v1"},
+									Resources:   []string{"deployments"},
+									Scope:       &namespacedScopeV1,
+								},
+							},
+						},
+						FailurePolicy: &failedTypeV1,
+						MatchPolicy:   &equivalentTypeV1,
+						SideEffects:   &noSideEffectsV1,
+						ClientConfig: admissionv1.WebhookClientConfig{
+							Service: &admissionv1.ServiceReference{
+								Name:      "deployment-validation-service",
+								Namespace: "default",
+								Path:      &webhookPathV1,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
 
 var _ = AfterSuite(func(done Done) {
 	Expect(env.Stop()).NotTo(HaveOccurred())

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -779,16 +779,18 @@ var _ = Describe("Test", func() {
 
 	Describe("Start", func() {
 		It("should raise an error on invalid dir when flag is enabled", func(done Done) {
-			env = &Environment{ErrorIfCRDPathMissing: true, CRDDirectoryPaths: []string{invalidDirectory}}
+			env := &Environment{ErrorIfCRDPathMissing: true, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).To(HaveOccurred())
+			Expect(env.Stop()).To(Succeed())
 			close(done)
 		}, 30)
 
 		It("should not raise an error on invalid dir when flag is disabled", func(done Done) {
-			env = &Environment{ErrorIfCRDPathMissing: false, CRDDirectoryPaths: []string{invalidDirectory}}
+			env := &Environment{ErrorIfCRDPathMissing: false, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).NotTo(HaveOccurred())
+			Expect(env.Stop()).To(Succeed())
 			close(done)
 		}, 30)
 	})

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -86,6 +86,9 @@ type Environment struct {
 	// CRDInstallOptions are the options for installing CRDs.
 	CRDInstallOptions CRDInstallOptions
 
+	// CRDInstallOptions are the options for installing webhooks.
+	WebhookInstallOptions WebhookInstallOptions
+
 	// ErrorIfCRDPathMissing provides an interface for the underlying
 	// CRDInstallOptions.ErrorIfPathMissing. It prevents silent failures
 	// for missing CRD paths.
@@ -136,6 +139,10 @@ func (te *Environment) Stop() error {
 	}
 	if te.useExistingCluster() {
 		return nil
+	}
+	err := te.WebhookInstallOptions.Cleanup()
+	if err != nil {
+		return err
 	}
 	return te.ControlPlane.Stop()
 }
@@ -240,7 +247,14 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
 	te.CRDInstallOptions.ErrorIfPathMissing = te.ErrorIfCRDPathMissing
 	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
+	if err != nil {
+		return te.Config, err
+	}
 	te.CRDs = crds
+
+	log.V(1).Info("installing webhooks")
+	err = te.WebhookInstallOptions.Install(te.Config)
+
 	return te.Config, err
 }
 

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -1,0 +1,419 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
+	"sigs.k8s.io/yaml"
+)
+
+// WebhookInstallOptions are the options for installing mutating or validating webhooks
+type WebhookInstallOptions struct {
+	// Paths is a list of paths to the directories containing the mutating or validating webhooks yaml or json configs.
+	DirectoryPaths []string
+
+	// MutatingWebhooks is a list of MutatingWebhookConfigurations to install
+	MutatingWebhooks []runtime.Object
+
+	// ValidatingWebhooks is a list of ValidatingWebhookConfigurations to install
+	ValidatingWebhooks []runtime.Object
+
+	// IgnoreErrorIfPathMissing will ignore an error if a DirectoryPath does not exist when set to true
+	IgnoreErrorIfPathMissing bool
+
+	// LocalServingHost is the host for serving webhooks on.
+	// it will be automatically populated
+	LocalServingHost string
+
+	// LocalServingPort is the allocated port for serving webhooks on.
+	// it will be automatically populated by a random available local port
+	LocalServingPort int
+
+	// LocalServingCertDir is the allocated directory for serving certificates.
+	// it will be automatically populated by the local temp dir
+	LocalServingCertDir string
+
+	// MaxTime is the max time to wait
+	MaxTime time.Duration
+
+	// PollInterval is the interval to check
+	PollInterval time.Duration
+}
+
+// ModifyWebhookDefinitions modifies webhook definitions by:
+// - applying CABundle based on the provided tinyca
+// - if webhook client config uses service spec, it's removed and replaced with direct url
+func (o *WebhookInstallOptions) ModifyWebhookDefinitions(caData []byte) error {
+	hostPort, err := o.generateHostPort()
+	if err != nil {
+		return err
+	}
+
+	for i, unstructuredHook := range runtimeListToUnstructured(o.MutatingWebhooks) {
+		webhooks, found, err := unstructured.NestedSlice(unstructuredHook.Object, "webhooks")
+		if !found || err != nil {
+			return fmt.Errorf("unexpected object, %v", err)
+		}
+		for j := range webhooks {
+			webhook, err := modifyWebhook(webhooks[j].(map[string]interface{}), caData, hostPort)
+			if err != nil {
+				return err
+			}
+			webhooks[j] = webhook
+			unstructuredHook.Object["webhooks"] = webhooks
+			o.MutatingWebhooks[i] = unstructuredHook
+		}
+	}
+
+	for i, unstructuredHook := range runtimeListToUnstructured(o.ValidatingWebhooks) {
+		webhooks, found, err := unstructured.NestedSlice(unstructuredHook.Object, "webhooks")
+		if !found || err != nil {
+			return fmt.Errorf("unexpected object, %v", err)
+		}
+		for j := range webhooks {
+			webhook, err := modifyWebhook(webhooks[j].(map[string]interface{}), caData, hostPort)
+			if err != nil {
+				return err
+			}
+			webhooks[j] = webhook
+			unstructuredHook.Object["webhooks"] = webhooks
+			o.ValidatingWebhooks[i] = unstructuredHook
+		}
+	}
+	return nil
+}
+
+func modifyWebhook(webhook map[string]interface{}, caData []byte, hostPort string) (map[string]interface{}, error) {
+	clientConfig, found, err := unstructured.NestedMap(webhook, "clientConfig")
+	if !found || err != nil {
+		return nil, fmt.Errorf("cannot find clientconfig: %v", err)
+	}
+	clientConfig["caBundle"] = base64.StdEncoding.EncodeToString(caData)
+	servicePath, found, err := unstructured.NestedString(clientConfig, "service", "path")
+	if found && err == nil {
+		// we cannot use service in integration tests since we're running controller outside cluster
+		// the intent here is that we swap out service for raw address because we don't have an actually standard kube service network.
+		// We want to users to be able to use your standard config though
+		url := fmt.Sprintf("https://%s/%s", hostPort, servicePath)
+		clientConfig["url"] = url
+		clientConfig["service"] = nil
+	}
+	webhook["clientConfig"] = clientConfig
+	return webhook, nil
+}
+
+func (o *WebhookInstallOptions) generateHostPort() (string, error) {
+	port, host, err := addr.Suggest()
+	if err != nil {
+		return "", fmt.Errorf("unable to grab random port for serving webhooks on: %v", err)
+	}
+	o.LocalServingPort = port
+	o.LocalServingHost = host
+	return net.JoinHostPort(host, fmt.Sprintf("%d", port)), nil
+}
+
+// Install installs specified webhooks to the API server
+func (o *WebhookInstallOptions) Install(config *rest.Config) error {
+	hookCA, err := o.setupCA()
+	if err != nil {
+		return err
+	}
+	if err := parseWebhookDirs(o); err != nil {
+		return err
+	}
+
+	err = o.ModifyWebhookDefinitions(hookCA)
+	if err != nil {
+		return err
+	}
+
+	if err := createWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks); err != nil {
+		return err
+	}
+
+	if err := WaitForWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks, *o); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Cleanup cleans up cert directories
+func (o *WebhookInstallOptions) Cleanup() error {
+	if o.LocalServingCertDir != "" {
+		return os.RemoveAll(o.LocalServingCertDir)
+	}
+	return nil
+}
+
+// WaitForWebhooks waits for the Webhooks to be available through API server
+func WaitForWebhooks(config *rest.Config,
+	mutatingWebhooks []runtime.Object,
+	validatingWebhooks []runtime.Object,
+	options WebhookInstallOptions) error {
+
+	waitingFor := map[schema.GroupVersionKind]*sets.String{}
+
+	for _, hook := range runtimeListToUnstructured(append(validatingWebhooks, mutatingWebhooks...)) {
+		if _, ok := waitingFor[hook.GroupVersionKind()]; !ok {
+			waitingFor[hook.GroupVersionKind()] = &sets.String{}
+		}
+		waitingFor[hook.GroupVersionKind()].Insert(hook.GetName())
+	}
+
+	// Poll until all resources are found in discovery
+	p := &webhookPoller{config: config, waitingFor: waitingFor}
+	return wait.PollImmediate(options.PollInterval, options.MaxTime, p.poll)
+}
+
+// poller checks if all the resources have been found in discovery, and returns false if not
+type webhookPoller struct {
+	// config is used to get discovery
+	config *rest.Config
+
+	// waitingFor is the map of resources keyed by group version that have not yet been found in discovery
+	waitingFor map[schema.GroupVersionKind]*sets.String
+}
+
+// poll checks if all the resources have been found in discovery, and returns false if not
+func (p *webhookPoller) poll() (done bool, err error) {
+	// Create a new clientset to avoid any client caching of discovery
+	c, err := client.New(p.config, client.Options{})
+	if err != nil {
+		return false, err
+	}
+
+	allFound := true
+	for gvk, names := range p.waitingFor {
+		if names.Len() == 0 {
+			delete(p.waitingFor, gvk)
+			continue
+		}
+		for _, name := range names.List() {
+			var obj = &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			err := c.Get(context.Background(), client.ObjectKey{
+				Namespace: "",
+				Name:      name,
+			}, obj)
+
+			if err == nil {
+				names.Delete(name)
+			}
+
+			if errors.IsNotFound(err) {
+				allFound = false
+			}
+			if err != nil {
+				return false, err
+			}
+		}
+	}
+	return allFound, nil
+}
+
+// setupCA creates CA for testing and writes them to disk
+func (o *WebhookInstallOptions) setupCA() ([]byte, error) {
+	hookCA, err := integration.NewTinyCA()
+	if err != nil {
+		return nil, fmt.Errorf("unable to set up webhook CA: %v", err)
+	}
+
+	hookCert, err := hookCA.NewServingCert()
+	if err != nil {
+		return nil, fmt.Errorf("unable to set up webhook serving certs: %v", err)
+	}
+
+	localServingCertsDir, err := ioutil.TempDir("", "envtest-serving-certs-")
+	o.LocalServingCertDir = localServingCertsDir
+	if err != nil {
+		return nil, fmt.Errorf("unable to create directory for webhook serving certs: %v", err)
+	}
+
+	certData, keyData, err := hookCert.AsBytes()
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal webhook serving certs: %v", err)
+	}
+
+	if err := ioutil.WriteFile(filepath.Join(localServingCertsDir, "tls.crt"), certData, 0640); err != nil {
+		return nil, fmt.Errorf("unable to write webhook serving cert to disk: %v", err)
+	}
+	if err := ioutil.WriteFile(filepath.Join(localServingCertsDir, "tls.key"), keyData, 0640); err != nil {
+		return nil, fmt.Errorf("unable to write webhook serving key to disk: %v", err)
+	}
+
+	return certData, nil
+}
+
+func createWebhooks(config *rest.Config, mutHooks []runtime.Object, valHooks []runtime.Object) error {
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return err
+	}
+
+	// Create each webhook
+	for _, hook := range runtimeListToUnstructured(mutHooks) {
+		log.V(1).Info("installing mutating webhook", "webhook", hook.GetName())
+		if err := ensureCreated(cs, hook); err != nil {
+			return err
+		}
+	}
+	for _, hook := range runtimeListToUnstructured(valHooks) {
+		log.V(1).Info("installing validating webhook", "webhook", hook.GetName())
+		if err := ensureCreated(cs, hook); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ensureCreated creates or update object if already exists in the cluster
+func ensureCreated(cs client.Client, obj *unstructured.Unstructured) error {
+	existing := obj.DeepCopy()
+	err := cs.Get(context.Background(), client.ObjectKey{Name: obj.GetName()}, existing)
+	switch {
+	case apierrors.IsNotFound(err):
+		if err := cs.Create(context.Background(), obj); err != nil {
+			return err
+		}
+	case err != nil:
+		return err
+	default:
+		log.V(1).Info("Webhook configuration already exists, updating", "webhook", obj.GetName())
+		obj.SetResourceVersion(existing.GetResourceVersion())
+		if err := cs.Update(context.Background(), obj); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseWebhookDirs reads the directories of Webhooks in options.DirectoryPaths and adds the Webhook structs to options
+func parseWebhookDirs(options *WebhookInstallOptions) error {
+	if len(options.DirectoryPaths) > 0 {
+		for _, path := range options.DirectoryPaths {
+			_, err := os.Stat(path)
+			if options.IgnoreErrorIfPathMissing && os.IsNotExist(err) {
+				continue // skip this path
+			}
+			if !options.IgnoreErrorIfPathMissing && os.IsNotExist(err) {
+				return err // treat missing path as error
+			}
+			mutHooks, valHooks, err := readWebhooks(path)
+			if err != nil {
+				return err
+			}
+			options.MutatingWebhooks = append(options.MutatingWebhooks, mutHooks...)
+			options.ValidatingWebhooks = append(options.ValidatingWebhooks, valHooks...)
+		}
+	}
+	return nil
+}
+
+// readWebhooks reads the Webhooks from files and Unmarshals them into structs
+// returns slice of mutating and validating webhook configurations
+func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
+	// Get the webhook files
+	var files []os.FileInfo
+	var err error
+	log.V(1).Info("reading Webhooks from path", "path", path)
+	if files, err = ioutil.ReadDir(path); err != nil {
+		return nil, nil, err
+	}
+
+	// file extensions that may contain Webhooks
+	resourceExtensions := sets.NewString(".json", ".yaml", ".yml")
+
+	var mutHooks []runtime.Object
+	var valHooks []runtime.Object
+	for _, file := range files {
+		// Only parse whitelisted file types
+		if !resourceExtensions.Has(filepath.Ext(file.Name())) {
+			continue
+		}
+
+		// Unmarshal Webhooks from file into structs
+		docs, err := readDocuments(filepath.Join(path, file.Name()))
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, doc := range docs {
+			var generic metav1.PartialObjectMetadata
+			if err = yaml.Unmarshal(doc, &generic); err != nil {
+				return nil, nil, err
+			}
+
+			switch {
+			case generic.Kind == "MutatingWebhookConfiguration":
+				if generic.APIVersion != "v1beta1" && generic.APIVersion != "v1" {
+					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for MutatingWebhookConfiguration (name: %s)", generic.Name)
+				}
+				hook := &unstructured.Unstructured{}
+				if err := yaml.Unmarshal(doc, &hook); err != nil {
+					return nil, nil, err
+				}
+				mutHooks = append(mutHooks, hook)
+			case generic.Kind == "ValidatingWebhookConfiguration":
+				if generic.APIVersion != "v1beta1" && generic.APIVersion != "v1" {
+					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for ValidatingWebhookConfiguration (name: %s)", generic.Name)
+				}
+				hook := &unstructured.Unstructured{}
+				if err := yaml.Unmarshal(doc, &hook); err != nil {
+					return nil, nil, err
+				}
+				valHooks = append(valHooks, hook)
+			default:
+				continue
+			}
+		}
+
+		log.V(1).Info("read webhooks from file", "file", file.Name())
+	}
+	return mutHooks, valHooks, nil
+}
+
+func runtimeListToUnstructured(l []runtime.Object) []*unstructured.Unstructured {
+	res := []*unstructured.Unstructured{}
+	for _, obj := range l {
+		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())
+		if err != nil {
+			continue
+		}
+		res = append(res, &unstructured.Unstructured{
+			Object: m,
+		})
+	}
+	return res
+}

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -1,0 +1,84 @@
+package envtest
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("Test", func() {
+
+	Describe("Webhook", func() {
+		It("should reject create request for webhook that rejects all requests", func(done Done) {
+			m, err := manager.New(env.Config, manager.Options{
+				Port:    env.WebhookInstallOptions.LocalServingPort,
+				Host:    env.WebhookInstallOptions.LocalServingHost,
+				CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+			}) // we need manager here just to leverage manager.SetFields
+			Expect(err).NotTo(HaveOccurred())
+			server := m.GetWebhookServer()
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			stopCh := make(chan struct{})
+			go func() {
+				_ = server.Start(stopCh)
+			}()
+
+			c, err := client.New(env.Config, client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			obj := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				return errors.ReasonForError(err) == metav1.StatusReason("Always denied")
+			}, 1*time.Second).Should(BeTrue())
+
+			close(stopCh)
+			close(done)
+		})
+	})
+})
+
+type rejectingValidator struct {
+}
+
+func (v *rejectingValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return admission.Denied(fmt.Sprint("Always denied"))
+}

--- a/pkg/internal/testing/integration/control_plane.go
+++ b/pkg/internal/testing/integration/control_plane.go
@@ -7,7 +7,13 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
 )
+
+// NewTinyCA creates a new a tiny CA utility for provisioning serving certs and client certs FOR TESTING ONLY.
+// Don't use this for anything else!
+var NewTinyCA = internal.NewTinyCA
 
 // ControlPlane is a struct that knows how to start your test control plane.
 //

--- a/pkg/internal/testing/integration/internal/apiserver.go
+++ b/pkg/internal/testing/integration/internal/apiserver.go
@@ -9,7 +9,7 @@ var APIServerDefaultArgs = []string{
 	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
-	"--admission-control=AlwaysAdmit",
+	"--disable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,ResourceQuota", //nolint
 	"--service-cluster-ip-range=10.0.0.0/24",
 	"--allow-privileged=true",
 }

--- a/pkg/internal/testing/integration/internal/tinyca.go
+++ b/pkg/internal/testing/integration/internal/tinyca.go
@@ -1,0 +1,149 @@
+package internal
+
+// NB(directxman12): nothing has verified that this has good settings.  In fact,
+// the setting generated here are probably terrible, but they're fine for integration
+// tests.  These ABSOLUTELY SHOULD NOT ever be exposed in the public API.  They're
+// ONLY for use with envtest's ability to configure webhook testing.
+// If I didn't otherwise not want to add a dependency on cfssl, I'd just use that.
+
+import (
+	"crypto"
+	crand "crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"time"
+
+	certutil "k8s.io/client-go/util/cert"
+)
+
+var (
+	rsaKeySize = 2048 // a decent number, as of 2019
+	bigOne     = big.NewInt(1)
+)
+
+// CertPair is a private key and certificate for use for client auth, as a CA, or serving.
+type CertPair struct {
+	Key  crypto.Signer
+	Cert *x509.Certificate
+}
+
+// CertBytes returns the PEM-encoded version of the certificate for this pair.
+func (k CertPair) CertBytes() []byte {
+	return pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: k.Cert.Raw,
+	})
+}
+
+// AsBytes encodes keypair in the appropriate formats for on-disk storage (PEM and
+// PKCS8, respectively).
+func (k CertPair) AsBytes() (cert []byte, key []byte, err error) {
+	cert = k.CertBytes()
+
+	rawKeyData, err := x509.MarshalPKCS8PrivateKey(k.Key)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to encode private key: %v", err)
+	}
+
+	key = pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: rawKeyData,
+	})
+
+	return cert, key, nil
+}
+
+// TinyCA supports signing serving certs and client-certs,
+// and can be used as an auth mechanism with envtest.
+type TinyCA struct {
+	CA      CertPair
+	orgName string
+
+	nextSerial *big.Int
+}
+
+// newPrivateKey generates a new private key of a relatively sane size (see
+// rsaKeySize).
+func newPrivateKey() (crypto.Signer, error) {
+	return rsa.GenerateKey(crand.Reader, rsaKeySize)
+}
+
+func NewTinyCA() (*TinyCA, error) {
+	caPrivateKey, err := newPrivateKey()
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate private key for CA: %v", err)
+	}
+	caCfg := certutil.Config{CommonName: "envtest-environment", Organization: []string{"envtest"}}
+	caCert, err := certutil.NewSelfSignedCACert(caCfg, caPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate certificate for CA: %v", err)
+	}
+
+	return &TinyCA{
+		CA:         CertPair{Key: caPrivateKey, Cert: caCert},
+		orgName:    "envtest",
+		nextSerial: big.NewInt(1),
+	}, nil
+}
+
+func (c *TinyCA) makeCert(cfg certutil.Config) (CertPair, error) {
+	now := time.Now()
+
+	key, err := newPrivateKey()
+	if err != nil {
+		return CertPair{}, fmt.Errorf("unable to create private key: %v", err)
+	}
+
+	serial := new(big.Int).Set(c.nextSerial)
+	c.nextSerial.Add(c.nextSerial, bigOne)
+
+	template := x509.Certificate{
+		Subject:      pkix.Name{CommonName: cfg.CommonName, Organization: cfg.Organization},
+		DNSNames:     cfg.AltNames.DNSNames,
+		IPAddresses:  cfg.AltNames.IPs,
+		SerialNumber: serial,
+
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: cfg.Usages,
+
+		// technically not necessary for testing, but let's set anyway just in case.
+		NotBefore: now.UTC(),
+		// 1 week -- the default for cfssl, and just long enough for a
+		// long-term test, but not too long that anyone would try to use this
+		// seriously.
+		NotAfter: now.Add(168 * time.Hour).UTC(),
+	}
+
+	certRaw, err := x509.CreateCertificate(crand.Reader, &template, c.CA.Cert, key.Public(), c.CA.Key)
+	if err != nil {
+		return CertPair{}, fmt.Errorf("unable to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certRaw)
+	if err != nil {
+		return CertPair{}, fmt.Errorf("generated invalid certificate, could not parse: %v", err)
+	}
+
+	return CertPair{
+		Key:  key,
+		Cert: cert,
+	}, nil
+}
+
+// NewServingCert returns a new CertPair for a serving HTTPS on localhost.
+func (c *TinyCA) NewServingCert() (CertPair, error) {
+	return c.makeCert(certutil.Config{
+		CommonName:   "localhost",
+		Organization: []string{c.orgName},
+		AltNames: certutil.AltNames{
+			DNSNames: []string{"localhost"},
+			IPs:      []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		},
+		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+}


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Ability to test webhooks with envtest

lots of code is reused from PoC done in #645

Fixes #563

Co-authored-by: Solly Ross <sollyross@google.com>