### PR TITLE
:warning: log/zap options Level and StacktraceLevel type

### DIFF
--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -81,7 +81,7 @@ func newConsoleEncoder() zapcore.Encoder {
 }
 
 type levelFlag struct {
-	setFunc func(zap.AtomicLevel)
+	setFunc func(zapcore.LevelEnabler)
 	value   string
 }
 
@@ -115,7 +115,7 @@ func (ev *levelFlag) Type() string {
 }
 
 type stackTraceFlag struct {
-	setFunc func(zap.AtomicLevel)
+	setFunc func(zapcore.LevelEnabler)
 	value   string
 }
 

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -100,7 +100,7 @@ func Encoder(encoder zapcore.Encoder) func(o *Options) {
 
 // Level sets the the minimum enabled logging level e.g Debug, Info
 // See Options.Level
-func Level(level *zap.AtomicLevel) func(o *Options) {
+func Level(level zapcore.LevelEnabler) func(o *Options) {
 	return func(o *Options) {
 		o.Level = level
 	}
@@ -109,7 +109,7 @@ func Level(level *zap.AtomicLevel) func(o *Options) {
 // StacktraceLevel configures the logger to record a stack trace for all messages at
 // or above a given level.
 // See Options.StacktraceLevel
-func StacktraceLevel(stacktraceLevel *zap.AtomicLevel) func(o *Options) {
+func StacktraceLevel(stacktraceLevel zapcore.LevelEnabler) func(o *Options) {
 	return func(o *Options) {
 		o.StacktraceLevel = stacktraceLevel
 	}
@@ -137,11 +137,11 @@ type Options struct {
 	DestWritter io.Writer
 	// Level configures the verbosity of the logging.  Defaults to Debug when
 	// Development is true and Info otherwise
-	Level *zap.AtomicLevel
+	Level zapcore.LevelEnabler
 	// StacktraceLevel is the level at and above which stacktraces will
 	// be recorded for all messages. Defaults to Warn when Development
 	// is true and Error otherwise
-	StacktraceLevel *zap.AtomicLevel
+	StacktraceLevel zapcore.LevelEnabler
 	// ZapOpts allows passing arbitrary zap.Options to configure on the
 	// underlying Zap logger.
 	ZapOpts []zap.Option
@@ -204,7 +204,7 @@ func NewRaw(opts ...Opts) *zap.Logger {
 	sink := zapcore.AddSync(o.DestWritter)
 
 	o.ZapOpts = append(o.ZapOpts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
-	log := zap.New(zapcore.NewCore(&KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, *o.Level))
+	log := zap.New(zapcore.NewCore(&KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level))
 	log = log.WithOptions(o.ZapOpts...)
 	return log
 }
@@ -232,8 +232,8 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 
 	// Set the Log Level
 	var levelVal levelFlag
-	levelVal.setFunc = func(fromFlag zap.AtomicLevel) {
-		o.Level = &fromFlag
+	levelVal.setFunc = func(fromFlag zapcore.LevelEnabler) {
+		o.Level = fromFlag
 	}
 	fs.Var(&levelVal, "zap-log-level",
 		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', "+
@@ -241,8 +241,8 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 
 	// Set the StrackTrace Level
 	var stackVal stackTraceFlag
-	stackVal.setFunc = func(fromFlag zap.AtomicLevel) {
-		o.StacktraceLevel = &fromFlag
+	stackVal.setFunc = func(fromFlag zapcore.LevelEnabler) {
+		o.StacktraceLevel = fromFlag
 	}
 	fs.Var(&stackVal, "zap-stacktrace-level",
 		"Zap Level at and above which stacktraces are captured (one of 'warn' or 'error')")


### PR DESCRIPTION
Update the options using the concrete type *zap.AtomicLevel to instead
use the zapcore.LevelEnabler interface.

Fixes #899 