### PR TITLE
CR-965: added subpaths for health checks

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -411,9 +411,11 @@ func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
 
 	if cm.readyzHandler != nil {
 		mux.Handle(cm.readinessEndpointName, http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
+		mux.Handle(cm.readinessEndpointName+"/", http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
 	}
 	if cm.healthzHandler != nil {
 		mux.Handle(cm.livenessEndpointName, http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
+		mux.Handle(cm.livenessEndpointName+"/", http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
 	}
 
 	server := http.Server{


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes: https://github.com/kubernetes-sigs/controller-runtime/issues/965

I just added paths with trailing slash. Shouldn't break anyone's code -- don't think anyone changed default endpoints names to names with slashes(in that case he would need to make separate call for each check, which is impractical).