### PR TITLE
🐛 Always shutdown etcd when stopping envtest

### DIFF
--- a/pkg/internal/testing/integration/control_plane.go
+++ b/pkg/internal/testing/integration/control_plane.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 
@@ -42,17 +43,20 @@ func (f *ControlPlane) Start() error {
 
 // Stop will stop your control plane processes, and clean up their data.
 func (f *ControlPlane) Stop() error {
+	var errList []error
+
 	if f.APIServer != nil {
 		if err := f.APIServer.Stop(); err != nil {
-			return err
+			errList = append(errList, err)
 		}
 	}
 	if f.Etcd != nil {
 		if err := f.Etcd.Stop(); err != nil {
-			return err
+			errList = append(errList, err)
 		}
 	}
-	return nil
+
+	return utilerrors.NewAggregate(errList)
 }
 
 // APIURL returns the URL you should connect to to talk to your API.


### PR DESCRIPTION


<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
This patch fixes an issue that occurs when shutting down an `envtest.Environment`. If the API server fails to shutdown, then the etcd process is orphaned. This can result in dozens of running etcd processes when debugging failed tests.

Please see this [Slack discussion](https://kubernetes.slack.com/archives/CAR30FCJZ/p1590779385006000) for more information.

cc @DirectXMan12 @fstrudel