### PR TITLE
🐛 Use GenerateName during fake client's Create method

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
 
@@ -45,6 +46,12 @@ type fakeClient struct {
 }
 
 var _ client.Client = &fakeClient{}
+
+const (
+	maxNameLength          = 63
+	randomLength           = 5
+	maxGeneratedNameLength = maxNameLength - randomLength
+)
 
 // NewFakeClient creates a new fake client for testing.
 // You can choose to initialize it with a slice of runtime.Object.
@@ -202,6 +209,15 @@ func (c *fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...cli
 	if err != nil {
 		return err
 	}
+
+	if accessor.GetName() == "" && accessor.GetGenerateName() != "" {
+		base := accessor.GetGenerateName()
+		if len(base) > maxGeneratedNameLength {
+			base = base[:maxGeneratedNameLength]
+		}
+		accessor.SetName(fmt.Sprintf("%s%s", base, utilrand.String(randomLength)))
+	}
+
 	return c.tracker.Create(gvr, obj, accessor.GetNamespace())
 }
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -171,6 +171,35 @@ var _ = Describe("Fake client", func() {
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1"))
 		})
 
+		It("should be able to Create with GenerateName", func() {
+			By("Creating a new configmap")
+			newcm := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "new-test-cm",
+					Namespace:    "ns2",
+					Labels: map[string]string{
+						"test-label": "label-value",
+					},
+				},
+			}
+			err := cl.Create(nil, newcm)
+			Expect(err).To(BeNil())
+
+			By("Listing configmaps with a particular label")
+			list := &corev1.ConfigMapList{}
+			err = cl.List(nil, list, client.InNamespace("ns2"),
+				client.MatchingLabels(map[string]string{
+					"test-label": "label-value",
+				}))
+			Expect(err).To(BeNil())
+			Expect(list.Items).To(HaveLen(1))
+			Expect(list.Items[0].Name).NotTo(BeEmpty())
+		})
+
 		It("should be able to Update", func() {
 			By("Updating a new configmap")
 			newcm := &corev1.ConfigMap{


### PR DESCRIPTION
When an object is created without a `Name` but with a `GenerateName`, the fake client will set a `Name` by appending a randomly generated UID to the end of the `GenerateName` prefix.

This change replicates the behavior of the [API Server's NameGenerator](https://github.com/kubernetes/apiserver/blob/master/pkg/storage/names/generate.go).