### PR TITLE
Remove coverage when running tests

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -23,15 +23,3 @@ setup_envs
 header_text "running go test"
 
 go test -race ${MOD_OPT} ./...
-
-header_text "running coverage"
-
-# Verify no coverage regressions have been introduced.  Remove the exception list from here
-# once the coverage has been brought back up
-if [[ ! $(go test ${MOD_OPT} ./pkg/...  -coverprofile cover.out | grep -v "coverage: 100.0% of statements" | grep "controller-runtime/pkg " | grep -v "controller-runtime/pkg \|controller-runtime/pkg/recorder \|pkg/cache\|pkg/client \|pkg/event \|pkg/client/config \|pkg/controller/controllertest \|pkg/reconcile/reconciletest \|pkg/test ") ]]; then
-echo "ok"
-else
-go test ${MOD_OPT} ./pkg/...  -coverprofile cover.out | grep -v "coverage: 100.0% of statements" | grep "controller-runtime/pkg " | grep -v "controller-runtime/pkg \|controller-runtime/pkg/recorder \|pkg/cache\|pkg/client \|pkg/event \|pkg/client/config \|pkg/controller/controllertest \|pkg/reconcile/reconciletest \|pkg/test "
-echo "missing test coverage"
-exit 1
-fi


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

This PR removes the coverage step when running in our CI job (and locally). These commands have been ignored for a long time and are not particularly useful. In the future, we should adopt prow coverage utilities if there is a strong need.

/milestone v0.6.x

/assign @alvaroaleman 