### PR TITLE
🐛 Return original error from GetConfig

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -133,11 +133,8 @@ func loadConfig(context string) (*rest.Config, error) {
 		}
 		loadingRules.Precedence = append(loadingRules.Precedence, path.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
 	}
-	if c, err := loadConfigWithContext(apiServerURL, loadingRules, context); err == nil {
-		return c, nil
-	}
 
-	return nil, fmt.Errorf("could not locate a kubeconfig")
+	return loadConfigWithContext(apiServerURL, loadingRules, context)
 }
 
 func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoader, context string) (*rest.Config, error) {


### PR DESCRIPTION
This PR changes GetConfig that it returns the original error from loadConfigWithContext.
In ~/.kube/config I had a context configured which did not exist. GetConfig reported `could not locate a kubeconfig`. Since there was a ~/.kube/config with a lot of content it was difficult to find the real reason for the problem. The original error does properly state the problem: `invalid configuration: [context was not found for specified context: system1, cluster has no server defined]`
