### PR TITLE
🏃 Add a WithoutLeaderElection option to controllers

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -41,6 +41,10 @@ type Options struct {
 	// Defaults to MaxOfRateLimiter which has both overall and per-item rate limiting.
 	// The overall is a token bucket and the per-item is exponential.
 	RateLimiter ratelimiter.RateLimiter
+
+	// WithoutLeaderElection is used to bypass manager leader election in case
+	// it's activated, by default leader election is activated for controllers.
+	WithoutLeaderElection bool
 }
 
 // Controller implements a Kubernetes API.  A Controller manages a work queue fed reconcile.Requests
@@ -109,6 +113,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
 		SetFields:               mgr.SetFields,
 		Name:                    name,
+		WithoutLeaderElection:   options.WithoutLeaderElection,
 	}
 
 	return c, nil

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -71,6 +71,9 @@ type Controller struct {
 	// Started is true if the Controller has been Started
 	Started bool
 
+	// Flag to indicate if this controller need leader election or not
+	WithoutLeaderElection bool
+
 	// TODO(community): Consider initializing a logger with the Controller Name as the tag
 
 	// watches maintains a list of sources, handlers, and predicates to start when the controller is started.
@@ -266,6 +269,11 @@ func (c *Controller) reconcileHandler(obj interface{}) bool {
 func (c *Controller) InjectFunc(f inject.Func) error {
 	c.SetFields = f
 	return nil
+}
+
+// NeedLeaderElection implements LeaderElectionRunnable
+func (c *Controller) NeedLeaderElection() bool {
+	return !c.WithoutLeaderElection
 }
 
 // updateMetrics updates prometheus metrics within the controller

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -74,6 +74,20 @@ var _ = Describe("controller", func() {
 		close(stop)
 	})
 
+	Describe("NeedLeaderElection", func() {
+		It("should return true by default", func() {
+			Expect(ctrl.NeedLeaderElection()).To(BeTrue())
+		})
+		It("should be true WithoutLeaderElection is false", func() {
+			ctrl.WithoutLeaderElection = false
+			Expect(ctrl.NeedLeaderElection()).To(BeTrue())
+		})
+		It("should be false WithoutLeaderElection is true", func() {
+			ctrl.WithoutLeaderElection = true
+			Expect(ctrl.NeedLeaderElection()).To(BeFalse())
+		})
+	})
+
 	Describe("Reconciler", func() {
 		It("should call the Reconciler function", func() {
 			ctrl.Do = reconcile.Func(func(reconcile.Request) (reconcile.Result, error) {


### PR DESCRIPTION
It will run the controllers with option `WithoutLeaderElection` set to `true` like the webhooks ignoring leader election in case manager is configured with LeaderElection. 

`WithoutLeaderElection` is choosen instead of `WithLeaderElection` to use the default bool value ot false so we don't need to discover if it's set by the user or not.


