### PR TITLE
:sparkles: Migrate controllerutil AddFinalizer and RemoveFinalizer to controllerutil.Object and deprecate *WithError functions

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -237,8 +237,8 @@ func mutate(f MutateFn, key client.ObjectKey, obj runtime.Object) error {
 // MutateFn is a function which mutates the existing object into it's desired state.
 type MutateFn func() error
 
-// AddFinalizer accepts a metav1 object and adds the provided finalizer if not present.
-func AddFinalizer(o metav1.Object, finalizer string) {
+// AddFinalizer accepts an Object and adds the provided finalizer if not present.
+func AddFinalizer(o Object, finalizer string) {
 	f := o.GetFinalizers()
 	for _, e := range f {
 		if e == finalizer {
@@ -250,17 +250,19 @@ func AddFinalizer(o metav1.Object, finalizer string) {
 
 // AddFinalizerWithError tries to convert a runtime object to a metav1 object and add the provided finalizer.
 // It returns an error if the provided object cannot provide an accessor.
+//
+// Deprecated: Use AddFinalizer instead. Check is performing on compile time.
 func AddFinalizerWithError(o runtime.Object, finalizer string) error {
 	m, err := meta.Accessor(o)
 	if err != nil {
 		return err
 	}
-	AddFinalizer(m, finalizer)
+	AddFinalizer(m.(Object), finalizer)
 	return nil
 }
 
-// RemoveFinalizer accepts a metav1 object and removes the provided finalizer if present.
-func RemoveFinalizer(o metav1.Object, finalizer string) {
+// RemoveFinalizer accepts an Object and removes the provided finalizer if present.
+func RemoveFinalizer(o Object, finalizer string) {
 	f := o.GetFinalizers()
 	for i := 0; i < len(f); i++ {
 		if f[i] == finalizer {
@@ -273,16 +275,18 @@ func RemoveFinalizer(o metav1.Object, finalizer string) {
 
 // RemoveFinalizerWithError tries to convert a runtime object to a metav1 object and remove the provided finalizer.
 // It returns an error if the provided object cannot provide an accessor.
+//
+// Deprecated: Use RemoveFinalizer instead. Check is performing on compile time.
 func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
 	m, err := meta.Accessor(o)
 	if err != nil {
 		return err
 	}
-	RemoveFinalizer(m, finalizer)
+	RemoveFinalizer(m.(Object), finalizer)
 	return nil
 }
 
-// ContainsFinalizer checks a metav1 object that the provided finalizer is present.
+// ContainsFinalizer checks an Object that the provided finalizer is present.
 func ContainsFinalizer(o Object, finalizer string) bool {
 	f := o.GetFinalizers()
 	for _, e := range f {


### PR DESCRIPTION
As #898 introduces controllerutil.Object interface this fix migrates controllerutil AddFinalizer and RemoveFinalizer to the controllerutil.Object interface and remove *WithError functions as they are not needed anymore as checks are performing on the compile time.

Fixes #959 

