### PR TITLE
:running: Release v0.5.2

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -16,13 +16,13 @@ aliases:
   controller-runtime-approvers:
   - gerred
   - shawn-hurley
+  - joelanford
 
   # folks who can review and LGTM any PRs in the repo (doesn't
   # include approvers & admins -- those count too via the OWNERS
   # file)
   controller-runtime-reviewers:
   - alvaroaleman
-  - joelanford
   - alenkacz
   - vincepri
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/onsi/gomega v1.8.1
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
-	go.uber.org/atomic v1.4.0 // indirect
+	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/sys v0.0.0-20190922100055-0a153f010e69 // indirect

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,6 @@ go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qL
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v1.3.2 h1:2Oa65PReHzfn29GpvgsYwloV9AVFHPDk8tYxt2c2tr4=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
-go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
-go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0 h1:ORx85nbTijNz8ljznvCMR1ZBIPKFn3jQrag10X2AsuM=

--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -50,6 +50,15 @@ SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
 function fetch_kb_tools {
   local dest_dir="${1}"
 
+  # use the pre-existing version in the temporary folder if it matches our k8s version
+  if [[ -x "${dest_dir}/kubebuilder/bin/kube-apiserver" ]]; then
+    version=$("${dest_dir}"/kubebuilder/bin/kube-apiserver --version)
+    if [[ $version == *"${k8s_version}"* ]]; then
+      header_text "Using cached kubebuilder-tools from ${dest_dir}"
+      return 0
+    fi
+  fi
+
   header_text "fetching tools (into '${dest_dir}')"
   kb_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
   kb_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$kb_tools_archive_name"

--- a/hack/release/release-notes.sh
+++ b/hack/release/release-notes.sh
@@ -30,6 +30,11 @@ while read commit_word commit; do
         # skip temporary merge commits and accidental merge commit inclusion
         # for calcuating release notes.
         continue
+    elif [[ ${title} == "Merge branch '"*"'"* ]]; then
+        # skip for accidental merge commit inclusion for calculating release notes
+        # NB(directxman12): it's not clear what tool generates this style, but we've
+        # got some now, so tolerate them.
+        continue
     fi
 
     read # skip the blank line

--- a/pkg/client/apiutil/dynamicrestmapper.go
+++ b/pkg/client/apiutil/dynamicrestmapper.go
@@ -318,5 +318,6 @@ func (b *dynamicLimiter) checkRate() error {
 	if res.Delay() == 0 {
 		return nil
 	}
+	res.Cancel()
 	return ErrRateLimited{res.Delay()}
 }

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -307,3 +307,7 @@ func (te *Environment) useExistingCluster() bool {
 	}
 	return *te.UseExistingCluster
 }
+
+// DefaultKubeAPIServerFlags exposes the default args for the APIServer so that
+// you can use those to append your own additional arguments.
+var DefaultKubeAPIServerFlags = integration.APIServerDefaultArgs

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package zap contains helpers for setting up a new logr.Logger instance
+// using the Zap logging framework.
+package zap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var levelStrings = map[string]zapcore.Level{
+	"debug":  zap.DebugLevel,
+	"-1":     zap.DebugLevel,
+	"info":   zap.InfoLevel,
+	"0":      zap.InfoLevel,
+	"error":  zap.ErrorLevel,
+	"2":      zap.ErrorLevel,
+	"dpanic": zap.DPanicLevel,
+	"panic":  zap.PanicLevel,
+	"warn":   zap.WarnLevel,
+	"fatal":  zap.FatalLevel,
+}
+
+type encoderFlag struct {
+	setFunc func(zapcore.Encoder)
+	value   string
+}
+
+var _ pflag.Value = &encoderFlag{}
+
+func (ev *encoderFlag) String() string {
+	return ev.value
+}
+
+func (ev *encoderFlag) Type() string {
+	return "encoder"
+}
+
+func (ev *encoderFlag) Set(flagValue string) error {
+	val := strings.ToLower(flagValue)
+	switch val {
+	case "json":
+		ev.setFunc(newJSONEncoder())
+	case "console":
+		ev.setFunc(newConsoleEncoder())
+	default:
+		return fmt.Errorf("invalid encoder value \"%s\"", flagValue)
+	}
+	ev.value = flagValue
+	return nil
+}
+
+func newJSONEncoder() zapcore.Encoder {
+	encoderConfig := zap.NewProductionEncoderConfig()
+	return zapcore.NewJSONEncoder(encoderConfig)
+}
+
+func newConsoleEncoder() zapcore.Encoder {
+	encoderConfig := zap.NewDevelopmentEncoderConfig()
+	return zapcore.NewConsoleEncoder(encoderConfig)
+}
+
+type levelFlag struct {
+	setFunc func(zap.AtomicLevel)
+	value   string
+}
+
+var _ pflag.Value = &levelFlag{}
+
+func (ev *levelFlag) Set(flagValue string) error {
+	level, validLevel := levelStrings[strings.ToLower(flagValue)]
+	if !validLevel {
+		logLevel, err := strconv.Atoi(flagValue)
+		if err != nil {
+			return fmt.Errorf("invalid log level \"%s\"", flagValue)
+		}
+		if logLevel > 0 {
+			intLevel := -1 * logLevel
+			ev.setFunc(zap.NewAtomicLevelAt(zapcore.Level(int8(intLevel))))
+		} else {
+			return fmt.Errorf("invalid log level \"%s\"", flagValue)
+		}
+	}
+	ev.setFunc(zap.NewAtomicLevelAt(level))
+	ev.value = flagValue
+	return nil
+}
+
+func (ev *levelFlag) String() string {
+	return ev.value
+}
+
+func (ev *levelFlag) Type() string {
+	return "level"
+}
+
+type stackTraceFlag struct {
+	setFunc func(zap.AtomicLevel)
+	value   string
+}
+
+var _ pflag.Value = &stackTraceFlag{}
+
+func (ev *stackTraceFlag) Set(flagValue string) error {
+	level, validLevel := levelStrings[strings.ToLower(flagValue)]
+	if !validLevel {
+		return fmt.Errorf("invalid stacktrace level \"%s\"", flagValue)
+	}
+	ev.setFunc(zap.NewAtomicLevelAt(level))
+	ev.value = flagValue
+	return nil
+}
+
+func (ev *stackTraceFlag) String() string {
+	return ev.value
+}
+
+func (ev *stackTraceFlag) Type() string {
+	return "level"
+}


### PR DESCRIPTION
```markdown
# v0.5.2

## :sparkles: New Features

- Add helpers to configure logger options via pflags (#767)

## :bug: Bug Fixes

- fix conservative delay in rate limiter (#859)
- expose DefaultKubeAPIServerFlags in envtest (#846) -- fixes an accidental breaking change in envtest

*Thanks to all our contributors!*
```
