### PR TITLE
✨ Allow removing individual informers from the cache (#935)

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -126,7 +126,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 	// Construct a new Mapper if unset
 	if opts.Mapper == nil {
 		var err error
-		opts.Mapper, err = apiutil.NewDiscoveryRESTMapper(config)
+		opts.Mapper, err = apiutil.NewDynamicRESTMapper(config)
 		if err != nil {
 			log.WithName("setup").Error(err, "Failed to get API Group-Resources")
 			return opts, fmt.Errorf("could not create RESTMapper from config")

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -92,6 +92,20 @@ func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj
 	return m.structured.Get(ctx, gvk, obj)
 }
 
+// Remove will remove an new Informer from the InformersMap and stop it if it exists.
+func (m *InformersMap) Remove(gvk schema.GroupVersionKind, obj runtime.Object) {
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+	isUnstructured = isUnstructured || isUnstructuredList
+
+	switch {
+	case isUnstructured:
+		m.unstructured.Remove(gvk)
+	default:
+		m.structured.Remove(gvk)
+	}
+}
+
 // newStructuredInformersMap creates a new InformersMap for structured objects.
 func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
 	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createStructuredListWatch)

--- a/pkg/cache/internal/internal_suite_test.go
+++ b/pkg/cache/internal/internal_suite_test.go
@@ -1,0 +1,14 @@
+package internal
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+)
+
+func TestCacheInternal(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "Cache Internal Suite", []Reporter{printer.NewlineReporter{}})
+}

--- a/pkg/cache/internal/sync.go
+++ b/pkg/cache/internal/sync.go
@@ -1,0 +1,79 @@
+package internal
+
+import (
+	"context"
+	"sync"
+)
+
+// anyOf returns a "done" channel that is closed when any of its input channels
+// are closed or when the retuned cancel function is called, whichever comes first.
+//
+// The cancel function should always be called by the caller to ensure
+// resources are properly released.
+func anyOf(ch ...<-chan struct{}) (<-chan struct{}, context.CancelFunc) {
+	var once sync.Once
+	cancel := make(chan struct{})
+	cancelFunc := func() {
+		once.Do(func() {
+			close(cancel)
+		})
+	}
+	return anyInternal(append(ch, cancel)...), cancelFunc
+}
+
+func anyInternal(ch ...<-chan struct{}) <-chan struct{} {
+	switch len(ch) {
+	case 0:
+		return nil
+	case 1:
+		return ch[0]
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		switch len(ch) {
+		case 2:
+			// This case saves a recursion + goroutine when there are exactly 2 channels.
+			select {
+			case <-ch[0]:
+			case <-ch[1]:
+			}
+		default:
+			// >=3 channels to merge
+			select {
+			case <-ch[0]:
+			case <-ch[1]:
+			case <-ch[2]:
+			case <-anyInternal(append(ch[3:], done)...):
+			}
+		}
+	}()
+
+	return done
+}
+
+// mergeChan returns a channel that is closed when any of the input channels are signaled.
+// The caller must call the returned CancelFunc to ensure no resources are leaked.
+func mergeChan(a, b, c <-chan struct{}) (<-chan struct{}, context.CancelFunc) {
+	var once sync.Once
+	out := make(chan struct{})
+	cancel := make(chan struct{})
+	cancelFunc := func() {
+		once.Do(func() {
+			close(cancel)
+		})
+	}
+	go func() {
+		defer close(out)
+		select {
+		case <-a:
+		case <-b:
+		case <-c:
+		case <-cancel:
+		}
+	}()
+
+	return out, cancelFunc
+}

--- a/pkg/cache/internal/sync_test.go
+++ b/pkg/cache/internal/sync_test.go
@@ -1,0 +1,71 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("anyOf", func() {
+	// Generate contexts for different number of input channels
+	for n := 0; n < 4; n++ {
+		n := n
+		Context(fmt.Sprintf("with %d channels", n), func() {
+			var (
+				channels []chan struct{}
+				done     <-chan struct{}
+				cancel   context.CancelFunc
+			)
+			BeforeEach(func() {
+				channels = make([]chan struct{}, n)
+				in := make([]<-chan struct{}, n)
+				for i := 0; i < n; i++ {
+					ch := make(chan struct{})
+					channels[i] = ch
+					in[i] = ch
+				}
+				done, cancel = anyOf(in...)
+			})
+			AfterEach(func() {
+				cancel()
+			})
+
+			It("isn't closed initially", func() {
+				select {
+				case <-done:
+					Fail("done was closed before cancel")
+				case <-time.After(5 * time.Millisecond):
+					// Ok.
+				}
+			})
+
+			// Verify that done is closed when we call cancel explicitly.
+			It("closes when cancelled", func() {
+				cancel()
+				select {
+				case <-done:
+					// Ok.
+				case <-time.After(5 * time.Millisecond):
+					Fail("timed out waiting for cancel")
+				}
+			})
+
+			// Generate test cases for closing each individual channel.
+			// Verify that done is closed in response.
+			for i := 0; i < n; i++ {
+				i := i
+				It(fmt.Sprintf("closes when channel %d is closed", i), func() {
+					close(channels[i])
+					select {
+					case <-done:
+						// Ok.
+					case <-time.After(5 * time.Millisecond):
+						Fail("timed out waiting for cancel")
+					}
+				})
+			}
+		})
+	}
+})


### PR DESCRIPTION
This change adds support for removing individual informers from the
cache using the new Remove() method. This is allowed before or after the
cache has been started.  Informers are stopped at the time of removal -
once stopped, they will no longer deliver events to registered event
handlers, and registered watched will be aborted.

Also adds non-blocking API for getting informers without waiting for their
cache to sync - GetInformerNonBlocking().

Currently marked as :sparkles: but depending on whether we decide to extend existing interfaces, may become breaking ⚠️ . 

This PR is introduced without comprehensive tests to give an opportunity to iron out the API with the maintainers.

Signed-off-by: Oren Shomron <shomron@gmail.com>