### PR TITLE
:bug: KubeAwareEncoder should handle unstructured object correctly

### DIFF
--- a/pkg/log/zap/kube_helpers.go
+++ b/pkg/log/zap/kube_helpers.go
@@ -105,7 +105,9 @@ func (k *KubeAwareEncoder) EncodeEntry(entry zapcore.Entry, fields []zapcore.Fie
 		// intercept stringer fields that happen to be Kubernetes runtime.Object or
 		// types.NamespacedName values (Kubernetes runtime.Objects commonly
 		// implement String, apparently).
-		if field.Type == zapcore.StringerType {
+		// *unstructured.Unstructured does NOT implement fmt.Striger interface.
+		// We have handle it specially.
+		if field.Type == zapcore.StringerType || field.Type == zapcore.ReflectType {
 			switch val := field.Interface.(type) {
 			case runtime.Object:
 				fields[i] = zapcore.Field{

--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	kapi "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -235,6 +236,27 @@ var _ = Describe("Zap logger setup", func() {
 
 				Expect(res).To(HaveKeyWithValue("thing", map[string]interface{}{
 					"name": name.Name,
+				}))
+			})
+
+			It("should log an unstructured Kubernetes object", func() {
+				pod := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"metadata": map[string]interface{}{
+							"name":      "some-pod",
+							"namespace": "some-ns",
+						},
+					},
+				}
+				logger.Info("here's a kubernetes object", "thing", pod)
+
+				outRaw := logOut.Bytes()
+				res := map[string]interface{}{}
+				Expect(json.Unmarshal(outRaw, &res)).To(Succeed())
+
+				Expect(res).To(HaveKeyWithValue("thing", map[string]interface{}{
+					"name":      "some-pod",
+					"namespace": "some-ns",
 				}))
 			})
 


### PR DESCRIPTION
Surprisingly `*unstructured.Unstructured` does NOT implement the `fmt.Striger` interface.
We have to work around it in `KubeAwareEncoder` until it is fixed.
