### PR TITLE
✨ Create a supported way of setting a cache on source.Kind

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -55,17 +55,18 @@ type Source interface {
 	Start(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 }
 
-// CreateSourceWithFixedCache creates a Source without InjectCache, so that it is assured that the given cache is used
-// and not overwritten
-func CreateSourceWithFixedCache(object runtime.Object, cache cache.Cache) Source {
-	return &sourceWithFixedCache{kind: Kind{Type: object, cache: cache}}
+// NewKindWithFixedCache creates a Source without InjectCache, so that it is assured that the given cache is used
+// and not overwritten. It can be used to watch objects in a different cluster by passing the cache
+// from that other cluster
+func NewKindWithFixedCache(object runtime.Object, cache cache.Cache) Source {
+	return &kindWithFixedCache{kind: Kind{Type: object, cache: cache}}
 }
 
-type sourceWithFixedCache struct {
+type kindWithFixedCache struct {
 	kind Kind
 }
 
-func (ks *sourceWithFixedCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (ks *kindWithFixedCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
 	return ks.kind.Start(handler, queue, prct...)
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -55,18 +55,18 @@ type Source interface {
 	Start(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 }
 
-// NewKindWithFixedCache creates a Source without InjectCache, so that it is assured that the given cache is used
+// NewKindWithCache creates a Source without InjectCache, so that it is assured that the given cache is used
 // and not overwritten. It can be used to watch objects in a different cluster by passing the cache
 // from that other cluster
-func NewKindWithFixedCache(object runtime.Object, cache cache.Cache) Source {
-	return &kindWithFixedCache{kind: Kind{Type: object, cache: cache}}
+func NewKindWithCache(object runtime.Object, cache cache.Cache) Source {
+	return &kindWithCache{kind: Kind{Type: object, cache: cache}}
 }
 
-type kindWithFixedCache struct {
+type kindWithCache struct {
 	kind Kind
 }
 
-func (ks *kindWithFixedCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (ks *kindWithCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
 	return ks.kind.Start(handler, queue, prct...)
 }

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -55,6 +55,21 @@ type Source interface {
 	Start(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 }
 
+// CreateSourceWithFixedCache creates a Source without InjectCache, so that it is assured that the given cache is used
+// and not overwritten
+func CreateSourceWithFixedCache(object runtime.Object, cache cache.Cache) Source {
+	return &sourceWithFixedCache{kind: Kind{Type: object, cache: cache}}
+}
+
+type sourceWithFixedCache struct {
+	kind Kind
+}
+
+func (ks *sourceWithFixedCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+	prct ...predicate.Predicate) error {
+	return ks.kind.Start(handler, queue, prct...)
+}
+
 // Kind is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create)
 type Kind struct {
 	// Type is the type of object to watch.  e.g. &v1.Pod{}


### PR DESCRIPTION
Create a wrapper for Kind without `InjectCache` to create a supported way of setting a cache on source.Kind. This can used, e.g., for watching resources on another cluster.

fixes #650 