### PR TITLE
✨ Add ListWatch Options to Manager

### DIFF
--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -46,11 +47,12 @@ func NewInformersMap(config *rest.Config,
 	scheme *runtime.Scheme,
 	mapper meta.RESTMapper,
 	resync time.Duration,
-	namespace string) *InformersMap {
+	namespace string,
+	listWatchOptions map[schema.GroupVersionKind]func(*metav1.ListOptions)) *InformersMap {
 
 	return &InformersMap{
-		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace),
-		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace),
+		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace, listWatchOptions),
+		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace, listWatchOptions),
 
 		Scheme: scheme,
 	}
@@ -93,11 +95,13 @@ func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.
-func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createStructuredListWatch)
+func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string,
+	listWatchOptions map[schema.GroupVersionKind]func(*metav1.ListOptions)) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, listWatchOptions, createStructuredListWatch)
 }
 
 // newUnstructuredInformersMap creates a new InformersMap for unstructured objects.
-func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
-	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createUnstructuredListWatch)
+func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string,
+	listWatchOptions map[schema.GroupVersionKind]func(*metav1.ListOptions)) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, listWatchOptions, createUnstructuredListWatch)
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -146,6 +147,10 @@ type Options struct {
 	// will only hold objects from the desired namespace.
 	Namespace string
 
+	// ListWatchOptions is the list/watch mutating functions which restrict the manager's cache
+	// to watch objects the desired label selector or field selector.
+	ListWatchOptions map[runtime.Object]func(*metav1.ListOptions)
+
 	// MetricsBindAddress is the TCP address that the controller should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
@@ -243,7 +248,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}
 
 	// Create the cache for the cached read client and registering informers
-	cache, err := options.NewCache(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod, Namespace: options.Namespace})
+	cache, err := options.NewCache(config, cache.Options{Scheme: options.Scheme, Mapper: mapper, Resync: options.SyncPeriod, Namespace: options.Namespace, ListWatchOptions: options.ListWatchOptions})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
ListWatch Options Help manager to filter objects which manager does not cared about during set-up List/Watch request to API Server.

### ListWatch filter vs Informer Event Predicate filter

ListWatch filter and Informer Event Predicate filter are all used to filter Object which controller not cared about, however, using ListWatch filter will helps reduce the manager memory cost and improve controller performer with less event received.

Example to filter Pod(Manager only cared about Pods with `foo=bar` Label):
```go
log.Info("setting up manager")
mgr, err := manager.New(cfg, manager.Options{
	ListWatchOptions: map[runtime.Object]func(options *metav1.ListOptions){
		&corev1.Pod{}: func(options *metav1.ListOptions) {
			options.LabelSelector = "foo=bar"
		},
	},
})
```