### PR TITLE
:sparkles: Add helper to handle panics in reconciler

### DIFF
--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -66,4 +66,30 @@ var _ = Describe("reconcile", func() {
 			Expect(actualErr).To(Equal(err))
 		})
 	})
+	Describe("Test panic handler", func() {
+		It("should panic and return error", func() {
+			var err error
+			func() {
+				defer reconcile.PanicHandler(&err)
+				panic("Test Panic")
+			}()
+			Expect(err).NotTo(BeNil())
+		})
+		It("should panic and return error as directed by custom handler", func() {
+			var res interface{}
+			var err error
+			handlers := []func(interface{}){
+				func(r interface{}) {
+					res = r
+				},
+			}
+			func() {
+				defer reconcile.PanicHandler(&err, handlers...)
+				panic("Test Panic")
+			}()
+			Expect(err).NotTo(BeNil())
+			Expect(res).To(Equal("Test Panic"))
+		})
+
+	})
 })


### PR DESCRIPTION
This PR adds a helper function to handle panics in reconciler.
The function converts panics to normal reconciler errors. Custom handlers can also be provided to handle the go routine.

This PR addresses the issue : https://github.com/kubernetes-sigs/controller-runtime/issues/797

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
