### PR TITLE
:sparkles: add EnqueueRequestForAnnotation enqueues Requests based on the presence of an annotation to watch resources

### DIFF
--- a/examples/annotationbasedwatch/controller.go
+++ b/examples/annotationbasedwatch/controller.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// reconcileReplicaSet reconciles ReplicaSets
+type reconcileReplicaSet struct {
+	// client can be used to retrieve objects from the APIServer.
+	client client.Client
+	log    logr.Logger
+}
+
+// Implement reconcile.Reconciler so the controller can reconcile objects
+var _ reconcile.Reconciler = &reconcileReplicaSet{}
+
+func (r *reconcileReplicaSet) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// set up a convenient log object so we don't have to type request over and over again
+	log := r.log.WithValues("request", request)
+
+	// Fetch the ReplicaSet from the cache
+	rs := &appsv1.ReplicaSet{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, rs)
+	if errors.IsNotFound(err) {
+		log.Error(nil, "Could not find ReplicaSet")
+		return reconcile.Result{}, nil
+	}
+
+	if err != nil {
+		log.Error(err, "Could not fetch ReplicaSet")
+		return reconcile.Result{}, err
+	}
+
+	// Print the ReplicaSet
+	log.Info("Reconciling ReplicaSet", "container name", rs.Spec.Template.Spec.Containers[0].Name)
+
+	// Check if the Pod already exists, if not create a new one
+	podRs := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: rs.Name, Namespace: rs.Namespace}, podRs)
+	if err != nil && errors.IsNotFound(err) {
+		// Define a new Deployment
+		pod := r.podForReplicasetWithWatchAnnotations(rs)
+		err = r.client.Create(context.TODO(), pod)
+		if err != nil {
+			log.Error(err, "Failed to create new Pod.", "Pod.Namespace", pod.Namespace, "Pod.Name", pod.Name)
+			return reconcile.Result{}, err
+		}
+		return reconcile.Result{Requeue: true}, nil
+	} else if err != nil {
+		log.Error(err, "Failed to get Pod.")
+		return reconcile.Result{}, err
+	}
+
+	// Set the label if it is missing
+	if rs.Labels == nil {
+		rs.Labels = map[string]string{}
+	}
+
+	if rs.Labels["hello"] == "world" {
+		return reconcile.Result{}, nil
+	}
+
+	// Update the ReplicaSet
+	rs.Labels["hello"] = "world"
+	err = r.client.Update(context.TODO(), rs)
+	if err != nil {
+		log.Error(err, "Could not write ReplicaSet")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// podForReplicasetWithWatchAnnotations returns a pod object with the annotations required to be watched with.
+func (r *reconcileReplicaSet) podForReplicasetWithWatchAnnotations(rs *appsv1.ReplicaSet) *corev1.Pod {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rs.Name,
+			Namespace: rs.Namespace,
+		},
+	}
+	annotation := schema.GroupKind{Group: "ReplicaSet", Kind: "apps"}
+	handler.SetWatchOwnerAnnotation(rs,pod, annotation)
+	return pod
+}

--- a/examples/annotationbasedwatch/main.go
+++ b/examples/annotationbasedwatch/main.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"os"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+var log = logf.Log.WithName("example-annotationbasedwatch")
+
+func main() {
+	logf.SetLogger(zap.Logger(false))
+	entryLog := log.WithName("entrypoint")
+
+	// Setup a Manager
+	entryLog.Info("setting up manager")
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
+	if err != nil {
+		entryLog.Error(err, "unable to set up overall controller manager")
+		os.Exit(1)
+	}
+
+	// Setup a new controller to reconcile ReplicaSets
+	entryLog.Info("Setting up controller")
+	c, err := controller.New("foo-controller", mgr, controller.Options{
+		Reconciler: &reconcileReplicaSet{client: mgr.GetClient(), log: log.WithName("reconciler")},
+	})
+	if err != nil {
+		entryLog.Error(err, "unable to set up individual controller")
+		os.Exit(1)
+	}
+
+	// Watch Pods that has the following annotations:
+	// ...
+	// annotations:
+	//    watch.kubebuilder.io/owner-namespaced-name:my-namespace/my-replicaset
+	//    watch.kubebuilder.io/owner-type:apps.ReplicaSet
+	// ...
+	// It will enqueue a Request to the primary-resource-namespace when some change occurs in a Pod resource with these
+	// annotations
+	annotation := schema.GroupKind{Group: "ReplicaSet", Kind: "apps"}
+	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForAnnotation{annotation}); err != nil {
+		entryLog.Error(err, "unable to watch Pods")
+		os.Exit(1)
+	}
+
+	// Watch ClusterRoles that has the following annotations:
+	// ...
+	// annotations:
+	//    watch.kubebuilder.io/owner-namespaced-name:my-namespace/my-replicaset
+	//    watch.kubebuilder.io/owner-type:apps.ReplicaSet
+	// ...
+	// It will enqueue a Request to the primary-resource-namespace when some change occurs in a ClusterRole resource with these
+	// annotations
+	if err := c.Watch(&source.Kind{
+		// Watch cluster roles
+		Type: &rbacv1.ClusterRole{}},
+
+		// Enqueue ReplicaSet reconcile requests using the
+		// namespacedName annotation value in the request.
+		&handler.EnqueueRequestForAnnotation{schema.GroupKind{Group:"ReplicaSet", Kind:"apps"}}); err != nil {
+		entryLog.Error(err, "unable to watch Cluster Role")
+		os.Exit(1)
+	}
+
+	entryLog.Info("starting manager")
+	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
+		entryLog.Error(err, "unable to run manager")
+		os.Exit(1)
+	}
+}

--- a/pkg/handler/enqueue_annotation.go
+++ b/pkg/handler/enqueue_annotation.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handler
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ EventHandler = &EnqueueRequestForAnnotation{}
+
+const (
+	// NamespacedNameAnnotation defines the annotation that will be used to get the primary resource namespaced name.
+	// The handler will use this value to build the types.NamespacedName object used to enqueue a Request when an event
+	// to update, to create or to delete the observed object is raised. Note that if only one value be informed without
+	// the "/"  then it will be set as the name of the primary resource.
+	NamespacedNameAnnotation = "watch.kubebuilder.io/owner-namespaced-name"
+
+	// TypeAnnotation define the annotation that will be used to verify that the primary resource is the primary resource
+	// to use. It should be the type schema.GroupKind. E.g watch.kubebuilder.io/owner-type:core.Pods
+	TypeAnnotation = "watch.kubebuilder.io/owner-type"
+)
+
+// EnqueueRequestForAnnotation enqueues Requests based on the presence of annotations that contain the type and
+// namespaced name of the primary resource. The purpose of this handler is to support cross-scope ownership
+// relationships that are not supported by native owner references.
+//
+// This handler should ALWAYS be paired with a finalizer on the primary resource. While the
+// annotation-based watch handler does not have the same scope restrictions that owner references
+// do, they also do not have the garbage collection guarantees that owner references do. Therefore,
+// if the reconciler of a primary resource creates a child resource across scopes not supported by
+// owner references, it is up to the reconciler to clean up that child resource.
+//
+// **NOTE** You might prefer to use the EnqueueRequestsFromMapFunc with predicates instead of it.
+//
+// **Examples:**
+//
+// The following code will enqueue a Request to the `primary-resource-namespace` when some change occurs in a Pod
+// resource:
+//
+// ...
+// annotation := schema.GroupKind{Group: "ReplicaSet", Kind: "apps"}
+// if err := c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForAnnotation{annotation}); err != nil {
+//    entryLog.Error(err, "unable to watch Pods")
+//    os.Exit(1)
+// }
+// ...
+//
+// With the annotations:
+//
+// ...
+// annotations:
+//    watch.kubebuilder.io/owner-namespaced-name:my-namespace/my-replicaset
+//    watch.kubebuilder.io/owner-type:apps.ReplicaSet
+// ...
+//
+// The following code will enqueue a Request to the `primary-resource-namespace`, ReplicaSet reconcile,
+// when some change occurs in a ClusterRole resource
+//
+// ...
+// if err := c.Watch(&source.Kind{
+//	  // Watch cluster roles
+//	  Type: &rbacv1.ClusterRole{}},
+//
+//	  // Enqueue ReplicaSet reconcile requests using the
+//	  // namespacedName annotation value in the request.
+//	  &handler.EnqueueRequestForAnnotation{schema.GroupKind{Group:"ReplicaSet", Kind:"apps"}}); err != nil {
+//	      entryLog.Error(err, "unable to watch ClusterRole")
+//	      os.Exit(1)
+//    }
+// }
+// ...
+// With the annotations:
+//
+// ...
+// annotations:
+//    watch.kubebuilder.io/owner-namespaced-name:my-namespace/my-replicaset
+//    watch.kubebuilder.io/owner-type:apps.ReplicaSet
+// ...
+//
+// **NOTE** Cluster-scoped resources will have the NamespacedNameAnnotation such as:
+// `watch.kubebuilder.io/owner-namespaced-name:my-replicaset
+type EnqueueRequestForAnnotation struct {
+	// It is used to verify that the primary resource is the primary resource to use.
+	// E.g watch.kubebuilder.io/owner-type:core.Pods
+	Type schema.GroupKind
+}
+
+// Create implements EventHandler
+func (e *EnqueueRequestForAnnotation) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Meta); ok {
+		q.Add(req)
+	}
+}
+
+// Update implements EventHandler
+func (e *EnqueueRequestForAnnotation) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.MetaOld); ok {
+		q.Add(req)
+	} else if ok, req := e.getAnnotationRequests(evt.MetaNew); ok {
+		q.Add(req)
+	}
+}
+
+// Delete implements EventHandler
+func (e *EnqueueRequestForAnnotation) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Meta); ok {
+		q.Add(req)
+	}
+}
+
+// Generic implements EventHandler
+func (e *EnqueueRequestForAnnotation) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	if ok, req := e.getAnnotationRequests(evt.Meta); ok {
+		q.Add(req)
+	}
+}
+
+// getAnnotationRequests will check if the object has the annotations for the watch handler and requeue
+func (e *EnqueueRequestForAnnotation) getAnnotationRequests(object metav1.Object) (bool, reconcile.Request) {
+	if typeString, ok := object.GetAnnotations()[TypeAnnotation]; ok && typeString == e.Type.String() {
+		namespacedNameString, ok := object.GetAnnotations()[NamespacedNameAnnotation]
+		if !ok {
+			log.Info("Unable to find the annotation for handle watch annotation",
+				"resource", object, "annotation", NamespacedNameAnnotation)
+		}
+		if len(namespacedNameString) < 1 {
+			return false, reconcile.Request{}
+		}
+		return true, reconcile.Request{NamespacedName: parseNamespacedName(namespacedNameString)}
+	}
+	return false, reconcile.Request{}
+}
+
+// parseNamespacedName will parse the value informed in the NamespacedNameAnnotation and return types.NamespacedName
+// with. Note that if just one value is informed, then it will be set as the name.
+func parseNamespacedName(namespacedNameString string) types.NamespacedName {
+	values := strings.SplitN(namespacedNameString, "/", 2)
+	if len(values) == 1 {
+		return types.NamespacedName{
+			Name:      values[0],
+			Namespace: "",
+		}
+	}
+	if len(values) >= 2 {
+		return types.NamespacedName{
+			Name:      values[1],
+			Namespace: values[0],
+		}
+	}
+	return types.NamespacedName{}
+}
+
+// SetWatchOwnerAnnotation is a helper method to add the watch annotation-based with the owner NamespacedName and the
+// schema.GroupKind to the object provided. This allows you to declare the watch annotations of an owner to an object.
+// If a annotation to the same object already exists, it'll be overwritten with the newly provided version.
+func SetWatchOwnerAnnotation(owner, object metav1.Object, ownerGK schema.GroupKind) error {
+
+	if len(owner.GetName()) < 1 {
+		return fmt.Errorf("%T has not a name, cannot call SetWatchOwnerAnnotation", owner)
+	}
+
+	if len(ownerGK.Kind) < 1 {
+		return fmt.Errorf("Owner Kind is not found, cannot call SetWatchOwnerAnnotation")
+	}
+
+	if len(ownerGK.Group) < 1 {
+		return fmt.Errorf("Owner Group is not found, cannot call SetWatchOwnerAnnotation")
+	}
+
+	annotations := object.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[NamespacedNameAnnotation] = fmt.Sprintf("%v/%v", owner.GetNamespace(), owner.GetName())
+	annotations[TypeAnnotation] = ownerGK.String()
+	object.SetAnnotations(annotations)
+
+	return nil
+}


### PR DESCRIPTION
**Story**
As an operator developer, it would be nice to be able to watch dependent resources based on the presence of an annotation in the dependent resource.

**Description**

While owner references are the idiomatic way to manage dependent resources, they don't solve all use cases. Owner references have restrictions that limit which objects can own other objects.

An annotation-based watch handler does not have these restrictions. However, they don't provide the same feature set either.

The watch handler can be used to trigger reconciliation of a parent resource based on changes to dependent resources that include an annotation. The purpose of this handler is to support cross-scope ownership relationships that are not supported by native owner references.

Since this is a niche feature that should only be used in specific circumstances. Note that for example, owner references are used for garbage collection. If a resource's owner is deleted, the resource will also be deleted. Because of this, annotation references need to be paired with a finalizer so that the operator can manually garbage collect.

**Example**

```go
	// Watch ClusterRoles that has the following annotations:
	// ...
	// annotations:
	//    watch.kubebuilder.io/owner-namespaced-name:my-namespace/my-replicaset
	//    watch.kubebuilder.io/owner-type:apps.ReplicaSet
	// ...
	// It will enqueue a Request to the primary-resource-namespace when some change occurs in a ClusterRole resource with these
	// annotations
	if err := c.Watch(&source.Kind{
		// Watch cluster roles
		Type: &rbacv1.ClusterRole{}},

		// Enqueue ReplicaSet reconcile requests using the
		// namespacedName annotation value in the request.
		&handler.EnqueueRequestForAnnotation{schema.GroupKind{Group:"ReplicaSet", Kind:"apps"}}); err != nil {
		entryLog.Error(err, "unable to watch Cluster Role")
		os.Exit(1)
	}

```

Closes: https://github.com/kubernetes-sigs/kubebuilder/issues/888