### PR TITLE
🐛  Enable Logger Injection for Controller Manager

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -244,6 +244,9 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 	if _, err := inject.MapperInto(cm.mapper, i); err != nil {
 		return err
 	}
+	if _, err := inject.LoggerInto(log, i); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1118,6 +1118,11 @@ var _ = Describe("manger.Manager", func() {
 					Expect(f).NotTo(BeNil())
 					return nil
 				},
+				log: func(logger logr.Logger) error {
+					defer GinkgoRecover()
+					Expect(logger).To(Equal(log))
+					return nil
+				},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -1256,6 +1261,7 @@ var _ inject.Client = &injectable{}
 var _ inject.Scheme = &injectable{}
 var _ inject.Config = &injectable{}
 var _ inject.Stoppable = &injectable{}
+var _ inject.Logger = &injectable{}
 
 type injectable struct {
 	scheme func(scheme *runtime.Scheme) error
@@ -1264,6 +1270,7 @@ type injectable struct {
 	cache  func(cache.Cache) error
 	f      func(inject.Func) error
 	stop   func(<-chan struct{}) error
+	log    func(logger logr.Logger) error
 }
 
 func (i *injectable) InjectCache(c cache.Cache) error {
@@ -1306,6 +1313,13 @@ func (i *injectable) InjectStopChannel(stop <-chan struct{}) error {
 		return nil
 	}
 	return i.stop(stop)
+}
+
+func (i *injectable) InjectLogger(log logr.Logger) error {
+	if i.log == nil {
+		return nil
+	}
+	return i.log(log)
 }
 
 func (i *injectable) Start(<-chan struct{}) error {


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
This PR fixes #1056 
Now Logger can be injected by the controller manager to the Object which implements the `inject.Logger` interface.
