### PR TITLE
🐛 Reset resource version if fake client Create call failed

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -96,7 +96,11 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
 	}
 	accessor.SetResourceVersion("1")
-	return t.ObjectTracker.Create(gvr, obj, ns)
+	if err := t.ObjectTracker.Create(gvr, obj, ns); err != nil {
+		accessor.SetResourceVersion("")
+		return err
+	}
+	return nil
 }
 
 func (t versionedTracker) Update(gvr schema.GroupVersionResource, obj runtime.Object, ns string) error {

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -186,6 +186,14 @@ var _ = Describe("Fake client", func() {
 			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 		})
 
+		It("should not change the submitted object if Create failed", func() {
+			By("Trying to create an existing configmap")
+			submitted := cm.DeepCopy()
+			err := cl.Create(context.Background(), submitted)
+			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
+			Expect(submitted).To(Equal(cm))
+		})
+
 		It("should error on Create with empty Name", func() {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/918

This breaks the code that relies on first checking if an object already exists via the error returned from `Create` and then run `Patch`. Since `Patch` call of fake client does an `Update` operation, which checks resource version match, it returns `object was changed` error in these cases because the local object now has resource version 1 but what storage has is resource version 0 since the client was initialized with that object.