### PR TITLE
🐛 Fix testdata imports in pkg/webhook/conversion

### DIFF
--- a/pkg/webhook/conversion/testdata/main.go
+++ b/pkg/webhook/conversion/testdata/main.go
@@ -21,11 +21,12 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	jobsv1 "testdata.kb.io/api/v1"
-	jobsv2 "testdata.kb.io/api/v2"
-	jobsv3 "testdata.kb.io/api/v3"
+	jobsv1 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v1"
+	jobsv2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
+	jobsv3 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v3"
 	// +kubebuilder:scaffold:imports
 )
 


### PR DESCRIPTION
The import path used here is incorrect, and there is no `go.mod` included in the root of this testdata directory to indicate its module name is `testdata.kb.io` (and I'm not actually certain this is a valid module path as it does not contain a `/`.

Additionally, the `api/v1` package itself imports `v2` as `sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2`: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/webhook/conversion/testdata/api/v1/externaljob_types.go#L23

I noticed this because Bazel attempts to resolve this import path in my project, and fails to resolve it to a real repository, leading to confusing log output when analysing our dependencies 😅