### PR TITLE
 🏃 Run tests with race detector enabled

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -22,8 +22,7 @@ setup_envs
 
 header_text "running go test"
 
-# TODO(directxman12): enable the race detector once the LeaderElector race condition is resolved in client-go
-go test ${MOD_OPT} ./... -parallel 4
+go test -race ${MOD_OPT} ./... -parallel 4
 
 header_text "running coverage"
 

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -214,7 +215,7 @@ var _ = Describe("application", func() {
 			var (
 				deployPrctExecuted     = false
 				replicaSetPrctExecuted = false
-				allPrctExecuted        = 0
+				allPrctExecuted        = int64(0)
 			)
 
 			deployPrct := predicate.Funcs{
@@ -246,7 +247,7 @@ var _ = Describe("application", func() {
 						BeAssignableToTypeOf(&appsv1.ReplicaSet{}),
 					))
 
-					allPrctExecuted++
+					atomic.AddInt64(&allPrctExecuted, 1)
 					return true
 				},
 			}

--- a/pkg/cache/informer_cache_unit_test.go
+++ b/pkg/cache/informer_cache_unit_test.go
@@ -6,6 +6,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -59,13 +60,14 @@ var _ = Describe("ip.objectTypeForListObject", func() {
 
 	It("should find the object type of a list with a slice of pointers items field", func() {
 		By("registering the type", func() {
+			ip.Scheme = runtime.NewScheme()
 			err := (&crscheme.Builder{
 				GroupVersion: schema.GroupVersion{Group: itemPointerSliceTypeGroupName, Version: itemPointerSliceTypeVersion},
 			}).
 				Register(
 					&controllertest.UnconventionalListType{},
 					&controllertest.UnconventionalListTypeList{},
-				).AddToScheme(scheme.Scheme)
+				).AddToScheme(ip.Scheme)
 			Expect(err).To(BeNil())
 		})
 

--- a/pkg/internal/testing/integration/internal/integration_tests/etcd_integration_test.go
+++ b/pkg/internal/testing/integration/internal/integration_tests/etcd_integration_test.go
@@ -39,9 +39,7 @@ var _ = Describe("Etcd", func() {
 		}
 
 		Expect(etcd.Start()).To(Succeed())
-		defer func() {
-			Expect(etcd.Stop()).To(Succeed())
-		}()
+		Expect(etcd.Stop()).To(Succeed())
 
 		Expect(stderr.String()).NotTo(BeEmpty())
 	})

--- a/pkg/internal/testing/integration/internal/process_test.go
+++ b/pkg/internal/testing/integration/internal/process_test.go
@@ -216,6 +216,7 @@ var _ = Describe("Start method", func() {
 			processState.StartTimeout = 1 * time.Second
 
 			Expect(processState.Start(stdout, stderr)).To(Succeed())
+			Expect(processState.Session).Should(gexec.Exit())
 
 			Expect(stdout.String()).To(Equal("that is stdout\n"))
 			Expect(stderr.String()).To(Equal("this is stderr\ni started\n"))


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

Changes the test script to run with `--race` and fixes the ~three~ five races found (all of which are in test code)
