### PR TITLE
🏃 Use whole list matching for known types.

### DIFF
--- a/pkg/scheme/scheme_test.go
+++ b/pkg/scheme/scheme_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,28 +38,30 @@ var _ = Describe("Scheme", func() {
 				Build()
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(s.AllKnownTypes()).To(HaveLen(16))
-			Expect(s.AllKnownTypes()[gv.WithKind("Pod")]).To(Equal(reflect.TypeOf(corev1.Pod{})))
-			Expect(s.AllKnownTypes()[gv.WithKind("PodList")]).To(Equal(reflect.TypeOf(corev1.PodList{})))
-
-			// Base types
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("UpdateOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("PatchOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("DeleteOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("ExportOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("GetOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("ListOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv.WithKind("WatchEvent")))
-
 			internalGv := schema.GroupVersion{Group: "core", Version: "__internal"}
-			Expect(s.AllKnownTypes()).To(HaveKey(internalGv.WithKind("WatchEvent")))
-
 			emptyGv := schema.GroupVersion{Group: "", Version: "v1"}
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIGroup")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIGroupList")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIResourceList")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIVersions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("Status")))
+			Expect(s.AllKnownTypes()).To(MatchAllKeys(Keys{
+				gv.WithKind("Pod"):     Equal(reflect.TypeOf(corev1.Pod{})),
+				gv.WithKind("PodList"): Equal(reflect.TypeOf(corev1.PodList{})),
+
+				// Base types
+				gv.WithKind("CreateOptions"): Ignore(),
+				gv.WithKind("UpdateOptions"): Ignore(),
+				gv.WithKind("PatchOptions"):  Ignore(),
+				gv.WithKind("DeleteOptions"): Ignore(),
+				gv.WithKind("ExportOptions"): Ignore(),
+				gv.WithKind("GetOptions"):    Ignore(),
+				gv.WithKind("ListOptions"):   Ignore(),
+				gv.WithKind("WatchEvent"):    Ignore(),
+
+				internalGv.WithKind("WatchEvent"): Ignore(),
+
+				emptyGv.WithKind("APIGroup"):        Ignore(),
+				emptyGv.WithKind("APIGroupList"):    Ignore(),
+				emptyGv.WithKind("APIResourceList"): Ignore(),
+				emptyGv.WithKind("APIVersions"):     Ignore(),
+				emptyGv.WithKind("Status"):          Ignore(),
+			}))
 		})
 
 		It("should be able to add types from other Builders", func() {
@@ -73,45 +76,47 @@ var _ = Describe("Scheme", func() {
 				Build()
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(s.AllKnownTypes()).To(HaveLen(27))
-
-			// Types from b1
-			Expect(s.AllKnownTypes()[gv1.WithKind("Pod")]).To(Equal(reflect.TypeOf(corev1.Pod{})))
-			Expect(s.AllKnownTypes()[gv1.WithKind("PodList")]).To(Equal(reflect.TypeOf(corev1.PodList{})))
-
-			// Types from b2
-			Expect(s.AllKnownTypes()[gv2.WithKind("Deployment")]).To(Equal(reflect.TypeOf(appsv1.Deployment{})))
-			Expect(s.AllKnownTypes()[gv2.WithKind("Deployment")]).To(Equal(reflect.TypeOf(appsv1.Deployment{})))
-
-			// Base types
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("UpdateOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("PatchOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("DeleteOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("ExportOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("GetOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("ListOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv1.WithKind("WatchEvent")))
-
 			internalGv1 := schema.GroupVersion{Group: "core", Version: "__internal"}
-			Expect(s.AllKnownTypes()).To(HaveKey(internalGv1.WithKind("WatchEvent")))
-
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("UpdateOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("PatchOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("DeleteOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("ExportOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("GetOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("ListOptions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(gv2.WithKind("WatchEvent")))
-
 			internalGv2 := schema.GroupVersion{Group: "apps", Version: "__internal"}
-			Expect(s.AllKnownTypes()).To(HaveKey(internalGv2.WithKind("WatchEvent")))
-
 			emptyGv := schema.GroupVersion{Group: "", Version: "v1"}
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIGroup")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIGroupList")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIResourceList")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("APIVersions")))
-			Expect(s.AllKnownTypes()).To(HaveKey(emptyGv.WithKind("Status")))
+			Expect(s.AllKnownTypes()).To(MatchAllKeys(Keys{
+				// Types from b1
+				gv1.WithKind("Pod"):     Equal(reflect.TypeOf(corev1.Pod{})),
+				gv1.WithKind("PodList"): Equal(reflect.TypeOf(corev1.PodList{})),
+
+				// Types from b2
+				gv2.WithKind("Deployment"):     Equal(reflect.TypeOf(appsv1.Deployment{})),
+				gv2.WithKind("DeploymentList"): Equal(reflect.TypeOf(appsv1.DeploymentList{})),
+
+				// Base types
+				gv1.WithKind("CreateOptions"): Ignore(),
+				gv1.WithKind("UpdateOptions"): Ignore(),
+				gv1.WithKind("PatchOptions"):  Ignore(),
+				gv1.WithKind("DeleteOptions"): Ignore(),
+				gv1.WithKind("ExportOptions"): Ignore(),
+				gv1.WithKind("GetOptions"):    Ignore(),
+				gv1.WithKind("ListOptions"):   Ignore(),
+				gv1.WithKind("WatchEvent"):    Ignore(),
+
+				internalGv1.WithKind("WatchEvent"): Ignore(),
+
+				gv2.WithKind("CreateOptions"): Ignore(),
+				gv2.WithKind("UpdateOptions"): Ignore(),
+				gv2.WithKind("PatchOptions"):  Ignore(),
+				gv2.WithKind("DeleteOptions"): Ignore(),
+				gv2.WithKind("ExportOptions"): Ignore(),
+				gv2.WithKind("GetOptions"):    Ignore(),
+				gv2.WithKind("ListOptions"):   Ignore(),
+				gv2.WithKind("WatchEvent"):    Ignore(),
+
+				internalGv2.WithKind("WatchEvent"): Ignore(),
+
+				emptyGv.WithKind("APIGroup"):        Ignore(),
+				emptyGv.WithKind("APIGroupList"):    Ignore(),
+				emptyGv.WithKind("APIResourceList"): Ignore(),
+				emptyGv.WithKind("APIVersions"):     Ignore(),
+				emptyGv.WithKind("Status"):          Ignore(),
+			}))
 		})
 	})
 })


### PR DESCRIPTION
The scheme test knows how many types should be returned, but omitted `CreateOptions` from being explicitly checked.