### PR TITLE
🐛 Avoid marshalling error in debug log line

### DIFF
--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -99,6 +99,11 @@ func (wh *Webhook) writeResponse(w io.Writer, response Response) {
 		wh.writeResponse(w, Errored(http.StatusInternalServerError, err))
 	} else {
 		res := responseAdmissionReview.Response
-		wh.log.V(1).Info("wrote response", "UID", res.UID, "allowed", res.Allowed, "result", res.Result)
+		if log := wh.log; log.V(1).Enabled() {
+			if res.Result != nil {
+				log = log.WithValues("code", res.Result.Code, "reason", res.Result.Reason)
+			}
+			log.V(1).Info("wrote response", "UID", res.UID, "allowed", res.Allowed)
+		}
 	}
 }


### PR DESCRIPTION
Currently every webhook requests ended up logging this in debug:
```
2020-06-10T16:04:20.883+0200	DEBUG	controller-runtime.webhook.webhooks	wrote response	{"webhook": "/validate-some-resource", "UID": "e5d00608-7f47-4d00-bd91-b1a8955dc5a7", "allowed": true, "result": {}, "resultError": "got runtime.Object without object metadata: &Status{ListMeta:ListMeta{SelfLink:,ResourceVersion:,Continue:,RemainingItemCount:nil,},Status:,Message:,Reason:,Details:nil,Code:200,}"}
```

The problem is that a `Status` Object is a runtime.Object with no metadata which is not well received by the `zap.KubeAwareEncoder`.