### PR TITLE
:sparkles: Add ContainsFinalizer helper to the controllerutil

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -282,6 +282,17 @@ func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
 	return nil
 }
 
+// ContainsFinalizer checks a metav1 object that the provided finalizer is present.
+func ContainsFinalizer(o Object, finalizer string) bool {
+	f := o.GetFinalizers()
+	for _, e := range f {
+		if e == finalizer {
+			return true
+		}
+	}
+	return false
+}
+
 // Object allows functions to work indistinctly with any resource that
 // implements both Object interfaces.
 type Object interface {

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -452,6 +452,18 @@ var _ = Describe("Controllerutil", func() {
 				Expect(deploy.ObjectMeta.GetFinalizers()).To(Equal([]string{}))
 			})
 		})
+
+		Describe("ContainsFinalizer", func() {
+			It("should check that finalizer is present", func() {
+				controllerutil.AddFinalizer(deploy, testFinalizer)
+				Expect(controllerutil.ContainsFinalizer(deploy, testFinalizer)).To(Equal(true))
+			})
+
+			It("should check that finalizer is not present after RemoveFinalizer call", func() {
+				controllerutil.RemoveFinalizer(deploy, testFinalizer)
+				Expect(controllerutil.ContainsFinalizer(deploy, testFinalizer)).To(Equal(false))
+			})
+		})
 	})
 })
 


### PR DESCRIPTION
This is ContainsFinalizer helper in the controllerutil package which checks that provided finalizer exists in the Object meta

Fixes #920
