### PR TITLE
🏃 (:running:, other) Bigger teardown timeout for flaky test

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -40,6 +40,8 @@ var _ = Describe("Test", func() {
 	var validDirectory = filepath.Join(".", "testdata")
 	var invalidDirectory = "fake"
 
+	var teardownTimeoutSeconds float64 = 10
+
 	// Initialize the client
 	BeforeEach(func(done Done) {
 		crds = []runtime.Object{}
@@ -76,7 +78,7 @@ var _ = Describe("Test", func() {
 			}, 1*time.Second).Should(BeTrue())
 		}
 		close(done)
-	})
+	}, teardownTimeoutSeconds)
 
 	Describe("InstallCRDs", func() {
 		It("should install the CRDs into the cluster using directory", func(done Done) {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
InstallCRDs test has been flaking a lot in various PRs (see https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-runtime/792/pull-controller-runtime-test-master/1225467749271080963/build-log.txt)

Recently we have started waiting for the CRD removal there, each CRD eventually block has a timeout of 1 second, while the overall AfterAll has also timeout of 1 second. This PR raises that timeout to give a more time to teardowns with multiple crds (like the InstallCRDs test).