### PR TITLE
:bug: Fix swapped constant value in webhook envtest

### DIFF
--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -376,8 +376,8 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 			}
 
 			const (
-				admissionregv1      = "admissionregistration.k8s.io/v1beta1"
-				admissionregv1beta1 = "admissionregistration.k8s.io/v1"
+				admissionregv1      = "admissionregistration.k8s.io/v1"
+				admissionregv1beta1 = "admissionregistration.k8s.io/v1beta1"
 			)
 			switch {
 			case generic.Kind == "MutatingWebhookConfiguration":


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Fixed because the constant values had been swapped.