### PR TITLE
✨ Introduce controllerutil.Object interface

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -22,7 +22,6 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -133,11 +132,4 @@ func IgnoreNotFound(err error) error {
 		return nil
 	}
 	return err
-}
-
-// KubernetesResource allows functions to work indistinctly with any resource that
-// implements both Object interfaces.
-type KubernetesResource interface {
-	metav1.Object
-	runtime.Object
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -22,6 +22,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -132,4 +133,11 @@ func IgnoreNotFound(err error) error {
 		return nil
 	}
 	return err
+}
+
+// KubernetesResource allows functions to work indistinctly with any resource that
+// implements both Object interfaces.
+type KubernetesResource interface {
+	metav1.Object
+	runtime.Object
 }

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -280,3 +280,10 @@ func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
 	RemoveFinalizer(m, finalizer)
 	return nil
 }
+
+// KubernetesObject allows functions to work indistinctly with any resource that
+// implements both Object interfaces.
+type KubernetesObject interface {
+	metav1.Object
+	runtime.Object
+}

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -281,9 +281,9 @@ func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
 	return nil
 }
 
-// KubernetesObject allows functions to work indistinctly with any resource that
+// Object allows functions to work indistinctly with any resource that
 // implements both Object interfaces.
-type KubernetesObject interface {
+type Object interface {
 	metav1.Object
 	runtime.Object
 }


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

Introduce an interface that combines `metav1.Object` and `runtime.Object` as discussed in https://github.com/kubernetes-sigs/controller-runtime/issues/594

The main purpose of this interface is to reduce type conversions between the two and provide generic method signatures that can show potential errors at compile time and help developers to write simpler code.

This can make reconsider many places in this library and dependent ones its usage each time a cast is done, usually like the following:
```
//metav1.Object -> runtime.Object
ro, ok := owner.(runtime.Object)

//runtime.Object -> metav1.Object
o, err := meta.Accessor(obj)
```
An example where this interface can be used is https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/controller/controllerutil/controllerutil.go#L95