### PR TITLE
🐛 respect context in unstructured client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -69,11 +68,6 @@ func New(config *rest.Config, options Options) (Client, error) {
 		}
 	}
 
-	dynamicClient, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
 	clientcache := &clientCache{
 		config:         config,
 		scheme:         options.Scheme,
@@ -89,9 +83,7 @@ func New(config *rest.Config, options Options) (Client, error) {
 		},
 		unstructuredClient: unstructuredClient{
 			cache:      clientcache,
-			client:     dynamicClient,
-			restMapper: options.Mapper,
-			paramCodec: parameterCodec{},
+			paramCodec: noConversionParamCodec{},
 		},
 	}
 

--- a/pkg/client/client_cache.go
+++ b/pkg/client/client_cache.go
@@ -17,7 +17,6 @@ limitations under the License.
 package client
 
 import (
-	"reflect"
 	"strings"
 	"sync"
 
@@ -45,19 +44,14 @@ type clientCache struct {
 	codecs serializer.CodecFactory
 
 	// resourceByType caches type metadata
-	resourceByType map[reflect.Type]*resourceMeta
+	resourceByType map[schema.GroupVersionKind]*resourceMeta
 	mu             sync.RWMutex
 }
 
 // newResource maps obj to a Kubernetes Resource and constructs a client for that Resource.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientCache) newResource(obj runtime.Object) (*resourceMeta, error) {
-	gvk, err := apiutil.GVKForObject(obj, c.scheme)
-	if err != nil {
-		return nil, err
-	}
-
-	if strings.HasSuffix(gvk.Kind, "List") && meta.IsListType(obj) {
+func (c *clientCache) newResource(gvk schema.GroupVersionKind, isList bool) (*resourceMeta, error) {
+	if strings.HasSuffix(gvk.Kind, "List") && isList {
 		// if this was a list, treat it as a request for the item's resource
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
@@ -76,12 +70,15 @@ func (c *clientCache) newResource(obj runtime.Object) (*resourceMeta, error) {
 // getResource returns the resource meta information for the given type of object.
 // If the object is a list, the resource represents the item's type instead.
 func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
-	typ := reflect.TypeOf(obj)
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return nil, err
+	}
 
 	// It's better to do creation work twice than to not let multiple
 	// people make requests at once
 	c.mu.RLock()
-	r, known := c.resourceByType[typ]
+	r, known := c.resourceByType[gvk]
 	c.mu.RUnlock()
 
 	if known {
@@ -91,11 +88,11 @@ func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
 	// Initialize a new Client
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	r, err := c.newResource(obj)
+	r, err = c.newResource(gvk, meta.IsListType(obj))
 	if err != nil {
 		return nil, err
 	}
-	c.resourceByType[typ] = r
+	c.resourceByType[gvk] = r
 	return r, err
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -869,6 +869,12 @@ var _ = Describe("Client", func() {
 				By("validating updated Deployment has type information")
 				Expect(u.GroupVersionKind()).To(Equal(depGvk))
 
+				By("validating patched Deployment has new status")
+				actual, err := clientset.AppsV1().Deployments(ns).Get(dep.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actual).NotTo(BeNil())
+				Expect(actual.Status.Replicas).To(BeEquivalentTo(1))
+
 				close(done)
 			})
 

--- a/pkg/client/codec.go
+++ b/pkg/client/codec.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"errors"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/conversion/queryparams"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type parameterCodec struct{}
+
+func (parameterCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
+	return queryparams.Convert(obj)
+}
+
+func (parameterCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
+	return errors.New("DecodeParameters not implemented on dynamic parameterCodec")
+}

--- a/pkg/client/codec.go
+++ b/pkg/client/codec.go
@@ -9,12 +9,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-type parameterCodec struct{}
+var _ runtime.ParameterCodec = noConversionParamCodec{}
 
-func (parameterCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
+// noConversionParamCodec is a no-conversion codec for serializing parameters into URL query strings.
+// it's useful in scenarios with the unstructured client and arbitrary resouces.
+type noConversionParamCodec struct{}
+
+func (noConversionParamCodec) EncodeParameters(obj runtime.Object, to schema.GroupVersion) (url.Values, error) {
 	return queryparams.Convert(obj)
 }
 
-func (parameterCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
-	return errors.New("DecodeParameters not implemented on dynamic parameterCodec")
+func (noConversionParamCodec) DecodeParameters(parameters url.Values, from schema.GroupVersion, into runtime.Object) error {
+	return errors.New("DecodeParameters not implemented on noConversionParamCodec")
 }

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -25,7 +25,7 @@ import (
 // client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
 // new clients at the time they are used, and caches the client.
 type typedClient struct {
-	cache      clientCache
+	cache      *clientCache
 	paramCodec runtime.ParameterCodec
 }
 

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -22,100 +22,135 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
 
 // client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
 // new clients at the time they are used, and caches the client.
 type unstructuredClient struct {
+	cache      *clientCache
 	client     dynamic.Interface
 	restMapper meta.RESTMapper
+	paramCodec runtime.ParameterCodec
 }
 
 // Create implements client.Client
-func (uc *unstructuredClient) Create(_ context.Context, obj runtime.Object, opts ...CreateOption) error {
+func (uc *unstructuredClient) Create(ctx context.Context, obj runtime.Object, opts ...CreateOption) error {
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	createOpts := CreateOptions{}
+
+	gvk := u.GroupVersionKind()
+
+	o, err := uc.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	createOpts := &CreateOptions{}
 	createOpts.ApplyOptions(opts)
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
-	if err != nil {
-		return err
-	}
-	i, err := r.Create(u, *createOpts.AsCreateOptions())
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
+	result := o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Body(obj).
+		VersionedParams(createOpts.AsCreateOptions(), uc.paramCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
+
+	u.SetGroupVersionKind(gvk)
+	return result
 }
 
 // Update implements client.Client
-func (uc *unstructuredClient) Update(_ context.Context, obj runtime.Object, opts ...UpdateOption) error {
+func (uc *unstructuredClient) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOption) error {
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
+
+	gvk := u.GroupVersionKind()
+
+	o, err := uc.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
 	updateOpts := UpdateOptions{}
 	updateOpts.ApplyOptions(opts)
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
-	if err != nil {
-		return err
-	}
-	i, err := r.Update(u, *updateOpts.AsUpdateOptions())
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
+	result := o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(obj).
+		VersionedParams(updateOpts.AsUpdateOptions(), uc.paramCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
+
+	u.SetGroupVersionKind(gvk)
+	return result
 }
 
 // Delete implements client.Client
-func (uc *unstructuredClient) Delete(_ context.Context, obj runtime.Object, opts ...DeleteOption) error {
-	u, ok := obj.(*unstructured.Unstructured)
+func (uc *unstructuredClient) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOption) error {
+	_, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
+
+	o, err := uc.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
+
 	deleteOpts := DeleteOptions{}
 	deleteOpts.ApplyOptions(opts)
-	err = r.Delete(u.GetName(), deleteOpts.AsDeleteOptions())
-	return err
+	return o.Delete().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		Body(deleteOpts.AsDeleteOptions()).
+		Context(ctx).
+		Do().
+		Error()
 }
 
 // DeleteAllOf implements client.Client
-func (uc *unstructuredClient) DeleteAllOf(_ context.Context, obj runtime.Object, opts ...DeleteAllOfOption) error {
-	u, ok := obj.(*unstructured.Unstructured)
+func (uc *unstructuredClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...DeleteAllOfOption) error {
+	_, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
+
+	o, err := uc.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
 
 	deleteAllOfOpts := DeleteAllOfOptions{}
 	deleteAllOfOpts.ApplyOptions(opts)
-	err = r.DeleteCollection(deleteAllOfOpts.AsDeleteOptions(), *deleteAllOfOpts.AsListOptions())
-	return err
+	return o.Delete().
+		NamespaceIfScoped(deleteAllOfOpts.ListOptions.Namespace, o.isNamespaced()).
+		Resource(o.resource()).
+		VersionedParams(deleteAllOfOpts.AsListOptions(), uc.paramCodec).
+		Body(deleteAllOfOpts.AsDeleteOptions()).
+		Context(ctx).
+		Do().
+		Error()
 }
 
 // Patch implements client.Client
-func (uc *unstructuredClient) Patch(_ context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
-	u, ok := obj.(*unstructured.Unstructured)
+func (uc *unstructuredClient) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
+	_, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
+
+	o, err := uc.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -126,81 +161,101 @@ func (uc *unstructuredClient) Patch(_ context.Context, obj runtime.Object, patch
 	}
 
 	patchOpts := &PatchOptions{}
-	i, err := r.Patch(u.GetName(), patch.Type(), data, *patchOpts.ApplyOptions(opts).AsPatchOptions())
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		VersionedParams(patchOpts.ApplyOptions(opts).AsPatchOptions(), uc.paramCodec).
+		Body(data).
+		Context(ctx).
+		Do().
+		Into(obj)
 }
 
 // Get implements client.Client
-func (uc *unstructuredClient) Get(_ context.Context, key ObjectKey, obj runtime.Object) error {
+func (uc *unstructuredClient) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
 	u, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), key.Namespace)
+
+	gvk := u.GroupVersionKind()
+
+	r, err := uc.cache.getResource(obj)
 	if err != nil {
 		return err
 	}
-	i, err := r.Get(key.Name, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
+
+	result := r.Get().
+		NamespaceIfScoped(key.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		Context(ctx).
+		Name(key.Name).Do().Into(obj)
+
+	u.SetGroupVersionKind(gvk)
+
+	return result
 }
 
 // List implements client.Client
-func (uc *unstructuredClient) List(_ context.Context, obj runtime.Object, opts ...ListOption) error {
+func (uc *unstructuredClient) List(ctx context.Context, obj runtime.Object, opts ...ListOption) error {
 	u, ok := obj.(*unstructured.UnstructuredList)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
+
 	gvk := u.GroupVersionKind()
 	if strings.HasSuffix(gvk.Kind, "List") {
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
+
 	listOpts := ListOptions{}
 	listOpts.ApplyOptions(opts)
-	r, err := uc.getResourceInterface(gvk, listOpts.Namespace)
+
+	r, err := uc.cache.getResource(obj)
 	if err != nil {
 		return err
 	}
 
-	i, err := r.List(*listOpts.AsListOptions())
-	if err != nil {
-		return err
-	}
-	u.Items = i.Items
-	u.Object = i.Object
-	return nil
+	return r.Get().
+		NamespaceIfScoped(listOpts.Namespace, r.isNamespaced()).
+		Resource(r.resource()).
+		VersionedParams(listOpts.AsListOptions(), uc.paramCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
 }
 
-func (uc *unstructuredClient) UpdateStatus(_ context.Context, obj runtime.Object, opts ...UpdateOption) error {
-	u, ok := obj.(*unstructured.Unstructured)
+func (uc *unstructuredClient) UpdateStatus(ctx context.Context, obj runtime.Object, opts ...UpdateOption) error {
+	_, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
+
+	o, err := uc.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
-	i, err := r.UpdateStatus(u, *(&UpdateOptions{}).ApplyOptions(opts).AsUpdateOptions())
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
+
+	return o.Put().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource("status").
+		Body(obj).
+		VersionedParams((&UpdateOptions{}).ApplyOptions(opts).AsUpdateOptions(), uc.paramCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
 }
 
-func (uc *unstructuredClient) PatchStatus(_ context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
-	u, ok := obj.(*unstructured.Unstructured)
+func (uc *unstructuredClient) PatchStatus(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
+	_, ok := obj.(*unstructured.Unstructured)
 	if !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
-	r, err := uc.getResourceInterface(u.GroupVersionKind(), u.GetNamespace())
+
+	o, err := uc.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -210,21 +265,15 @@ func (uc *unstructuredClient) PatchStatus(_ context.Context, obj runtime.Object,
 		return err
 	}
 
-	i, err := r.Patch(u.GetName(), patch.Type(), data, *(&PatchOptions{}).ApplyOptions(opts).AsPatchOptions(), "status")
-	if err != nil {
-		return err
-	}
-	u.Object = i.Object
-	return nil
-}
-
-func (uc *unstructuredClient) getResourceInterface(gvk schema.GroupVersionKind, ns string) (dynamic.ResourceInterface, error) {
-	mapping, err := uc.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return nil, err
-	}
-	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
-		return uc.client.Resource(mapping.Resource), nil
-	}
-	return uc.client.Resource(mapping.Resource).Namespace(ns), nil
+	patchOpts := &PatchOptions{}
+	return o.Patch(patch.Type()).
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource("status").
+		Body(data).
+		VersionedParams(patchOpts.ApplyOptions(opts).AsPatchOptions(), uc.paramCodec).
+		Context(ctx).
+		Do().
+		Into(obj)
 }


### PR DESCRIPTION
ref: https://github.com/kubernetes-sigs/controller-runtime/issues/41#issuecomment-589237195

aligns the unstructured client with the typed client, sharing a cache between them for object metadata. plumbs context through to the restclient for unstructured client in doing so.

@shawn-hurley mentioned there were previously some issues with this, but as-is the implementation passes all current tests?

also, idk how hacky people consider this 😄 feels like I probably need to fix up some GVKs somewhere in the lists...