### PR TITLE
📖 Prevent errors to be logged multiple times in builtins example

### DIFF
--- a/examples/builtins/controller.go
+++ b/examples/builtins/controller.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 
@@ -50,8 +51,7 @@ func (r *reconcileReplicaSet) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	if err != nil {
-		log.Error(err, "Could not fetch ReplicaSet")
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("could not fetch ReplicaSet: %+v", err)
 	}
 
 	// Print the ReplicaSet
@@ -69,8 +69,7 @@ func (r *reconcileReplicaSet) Reconcile(request reconcile.Request) (reconcile.Re
 	rs.Labels["hello"] = "world"
 	err = r.client.Update(context.TODO(), rs)
 	if err != nil {
-		log.Error(err, "Could not write ReplicaSet")
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("could not write ReplicaSet: %+v", err)
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Reconciler errors are logged by the framework. See https://github.com/kubernetes-sigs/controller-runtime/blob/198197fe0fd7553cadd8afcd3338f8ee4b8a7e3f/pkg/internal/controller/controller.go#L258

Currently in the builtins example errors are logged 2 times - once by `example-controller.reconciler` logger and once by the `controller-runtime.controller` logger. Logging the error in the `reconcileReplicaSet ` itself is superfluous and the controller-runtime idiomatic way would be to return the error and have it logged only once by the `controller-runtime.controller` logger.