### PR TITLE
🐛 fix version check when reading webhooks from file

### DIFF
--- a/pkg/envtest/testdata/webhooks/manifests.yaml
+++ b/pkg/envtest/testdata/webhooks/manifests.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1beta1
+  failurePolicy: Fail
+  name: mpods.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: mutating-webhook-configuration2
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-v1
+  failurePolicy: Fail
+  name: mpods2.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1beta1
+  failurePolicy: Fail
+  name: vpods.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration2
+webhooks:
+- clientConfig:
+    caBundle: Cg==
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1
+  failurePolicy: Fail
+  name: vpods2.kb.io
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - pods
+

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -375,9 +375,13 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 				return nil, nil, err
 			}
 
+			const (
+				admissionregv1      = "admissionregistration.k8s.io/v1beta1"
+				admissionregv1beta1 = "admissionregistration.k8s.io/v1"
+			)
 			switch {
 			case generic.Kind == "MutatingWebhookConfiguration":
-				if generic.APIVersion != "admissionregistration.k8s.io/v1beta1" && generic.APIVersion != "admissionregistration.k8s.io/v1" {
+				if generic.APIVersion != admissionregv1beta1 && generic.APIVersion != admissionregv1 {
 					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for MutatingWebhookConfiguration (name: %s)", generic.Name)
 				}
 				hook := &unstructured.Unstructured{}
@@ -386,7 +390,7 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 				}
 				mutHooks = append(mutHooks, hook)
 			case generic.Kind == "ValidatingWebhookConfiguration":
-				if generic.APIVersion != "admissionregistration.k8s.io/v1beta1" && generic.APIVersion != "admissionregistration.k8s.io/v1" {
+				if generic.APIVersion != admissionregv1beta1 && generic.APIVersion != admissionregv1 {
 					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for ValidatingWebhookConfiguration (name: %s)", generic.Name)
 				}
 				hook := &unstructured.Unstructured{}

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -377,7 +377,7 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 
 			switch {
 			case generic.Kind == "MutatingWebhookConfiguration":
-				if generic.APIVersion != "v1beta1" && generic.APIVersion != "v1" {
+				if generic.APIVersion != "admissionregistration.k8s.io/v1beta1" && generic.APIVersion != "admissionregistration.k8s.io/v1" {
 					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for MutatingWebhookConfiguration (name: %s)", generic.Name)
 				}
 				hook := &unstructured.Unstructured{}
@@ -386,7 +386,7 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 				}
 				mutHooks = append(mutHooks, hook)
 			case generic.Kind == "ValidatingWebhookConfiguration":
-				if generic.APIVersion != "v1beta1" && generic.APIVersion != "v1" {
+				if generic.APIVersion != "admissionregistration.k8s.io/v1beta1" && generic.APIVersion != "admissionregistration.k8s.io/v1" {
 					return nil, nil, fmt.Errorf("only v1beta1 and v1 are supported right now for ValidatingWebhookConfiguration (name: %s)", generic.Name)
 				}
 				hook := &unstructured.Unstructured{}

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -3,6 +3,7 @@ package envtest
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -72,6 +73,16 @@ var _ = Describe("Test", func() {
 
 			close(stopCh)
 			close(done)
+		})
+
+		It("should load webhooks from files", func() {
+			installOptions := WebhookInstallOptions{
+				DirectoryPaths: []string{filepath.Join("testdata", "webhooks")},
+			}
+			err := parseWebhookDirs(&installOptions)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(installOptions.MutatingWebhooks)).To(Equal(2))
+			Expect(len(installOptions.ValidatingWebhooks)).To(Equal(2))
 		})
 	})
 })


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
At the moment the `DirectoryPaths` option of the `WebhookInstallOptions` is broken. This PR fixes it.

Fixed #867