### PR TITLE
🐛 Test can inspect stdout & stderr: Give some time to exit

### DIFF
--- a/pkg/internal/testing/integration/internal/process_test.go
+++ b/pkg/internal/testing/integration/internal/process_test.go
@@ -216,7 +216,7 @@ var _ = Describe("Start method", func() {
 			processState.StartTimeout = 1 * time.Second
 
 			Expect(processState.Start(stdout, stderr)).To(Succeed())
-			Expect(processState.Session).Should(gexec.Exit())
+			Eventually(processState.Session).Should(gexec.Exit())
 
 			Expect(stdout.String()).To(Equal("that is stdout\n"))
 			Expect(stderr.String()).To(Equal("this is stderr\ni started\n"))


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->


Hopefully will fix our top failing test. I believe it is failing because we expect it to be exited immediately after it started. However it might need a bit more time after printing the successful start message to be exited.
