### PR TITLE
add a known limitations section to fake Client

### DIFF
--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -27,7 +27,7 @@ You can invoke the methods defined in the Client interface.
 When in doubt, it's almost always better not to use this package and instead use
 envtest.Environment with a real client and API server.
 
-Current Limitations / Known Issues with the fake Client:
+WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
 - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
 - There is some support for sub resources which can cause issues with tests if you're trying to update
   e.g. metadata and status in the same reconcile.

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -28,8 +28,7 @@ When in doubt, it's almost always better not to use this package and instead use
 envtest.Environment with a real client and API server.
 
 Current Limitations / Known Issues with the fake Client:
-- this client does not use reactors so it can not be setup with detailed responses for testing
-- possible locking issues when using fake client and not the actual client
+- this client does not have a way to inject specific errors to test handled vs. unhandled errors
 - there is some support for sub resources which can cause issues with tests if you're trying to update
   e.g. metadata and status in the same reconcile
 - No OpeanAPI validation is performed when creating or updating objects.

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -28,9 +28,9 @@ When in doubt, it's almost always better not to use this package and instead use
 envtest.Environment with a real client and API server.
 
 Current Limitations / Known Issues with the fake Client:
-- this client does not have a way to inject specific errors to test handled vs. unhandled errors
-- there is some support for sub resources which can cause issues with tests if you're trying to update
-  e.g. metadata and status in the same reconcile
+- This client does not have a way to inject specific errors to test handled vs. unhandled errors.
+- There is some support for sub resources which can cause issues with tests if you're trying to update
+  e.g. metadata and status in the same reconcile.
 - No OpeanAPI validation is performed when creating or updating objects.
 - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
 operations that rely on these fields will fail, or give false positives.

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -17,10 +17,10 @@ limitations under the License.
 /*
 Package fake provides a fake client for testing.
 
-fake client is backed by its simple object store indexed by GroupVersionResource.
+A fake client is backed by its simple object store indexed by GroupVersionResource.
 You can create a fake client with optional objects.
 
-	client := NewFakeClient(initObjs...) // initObjs is a slice of runtime.Object
+	client := NewFakeClientWithScheme(scheme, initObjs...) // initObjs is a slice of runtime.Object
 
 You can invoke the methods defined in the Client interface.
 
@@ -30,11 +30,11 @@ envtest.Environment with a real client and API server.
 Current Limitations / Known Issues with the fake Client:
 - this client does not use reactors so it can not be setup with detailed responses for testing
 - possible locking issues when using fake client and not the actual client
-- by default you are using the wrong scheme
-- there is no support for sub resources which can cause issues with tests if you're trying to update
+- there is some support for sub resources which can cause issues with tests if you're trying to update
   e.g. metadata and status in the same reconcile
-- There is also no OpenAPI validation
-- It does not bump `Generation` or `ResourceVersion` so Patch/Update will not behave properly
+- No OpeanAPI validation is performed when creating or updating objects.
+- ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
+operations that rely on these fields will fail, or give false positives.
 
 */
 package fake

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -17,17 +17,24 @@ limitations under the License.
 /*
 Package fake provides a fake client for testing.
 
-Deprecated: please use pkg/envtest for testing. This package will be dropped
-before the v1.0.0 release.
-
-An fake client is backed by its simple object store indexed by GroupVersionResource.
+fake client is backed by its simple object store indexed by GroupVersionResource.
 You can create a fake client with optional objects.
 
 	client := NewFakeClient(initObjs...) // initObjs is a slice of runtime.Object
 
 You can invoke the methods defined in the Client interface.
 
-When it doubt, it's almost always better not to use this package and instead use
+When in doubt, it's almost always better not to use this package and instead use
 envtest.Environment with a real client and API server.
+
+Current Limitations / Known Issues with the fake Client:
+- this client does not use reactors so it can not be setup with detailed responses for testing
+- possible locking issues when using fake client and not the actual client
+- by default you are using the wrong scheme
+- there is no support for sub resources which can cause issues with tests if you're trying to update
+  e.g. metadata and status in the same reconcile
+- There is also no OpenAPI validation
+- It does not bump `Generation` or `ResourceVersion` so Patch/Update will not behave properly
+
 */
 package fake


### PR DESCRIPTION
This PR adds more information to let users know of the currently known limitations as they exist in `fake.Client`.

We need this to:

* share this list with potential users of the fake client to help with expectations around TDD
* also will help with discussion around which item on the list may be fixed via its own issue. 

This PR also removes the deprecation warning as per issue #768 and is the first step to see if we can improve TDD experience for unit testing by using the fake Client in various testing use cases and scenarios.
