### PR TITLE
📖 correct typo in envtest.Environment documentation

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -95,7 +95,7 @@ type Environment struct {
 	// CRDInstallOptions are the options for installing CRDs.
 	CRDInstallOptions CRDInstallOptions
 
-	// CRDInstallOptions are the options for installing webhooks.
+	// WebhookInstallOptions are the options for installing webhooks.
 	WebhookInstallOptions WebhookInstallOptions
 
 	// ErrorIfCRDPathMissing provides an interface for the underlying


### PR DESCRIPTION
Correct a typo in the envtest.Environment documentation
