### PR TITLE
✨Allow controllers to be started and stopped separately from the manager

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -111,6 +111,7 @@ func Configure(name string, mgr manager.Manager, options Options) (Controller, e
 			return workqueue.NewNamedRateLimitingQueue(options.RateLimiter, name)
 		},
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
+		SetFields:               mgr.SetFields,
 		Name:                    name,
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,7 +67,7 @@ type Controller interface {
 // New returns a new Controller registered with the Manager.  The Manager will ensure that shared Caches have
 // been synced before the Controller is Started.
 func New(name string, mgr manager.Manager, options Options) (Controller, error) {
-	c, err := Configure(name, mgr, options)
+	c, err := NewUnmanaged(name, mgr, options)
 	if err != nil {
 		return nil, err
 	}
@@ -76,8 +76,9 @@ func New(name string, mgr manager.Manager, options Options) (Controller, error) 
 	return c, mgr.Add(c)
 }
 
-// Configure a new controller without starting it or adding it to the manager.
-func Configure(name string, mgr manager.Manager, options Options) (Controller, error) {
+// NewUnmanaged returns a new controller without adding it to the manager. The
+// caller is responsible for starting the returned controller.
+func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller, error) {
 	if options.Reconciler == nil {
 		return nil, fmt.Errorf("must specify Reconciler")
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -67,6 +67,17 @@ type Controller interface {
 // New returns a new Controller registered with the Manager.  The Manager will ensure that shared Caches have
 // been synced before the Controller is Started.
 func New(name string, mgr manager.Manager, options Options) (Controller, error) {
+	c, err := Configure(name, mgr, options)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the controller as a Manager components
+	return c, mgr.Add(c)
+}
+
+// Configure a new controller without starting it or adding it to the manager.
+func Configure(name string, mgr manager.Manager, options Options) (Controller, error) {
 	if options.Reconciler == nil {
 		return nil, fmt.Errorf("must specify Reconciler")
 	}
@@ -103,6 +114,5 @@ func New(name string, mgr manager.Manager, options Options) (Controller, error) 
 		Name:                    name,
 	}
 
-	// Add the controller as a Manager components
-	return c, mgr.Add(c)
+	return c, nil
 }

--- a/pkg/controller/example_test.go
+++ b/pkg/controller/example_test.go
@@ -152,7 +152,7 @@ func ExampleNewUnmanaged() {
 		// Block until our controller manager is elected leader. We presume our
 		// entire process will terminate if we lose leadership, so we don't need
 		// to handle that.
-		<-mgr.Leading()
+		<-mgr.Elected()
 
 		// Start our controller. This will block until the stop channel is
 		// closed, or the controller returns an error.

--- a/pkg/controller/example_test.go
+++ b/pkg/controller/example_test.go
@@ -119,3 +119,48 @@ func ExampleController_unstructured() {
 		os.Exit(1)
 	}
 }
+
+// This example creates a new controller named "pod-controller" to watch Pods
+// and call a no-op reconciler. The controller is not added to the provided
+// manager, and must thus be started and stopped by the caller.
+func ExampleNewUnmanaged() {
+	// mgr is a manager.Manager
+
+	// Configure creates a new controller but does not add it to the supplied
+	// manager.
+	c, err := controller.NewUnmanaged("pod-controller", mgr, controller.Options{
+		Reconciler: reconcile.Func(func(_ reconcile.Request) (reconcile.Result, error) {
+			return reconcile.Result{}, nil
+		}),
+	})
+	if err != nil {
+		log.Error(err, "unable to create pod-controller")
+		os.Exit(1)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		log.Error(err, "unable to watch pods")
+		os.Exit(1)
+	}
+
+	// Create a stop channel for our controller. The controller will stop when
+	// this channel is closed.
+	stop := make(chan struct{})
+
+	// Start our controller in a goroutine so that we do not block.
+	go func() {
+		// Block until our controller manager is elected leader. We presume our
+		// entire process will terminate if we lose leadership, so we don't need
+		// to handle that.
+		<-mgr.Leading()
+
+		// Start our controller. This will block until the stop channel is
+		// closed, or the controller returns an error.
+		if err := c.Start(stop); err != nil {
+			log.Error(err, "cannot run experiment controller")
+		}
+	}()
+
+	// Stop our controller.
+	close(stop)
+}

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -130,10 +130,10 @@ type controllerManager struct {
 	// It and `internalStop` should point to the same channel.
 	internalStopper chan<- struct{}
 
-	// leading is closed when this manager becomes the leader of a group of
+	// elected is closed when this manager becomes the leader of a group of
 	// managers, either because it won a leader election or because no leader
 	// election was configured.
-	leading chan struct{}
+	elected chan struct{}
 
 	startCache func(stop <-chan struct{}) error
 
@@ -429,7 +429,7 @@ func (cm *controllerManager) Start(stop <-chan struct{}) error {
 		}
 	} else {
 		// Treat not having leader election enabled the same as being elected.
-		close(cm.leading)
+		close(cm.elected)
 		go cm.startLeaderElectionRunnables()
 	}
 
@@ -518,7 +518,7 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 		RetryPeriod:   cm.retryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
-				close(cm.leading)
+				close(cm.elected)
 				cm.startLeaderElectionRunnables()
 			},
 			OnStoppedLeading: func() {
@@ -547,6 +547,6 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 	return nil
 }
 
-func (cm *controllerManager) Leading() <-chan struct{} {
-	return cm.leading
+func (cm *controllerManager) Elected() <-chan struct{} {
+	return cm.elected
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -50,10 +50,10 @@ type Manager interface {
 	// non-leaderelection mode (always running) or leader election mode (managed by leader election if enabled).
 	Add(Runnable) error
 
-	// Leading is closed when this manager becomes the leader of a group of
+	// Elected is closed when this manager is elected leader of a group of
 	// managers, either because it won a leader election or because no leader
 	// election was configured.
-	Leading() <-chan struct{}
+	Elected() <-chan struct{}
 
 	// SetFields will set any dependencies on an object for which the object has implemented the inject
 	// interface - e.g. inject.Client.
@@ -318,7 +318,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		metricsListener:       metricsListener,
 		internalStop:          stop,
 		internalStopper:       stop,
-		leading:               make(chan struct{}),
+		elected:               make(chan struct{}),
 		port:                  options.Port,
 		host:                  options.Host,
 		certDir:               options.CertDir,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -50,9 +50,10 @@ type Manager interface {
 	// non-leaderelection mode (always running) or leader election mode (managed by leader election if enabled).
 	Add(Runnable) error
 
-	// Elected is closed when this manager is elected the leader, or when no
-	// election is configured.
-	Elected() <-chan struct{}
+	// Leading is closed when this manager becomes the leader of a group of
+	// managers, either because it won a leader election or because no leader
+	// election was configured.
+	Leading() <-chan struct{}
 
 	// SetFields will set any dependencies on an object for which the object has implemented the inject
 	// interface - e.g. inject.Client.
@@ -317,7 +318,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		metricsListener:       metricsListener,
 		internalStop:          stop,
 		internalStopper:       stop,
-		elected:               make(chan struct{}),
+		leading:               make(chan struct{}),
 		port:                  options.Port,
 		host:                  options.Host,
 		certDir:               options.CertDir,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -50,6 +50,10 @@ type Manager interface {
 	// non-leaderelection mode (always running) or leader election mode (managed by leader election if enabled).
 	Add(Runnable) error
 
+	// Elected is closed when this manager is elected the leader, or when no
+	// election is configured.
+	Elected() <-chan struct{}
+
 	// SetFields will set any dependencies on an object for which the object has implemented the inject
 	// interface - e.g. inject.Client.
 	SetFields(interface{}) error
@@ -313,6 +317,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		metricsListener:       metricsListener,
 		internalStop:          stop,
 		internalStopper:       stop,
+		elected:               make(chan struct{}),
 		port:                  options.Port,
 		host:                  options.Host,
 		certDir:               options.CertDir,

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -261,6 +261,7 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(stop)).NotTo(HaveOccurred())
+					Expect(m.Elected()).To(BeClosed())
 				}()
 				<-c1
 				<-c2


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/730

Increasingly in [Crossplane](https://github.com/crossplane) we find that we'd like to use one kind of custom resource to describe how another, arbitrary, kind of custom resource should be reconciled. For example a `kind: Template` resource may configure how a `kind: Widget` resource should be reconciled. This involves the controller that watches for `kind: Template` managing the lifecycles of another set of controllers, including the controller that watches for `kind: Widget`. This is not currently possible in controller-runtime because all controllers are implicitly added to and started by the controller manager, which has no facility for stopping or removing a controller.

This PR makes it possible to start, run, _and stop_ a controller without ever adding the controller to the controller manager. My goal is not to arrive at the ideal API for this concept, but rather to enable the use case with the smallest possible change to controller-runtime. I imagine this will be niche functionality, and functionality that is slated for a broader refactoring at some point per https://github.com/kubernetes-sigs/controller-runtime/issues/764.

I've tested this functionality using https://github.com/negz/crossplane/commit/28e76ecd6fa285929370a8daa380d1fa27fbe9d8, which contains an example implementation of a controller that starts and stops other controllers.