### PR TITLE
:running: Allow specifying custom TLS Config for webhooks

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -253,7 +253,11 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDs = crds
 
 	log.V(1).Info("installing webhooks")
-	err = te.WebhookInstallOptions.Install(te.Config)
+	if te.WebhookInstallOptions.CustomTLSConfig != nil {
+		err = te.WebhookInstallOptions.InstallWithCustomTLS(te.Config)
+	} else {
+		err = te.WebhookInstallOptions.Install(te.Config)
+	}
 
 	return te.Config, err
 }

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -15,6 +15,7 @@ package envtest
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -63,6 +64,11 @@ type WebhookInstallOptions struct {
 	// LocalServingCertDir is the allocated directory for serving certificates.
 	// it will be automatically populated by the local temp dir
 	LocalServingCertDir string
+
+	// CustomTLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	CustomTLSConfig *tls.Config
 
 	// MaxTime is the max time to wait
 	MaxTime time.Duration
@@ -166,6 +172,28 @@ func (o *WebhookInstallOptions) Install(config *rest.Config) error {
 		return err
 	}
 
+	return nil
+}
+
+// InstallWithCustomTLS installs specified webhooks to the API server but
+// doesn't setup a CA/cert via tinyca
+func (o *WebhookInstallOptions) InstallWithCustomTLS(config *rest.Config) error {
+	if err := parseWebhookDirs(o); err != nil {
+		return err
+	}
+
+	err := o.ModifyWebhookDefinitions([]byte{})
+	if err != nil {
+		return err
+	}
+
+	if err := createWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks); err != nil {
+		return err
+	}
+
+	if err := WaitForWebhooks(config, o.MutatingWebhooks, o.ValidatingWebhooks, *o); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -2,7 +2,9 @@ package envtest
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -68,6 +70,74 @@ var _ = Describe("Test", func() {
 			Eventually(func() bool {
 				err = c.Create(context.TODO(), obj)
 				return errors.ReasonForError(err) == metav1.StatusReason("Always denied")
+			}, 1*time.Second).Should(BeTrue())
+
+			close(stopCh)
+			close(done)
+		})
+	})
+
+	Describe("Webhook With Custom TLS", func() {
+		It("should reject requests due to bad certificate", func(done Done) {
+			_, err := env.WebhookInstallOptions.setupCA()
+			dir := env.WebhookInstallOptions.LocalServingCertDir
+			certFile := filepath.Join(dir, "tls.crt")
+			keyFile := filepath.Join(dir, "tls.key")
+			Expect(err).NotTo(HaveOccurred())
+			sCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			m, err := manager.New(env.Config, manager.Options{
+				Port: env.WebhookInstallOptions.LocalServingPort,
+				Host: env.WebhookInstallOptions.LocalServingHost,
+				// CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+				WebhookTLSConfig: &tls.Config{
+					NextProtos:   []string{"h2"},
+					Certificates: []tls.Certificate{sCert},
+					ClientAuth:   tls.NoClientCert,
+				},
+			}) // we need manager here just to leverage manager.SetFields
+			Expect(err).NotTo(HaveOccurred())
+			server := m.GetWebhookServer()
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			stopCh := make(chan struct{})
+			go func() {
+				_ = server.Start(stopCh)
+			}()
+
+			c, err := client.New(env.Config, client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			obj := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				// Bad Certificate shows up as InternalError
+				return errors.ReasonForError(err) == metav1.StatusReason("InternalError")
 			}, 1*time.Second).Should(BeTrue())
 
 			close(stopCh)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"time"
@@ -175,6 +176,11 @@ type Options struct {
 	CertDir string
 	// Functions to all for a user to customize the values that will be injected.
 
+	// WebhookTLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	WebhookTLSConfig *tls.Config
+
 	// NewCache is the function that will create the cache to be used
 	// by the manager. If not set this will use the default new cache function.
 	NewCache cache.NewCacheFunc
@@ -307,6 +313,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		port:                  options.Port,
 		host:                  options.Host,
 		certDir:               options.CertDir,
+		webhookTLSConfig:      options.WebhookTLSConfig,
 		leaseDuration:         *options.LeaseDuration,
 		renewDeadline:         *options.RenewDeadline,
 		retryPeriod:           *options.RetryPeriod,


### PR DESCRIPTION
* This implements a Manager option WebhookTLSConfig which allows for
  specifying a custom TLS configuration when running webhooks using
  controller-runtime
* Added CustomTLSConfig attribute to WebhookInstallOptions
* Added test to show this config overrides the config generated by
  CertDir