### PR TITLE
:bug: Add error message for certDir default

### DIFF
--- a/examples/builtins/main.go
+++ b/examples/builtins/main.go
@@ -78,6 +78,11 @@ func main() {
 	hookServer.Register("/mutate-v1-pod", &webhook.Admission{Handler: &podAnnotator{Client: mgr.GetClient()}})
 	hookServer.Register("/validate-v1-pod", &webhook.Admission{Handler: &podValidator{Client: mgr.GetClient()}})
 
+	if mgr.GetWebhookServer().CertDir == "" {
+		entryLog.Error(err, "unable to read certs from Manager.CertDir: %w")
+		os.Exit(1)
+	}
+
 	entryLog.Info("starting manager")
 	if err := mgr.Start(signals.SetupSignalHandler()); err != nil {
 		entryLog.Error(err, "unable to run manager")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -183,8 +183,9 @@ type Options struct {
 
 	// CertDir is the directory that contains the server key and certificate.
 	// if not set, webhook server would look up the server key and certificate in
-	// {TempDir}/k8s-webhook-server/serving-certs. The server key and certificate
-	// must be named tls.key and tls.crt, respectively.
+	// {TempDir}/k8s-webhook-server/serving-certs. Please note that TempDir is
+	// os.TempDir(). The server key and certificate must be named tls.key and
+	// tls.crt, respectively.
 	CertDir string
 	// Functions to all for a user to customize the values that will be injected.
 


### PR DESCRIPTION
Description: Update the comment on the type definition for certDir, and add Error message for missing CertDir.
Closes: #900 partially.