### PR TITLE
:sparkles: Manager: Export defaultNewClient

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -343,8 +343,8 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}, nil
 }
 
-// defaultNewClient creates the default caching client
-func defaultNewClient(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
+// DefaultNewClient creates the default caching client
+func DefaultNewClient(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
 	// Create the Client for Write operations.
 	c, err := client.New(config, options)
 	if err != nil {
@@ -389,7 +389,7 @@ func setOptionsDefaults(options Options) Options {
 
 	// Allow newClient to be mocked
 	if options.NewClient == nil {
-		options.NewClient = defaultNewClient
+		options.NewClient = DefaultNewClient
 	}
 
 	// Allow newCache to be mocked


### PR DESCRIPTION
There is a set of cases where ppl might want to wrap the
defaultNewClient, for example:

* To force dry run (currently possible via a manager opt)
* To enforce usage of a given namespace

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @mengqiy @DirectXMan12 
