### PR TITLE
update options.go: add a nil check

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -138,6 +138,9 @@ func (o *CreateOptions) AsCreateOptions() *metav1.CreateOptions {
 // and then returns itself (for convenient chaining).
 func (o *CreateOptions) ApplyOptions(opts []CreateOption) *CreateOptions {
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt.ApplyToCreate(o)
 	}
 	return o


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->
:sparkles: 
<!-- What does this do, and why do we need it? -->
This PR fixes #806 
All of the Create, List, Update and Delete client methods are variadic in that it takes any number of options.

It's too easy to pass nil as the last argument for these methods and then it crashes with a NPE.
So added a nil check.