### PR TITLE
:sparkles: Envtest exports rest.Config for the secure endpoint of kube-apiserver

### DIFF
--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/rest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
+
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
 	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
@@ -25,7 +26,7 @@ type APIServer struct {
 	SecurePort int
 
 	// TLSconfig is tls configuration to connect to its secure endpoint.
-	TlsClientConfig rest.TLSClientConfig
+	TLSClientConfig rest.TLSClientConfig
 
 	// Path is the path to the apiserver binary.
 	//
@@ -161,7 +162,7 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	s.TlsClientConfig = rest.TLSClientConfig{
+	s.TLSClientConfig = rest.TLSClientConfig{
 		CAData: ca.CA.CertBytes(),
 	}
 

--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"k8s.io/client-go/rest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,6 +23,9 @@ type APIServer struct {
 
 	// SecurePort is the additional secure port that the APIServer should listen on.
 	SecurePort int
+
+	// TLSconfig is tls configuration to connect to its secure endpoint.
+	TlsClientConfig rest.TLSClientConfig
 
 	// Path is the path to the apiserver binary.
 	//
@@ -155,6 +159,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 	}
 	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil {
 		return err
+	}
+
+	s.TlsClientConfig = rest.TLSClientConfig{
+		CAData: ca.CA.CertBytes(),
 	}
 
 	return nil


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
fixes #983 

This PR added:
- `internal.integration.APISever`: expose `TLSClientConfig` to connect its secure endpoint
- `envtest.Environment`: introduce `SecureConfig` that just contains kube-apiserver's secure endpoint and its `TLSClientConfig`. 

Note:  _To work with `SecureConfig`, users will have to set authn information like this._

```go
te := &envtest.Environment{
  KubeAPIServerFlags: append(
    envtest.DefaultKubeAPIServerFlags, 
    "--basic-auth-file=my-file", "--authorization-mode=RBAC",
  ),
}
te.Start()
cfg := rest.CopyConfig(te.SecureConfig)
cfg.Username = "myname"
cfg.Password = "mypassword"

// This client can send a request as "myname" user.
client.New(cfg)
```