### PR TITLE
:running: Disable golangs parallel testing

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -22,7 +22,7 @@ setup_envs
 
 header_text "running go test"
 
-go test -race ${MOD_OPT} ./... -parallel 4
+go test -race ${MOD_OPT} ./...
 
 header_text "running coverage"
 


### PR DESCRIPTION
According to https://github.com/onsi/ginkgo/issues/280 this doesn't seem
to be properly supported. If we want parallelization, we should use
ginkgos built-in mechanism for that.

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
