### PR TITLE
Remove inactive members from OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -33,7 +33,6 @@ aliases:
   testing-integration-approvers:
   - apelisse
   - hoegaarden
-  - totherme
 
   # folks who may have context on ancient history,
   # but are no longer directly involved


### PR DESCRIPTION
For https://github.com/kubernetes/org/issues/2013

As a part of cleaning up inactive members (who haven't been active since
the release of v1.11) from OWNERS, this commit removes totherme from
the OWNERS_ALIASES file.

/assign @DirectXMan12 
cc @mrbobbytables @totherme
