### PR TITLE
⚠️ Remove deprecated "--master" flag

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -30,19 +30,14 @@ import (
 )
 
 var (
-	kubeconfig, apiServerURL string
-	log                      = logf.RuntimeLog.WithName("client").WithName("config")
+	kubeconfig string
+	log        = logf.RuntimeLog.WithName("client").WithName("config")
 )
 
 func init() {
 	// TODO: Fix this to allow double vendoring this library but still register flags on behalf of users
 	flag.StringVar(&kubeconfig, "kubeconfig", "",
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
-
-	// This flag is deprecated, it'll be removed in a future iteration, please switch to --kubeconfig.
-	flag.StringVar(&apiServerURL, "master", "",
-		"(Deprecated: switch to `--kubeconfig`) The address of the Kubernetes API server. Overrides any value in kubeconfig. "+
-			"Only required if out-of-cluster.")
 }
 
 // GetConfig creates a *rest.Config for talking to a Kubernetes API server.
@@ -105,7 +100,7 @@ func loadConfig(context string) (*rest.Config, error) {
 
 	// If a flag is specified with the config location, use that
 	if len(kubeconfig) > 0 {
-		return loadConfigWithContext(apiServerURL, &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}, context)
+		return loadConfigWithContext("", &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}, context)
 	}
 
 	// If the recommended kubeconfig env variable is not specified,
@@ -134,7 +129,7 @@ func loadConfig(context string) (*rest.Config, error) {
 		loadingRules.Precedence = append(loadingRules.Precedence, path.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
 	}
 
-	return loadConfigWithContext(apiServerURL, loadingRules, context)
+	return loadConfigWithContext("", loadingRules, context)
 }
 
 func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoader, context string) (*rest.Config, error) {

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -30,7 +30,6 @@ import (
 
 type testCase struct {
 	text           string
-	apiServerURL   string
 	context        string
 	kubeconfigFlag string
 	kubeconfigEnv  []string
@@ -56,7 +55,6 @@ var _ = Describe("Config", func() {
 	AfterEach(func() {
 		os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
 		kubeconfig = ""
-		apiServerURL = ""
 		clientcmd.RecommendedHomeFile = origRecommendedHomeFile
 
 		err := os.RemoveAll(dir)
@@ -159,12 +157,6 @@ var _ = Describe("Config", func() {
 					wantHost:      "from-multi-env-1",
 				},
 				{
-					text:          "should allow overriding the API server URL",
-					apiServerURL:  "override",
-					kubeconfigEnv: []string{"kubeconfig-multi-context"},
-					wantHost:      "override",
-				},
-				{
 					text:          "should allow overriding the context",
 					context:       "from-multi-env-2",
 					kubeconfigEnv: []string{"kubeconfig-multi-context"},
@@ -183,9 +175,6 @@ var _ = Describe("Config", func() {
 })
 
 func setConfigs(tc testCase, dir string) {
-	// Set API Server URL
-	apiServerURL = tc.apiServerURL
-
 	// Set kubeconfig flag value
 	if len(tc.kubeconfigFlag) > 0 {
 		kubeconfig = filepath.Join(dir, tc.kubeconfigFlag)


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes:https://github.com/kubernetes-sigs/controller-runtime/issues/1028
/cc @vincepri 