### PR TITLE
(:warning:) Add helper to get RESTClient from Manager

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -111,6 +111,10 @@ type Manager interface {
 
 	// GetWebhookServer returns a webhook.Server
 	GetWebhookServer() *webhook.Server
+
+	// GetRESTClientFor returns new rest.Interface capable of accessing the resources
+	// of the same GVK as the specified object.
+	GetRESTClientFor(obj runtime.Object) (rest.Interface, error)
 }
 
 // Options are the arguments for creating a new Manager

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -34,6 +34,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
@@ -1235,6 +1236,12 @@ var _ = Describe("manger.Manager", func() {
 		m, err := New(cfg, Options{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(m.GetAPIReader()).NotTo(BeNil())
+	})
+	It("should provide a function to get a REST client for a runtime object", func() {
+		dep := &appsv1.Deployment{}
+		m, err := New(cfg, Options{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(m.GetRESTClientFor(dep)).NotTo(BeNil())
 	})
 })
 


### PR DESCRIPTION
This PR adds a helper to Manager, which can be used to create
REST clients to access resources of the same GVK as the
specified runtime object.

This PR is created to address the issue: [#680 ](https://github.com/kubernetes-sigs/controller-runtime/issues/680)
