### PR TITLE
🐛 fix(dependency) Use github.com/fsnotify/fsnotify

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.13
 
 require (
 	github.com/evanphx/json-patch v4.5.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.7
 	github.com/go-logr/logr v0.1.0
 	github.com/go-logr/zapr v0.1.0
 	github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef // indirect
@@ -19,7 +20,6 @@ require (
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gomodules.xyz/jsonpatch/v2 v2.0.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
-	gopkg.in/fsnotify.v1 v1.4.7
 	k8s.io/api v0.18.2
 	k8s.io/apiextensions-apiserver v0.18.2
 	k8s.io/apimachinery v0.18.2

--- a/pkg/webhook/internal/certwatcher/certwatcher.go
+++ b/pkg/webhook/internal/certwatcher/certwatcher.go
@@ -20,7 +20,7 @@ import (
 	"crypto/tls"
 	"sync"
 
-	"gopkg.in/fsnotify.v1"
+	"github.com/fsnotify/fsnotify"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 )
 


### PR DESCRIPTION
Use github.com/fsnotify/fsnotify instead of deprecated gopkg.in/fsnotify.v1
See https://github.com/fsnotify/fsnotify/blob/master/go.mod#L1

Signed-off-by: Pierre Péronnet <pierre.peronnet@ovhcloud.com>
