### PR TITLE
:bug: Ensure KUBECONFIG is unset when testing GetConfigWithContext

### DIFF
--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -81,6 +81,9 @@ var _ = Describe("Config", func() {
 
 		Context("when kubeconfig files don't exist", func() {
 			It("should fail", func() {
+				err := os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
+				Expect(err).NotTo(HaveOccurred())
+
 				cfg, err := GetConfigWithContext("")
 				Expect(cfg).To(BeNil())
 				Expect(err).To(HaveOccurred())


### PR DESCRIPTION
Where `~/kube/foo.yaml` is a valid yaml, when $KUBECONFIG is set the tests fail. 
```
KUBECONFIG=~/kube/foo.yaml TRACE=1 ./hack/check-everything.sh
```

```

Expected <snip> to be nil

Summarizing 1 Failure:

[Fail] Config GetConfigWithContext when kubeconfig files don't exist [It] should fail 
/Users/mcristi1/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/client/config/config_test.go:85


```

This ensures the env var is unset prior to testing the failure case of `GetConfigWithContext("")`