### PR TITLE
:sparkles: optionally override leader election client config

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -140,6 +140,10 @@ type Options struct {
 	// will use for holding the leader lock.
 	LeaderElectionID string
 
+	// LeaderElectionConfig can be specified to override the default configuration
+	// that is used to build the leader election client.
+	LeaderElectionConfig *rest.Config
+
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack. Default is 15 seconds.
@@ -288,7 +292,11 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}
 
 	// Create the resource lock to enable leader election)
-	resourceLock, err := options.newResourceLock(config, recorderProvider, leaderelection.Options{
+	leaderConfig := config
+	if options.LeaderElectionConfig != nil {
+		leaderConfig = options.LeaderElectionConfig
+	}
+	resourceLock, err := options.newResourceLock(leaderConfig, recorderProvider, leaderelection.Options{
 		LeaderElection:          options.LeaderElection,
 		LeaderElectionID:        options.LeaderElectionID,
 		LeaderElectionNamespace: options.LeaderElectionNamespace,


### PR DESCRIPTION
Allow controllers to have more control over leader election REST config if desired.