### PR TITLE
Adding docs using utilruntime.Must for scheme registration

### DIFF
--- a/pkg/scheme/scheme.go
+++ b/pkg/scheme/scheme.go
@@ -36,13 +36,13 @@ limitations under the License.
 //  )
 //
 // This also true of the built-in Kubernetes types.  Then, in the entrypoint for
-// your manager, assemble the scheme containing exactly the types you need.
-// For instance, if our controller needs types from the core/v1 API group (e.g. Pod),
-// plus types from my.api.group/v1:
+// your manager, assemble the scheme containing exactly the types you need,
+// panicing if scheme registration failed. For instance, if our controller needs
+// types from the core/v1 API group (e.g. Pod), plus types from my.api.group/v1:
 //
 //  func init() {
-//  	myapigroupv1.AddToScheme(scheme)
-//  	kubernetesscheme.AddToScheme(scheme)
+//  	utilruntime.Must(myapigroupv1.AddToScheme(scheme))
+//  	utilruntime.Must(kubernetesscheme.AddToScheme(scheme))
 //  }
 //
 //  func main() {


### PR DESCRIPTION
In addition to adding scaffolded `utilruntime.Must` for scheme registration in `kubebuilder` (https://github.com/kubernetes-sigs/kubebuilder/pull/1462) this updates the docs for `controller-runtime` docs to include panicking when scheme registration fails. 

You will notice that internal to `localSchemeBuilder` in `client-go` (https://github.com/kubernetes/client-go/blob/master/kubernetes/scheme/register.go#L133) and most schemes within kubernetes they cause panics if anything from conversions to defaults fail.

After discussing with @DirectXMan12 this being left out probably either an oversight to that this pattern was developed after these packages where made.

Signed-off-by: Chris Hein <me@chrishein.com>
