### PR TITLE
🏃Rename EnsureOwnerReference to SetOwnerReference for consistency

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -89,10 +89,10 @@ func SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Sch
 	return nil
 }
 
-// EnsureOwnerReference is a helper method to make sure the given object contains
-// an object reference to the object provided.
-// If a reference already exists, it'll be overwritten with the newly provided version.
-func EnsureOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
+// SetOwnerReference is a helper method to make sure the given object contains an object reference to the object provided.
+// This allows you to declare that owner has a dependency on the object without specifying it as a controller.
+// If a reference to the same object already exists, it'll be overwritten with the newly provided version.
+func SetOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
 	// Validate the owner.
 	ro, ok := owner.(runtime.Object)
 	if !ok {

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -35,13 +35,13 @@ import (
 )
 
 var _ = Describe("Controllerutil", func() {
-	Describe("EnsureOwnerReference", func() {
+	Describe("SetOwnerReference", func() {
 		It("should set ownerRef on an empty list", func() {
 			rs := &appsv1.ReplicaSet{}
 			dep := &extensionsv1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid"},
 			}
-			Expect(controllerutil.EnsureOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
 			Expect(rs.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
 				Name:       "foo",
 				Kind:       "Deployment",
@@ -67,7 +67,7 @@ var _ = Describe("Controllerutil", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid"},
 			}
 
-			Expect(controllerutil.EnsureOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
 			Expect(rs.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
 				Name:       "foo",
 				Kind:       "Deployment",
@@ -93,7 +93,7 @@ var _ = Describe("Controllerutil", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid-2"},
 			}
 
-			Expect(controllerutil.EnsureOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
 			Expect(rs.OwnerReferences).To(ConsistOf(metav1.OwnerReference{
 				Name:       "foo",
 				Kind:       "Deployment",


### PR DESCRIPTION
To be consistent with `SetControllerReference`, rename EnsureOwnerReference to SetOwnerReference.