### PR TITLE
:bug: MatchingLabels: Make sure requests with invalid labels fail

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -381,7 +381,7 @@ type MatchingLabels map[string]string
 
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid reserializing this over and over?
-	sel := labels.SelectorFromSet(map[string]string(m))
+	sel := labels.SelectorFromValidatedSet(map[string]string(m))
 	opts.LabelSelector = sel
 }
 

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -215,3 +215,17 @@ var _ = Describe("DeleteAllOfOptions", func() {
 		Expect(newDeleteAllOfOpts).To(Equal(o))
 	})
 })
+
+var _ = Describe("MatchingLabels", func() {
+	It("Should produce an invalid selector when given invalid input", func() {
+		matchingLabels := client.MatchingLabels(map[string]string{"k": "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui"})
+		listOpts := &client.ListOptions{}
+		matchingLabels.ApplyToList(listOpts)
+
+		r, _ := listOpts.LabelSelector.Requirements()
+		_, err := labels.NewRequirement(r[0].Key(), r[0].Operator(), r[0].Values().List())
+		Expect(err).ToNot(BeNil())
+		expectedErrMsg := `invalid label value: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui": at key: "k": must be no more than 63 characters`
+		Expect(err.Error()).To(Equal(expectedErrMsg))
+	})
+})


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/740

Following up on an idea by [@lavalamp](https://github.com/kubernetes/kubernetes/pull/89747#discussion_r401959488) this PR makes `MatchingLabels` construct an invalid selector rather than a (valid) match all selector in case of invalid input, which means the server will reject the request.

/assign @alexeldeib @vincepri 
