### PR TITLE
⚠ (:warning:, major) Do not disable admission plugins by default

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -40,7 +40,7 @@ kb_root_dir=$tmp_root/kubebuilder
 # Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
 # in your environment to any value:
 #
-# $ SKIP_FETCH_TOOLS=1 ./test.sh
+# $ SKIP_FETCH_TOOLS=1 ./check-everything.sh
 #
 # If you skip fetching tools, this script will use the tools already on your
 # machine, but rebuild the kubebuilder and kubebuilder-bin binaries.

--- a/pkg/internal/testing/integration/internal/apiserver.go
+++ b/pkg/internal/testing/integration/internal/apiserver.go
@@ -9,7 +9,9 @@ var APIServerDefaultArgs = []string{
 	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
-	"--disable-admission-plugins=NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,StorageObjectInUseProtection,PersistentVolumeClaimResize,ResourceQuota", //nolint
+	// we're keeping this disabled because if enabled, default SA is missing which would force all tests to create one
+	// in normal apiserver operation this SA is created by controller, but that is not run in integration environment
+	"--disable-admission-plugins=ServiceAccount",
 	"--service-cluster-ip-range=10.0.0.0/24",
 	"--allow-privileged=true",
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

If we enable ServiceAccount plugin, tests fail with this error. That is because controller normally takes care of creating default service account but that controller is not running in the integration environment.

```
 "pods \"test-pod-1\" is forbidden: error looking up service account test-namespace-1/default: serviceaccount \"default\" not found",
```

We either keep that disabled by default or envtest would have to create that SA for the users? Otherwise all users would have to create that SA which I think is not desired.
