### PR TITLE
:bug: ensure multiple Option values append predicates

### DIFF
--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -58,17 +58,17 @@ type Predicates struct {
 
 // ApplyToFor applies this configuration to the given ForInput options.
 func (w Predicates) ApplyToFor(opts *ForInput) {
-	opts.predicates = w.predicates
+	opts.predicates = append(opts.predicates, w.predicates...)
 }
 
 // ApplyToOwns applies this configuration to the given OwnsInput options.
 func (w Predicates) ApplyToOwns(opts *OwnsInput) {
-	opts.predicates = w.predicates
+	opts.predicates = append(opts.predicates, w.predicates...)
 }
 
 // ApplyToWatches applies this configuration to the given WatchesInput options.
 func (w Predicates) ApplyToWatches(opts *WatchesInput) {
-	opts.predicates = w.predicates
+	opts.predicates = append(opts.predicates, w.predicates...)
 }
 
 var _ ForOption = &Predicates{}

--- a/pkg/builder/options_test.go
+++ b/pkg/builder/options_test.go
@@ -1,0 +1,62 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("options", func() {
+	rvcPred := predicate.ResourceVersionChangedPredicate{}
+	gcPred := predicate.GenerationChangedPredicate{}
+
+	Describe("Builder", func() {
+		It("should have empty predicates when no ForOption supplied", func() {
+			bldr := &Builder{}
+			bldr = bldr.For(&fakeType{})
+			Expect(bldr.forInput).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).To(BeNil())
+		})
+		It("should have one predicate when one ForOption supplied", func() {
+			bldr := &Builder{}
+			bldr = bldr.For(&fakeType{}, WithPredicates(rvcPred))
+			Expect(bldr.forInput).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).To(HaveLen(1))
+			Expect(bldr.forInput.predicates).To(ContainElement(rvcPred))
+		})
+		It("should have two predicates when one multi-value Predicates ForOption supplied", func() {
+			bldr := &Builder{}
+			bldr = bldr.For(&fakeType{}, WithPredicates(rvcPred, gcPred))
+			Expect(bldr.forInput).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).To(HaveLen(2))
+			Expect(bldr.forInput.predicates).To(ContainElement(rvcPred))
+			Expect(bldr.forInput.predicates).To(ContainElement(gcPred))
+		})
+		It("should have two predicates when two single-value Predicates ForOption supplied", func() {
+			bldr := &Builder{}
+			bldr = bldr.For(&fakeType{}, WithPredicates(rvcPred), WithPredicates(gcPred))
+			Expect(bldr.forInput).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).NotTo(BeNil())
+			Expect(bldr.forInput.predicates).To(HaveLen(2))
+			Expect(bldr.forInput.predicates).To(ContainElement(rvcPred))
+			Expect(bldr.forInput.predicates).To(ContainElement(gcPred))
+		})
+	})
+})


### PR DESCRIPTION
The `Builder` struct's `For`, `Owns` and `Watches` methods all follow
the same pattern of having a variable number of modifying `Option`
structs as the final parameter to the method. Here is the code for the
`For` method:

```go
// For defines the type of Object being *reconciled*, and configures the ControllerManagedBy to respond to create / delete /
// update events by *reconciling the object*.
// This is the equivalent of calling
// Watches(&source.Kind{Type: apiType}, &handler.EnqueueRequestForObject{})
func (blder *Builder) For(object runtime.Object, opts ...ForOption) *Builder {
	input := ForInput{object: object}
	for _, opt := range opts {
		opt.ApplyToFor(&input)
	}

	blder.forInput = input
	return blder
}
```

The problem with the above is if you call `For` with more than one
`ForOption`, the builder's `forInput` member ends up containing only the
predicates contained in the last `ForOption`. The reason is because the
`ForOption.ApplyToFor` *assigns* the `ForOption.predicates` member to
the supplied `ForInput.predicates` member (note: `ForOption` is an
interface that is implemented by the `Predicates` struct):

```go
// ApplyToFor applies this configuration to the given ForInput options.
func (w Predicates) ApplyToFor(opts *ForInput) {
	opts.predicates = w.predicates
}
```

The solution is to append `w.predicates` to the supplied
`opt.predicates` instead of assigning/overwriting the value of
`opts.predicates`:

```go
// ApplyToFor applies this configuration to the given ForInput options.
func (w Predicates) ApplyToFor(opts *ForInput) {
	opts.predicates = append(opts.predicates, w.predicates...)
}
```

Fixes Issue #945