### PR TITLE
✨Expose metrics http server for extra endpoints

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -19,6 +19,7 @@ package manager
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,13 @@ type Manager interface {
 	// SetFields will set any dependencies on an object for which the object has implemented the inject
 	// interface - e.g. inject.Client.
 	SetFields(interface{}) error
+
+	// AddMetricsExtraHandler adds an extra handler served on path to the http server that serves metrics.
+	// Might be useful to register some diagnostic endpoints e.g. pprof. Note that these endpoints meant to be
+	// sensitive and shouldn't be exposed publicly.
+	// If the simple path -> handler mapping offered here is not enough, a new http server/listener should be added as
+	// Runnable to the manager via Add method.
+	AddMetricsExtraHandler(path string, handler http.Handler) error
 
 	// AddHealthzCheck allows you to add Healthz checker
 	AddHealthzCheck(name string, check healthz.Checker) error
@@ -282,6 +290,9 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
+	// By default we have no extra endpoints to expose on metrics http server.
+	metricsExtraHandlers := make(map[string]http.Handler)
+
 	// Create health probes listener. This will throw an error if the bind
 	// address is invalid or already in use.
 	healthProbeListener, err := options.newHealthProbeListener(options.HealthProbeBindAddress)
@@ -302,6 +313,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		resourceLock:          resourceLock,
 		mapper:                mapper,
 		metricsListener:       metricsListener,
+		metricsExtraHandlers:  metricsExtraHandlers,
 		internalStop:          stop,
 		internalStopper:       stop,
 		port:                  options.Port,


### PR DESCRIPTION
Allows users to add extra http handlers served on custom path to the http server that serves metrics. Might be useful to register some diagnostic endpoints e.g. pprof or custom debug info.

Ref: #684

---

Some additional thoughts: since we expose this, naming the server "metrics server" is not 100% correct anymore. Probably we might call it "diagnostic server" or something, that describes the purpose more clearly. Of course renaming would be a breaking change. As far as I found, the only metrics-related name we expose in the API is `MetricsBindAddress` in manager options. 