### PR TITLE
:bug: cannot specify ControlPlane in envtest.Environment

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -72,6 +72,15 @@ func defaultAssetPath(binary string) string {
 
 }
 
+// ControlPlane is the re-exported ControlPlane type from the internal integration package
+type ControlPlane = integration.ControlPlane
+
+// APIServer is the re-exported APIServer type from the internal integration package
+type APIServer = integration.APIServer
+
+// Etcd is the re-exported Etcd type from the internal integration package
+type Etcd = integration.Etcd
+
 // Environment creates a Kubernetes test environment that will start / stop the Kubernetes control plane and
 // install extension APIs
 type Environment struct {


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
This is a backport of #929 to the v0.5 release branch.

I believe the testing_frameworks refactoring first appeared in v0.5.0.