### PR TITLE
⚠️ Add support to read webhook configurations from files for WebhookInstallOptions

### DIFF
--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -75,11 +75,21 @@ var _ = Describe("Test", func() {
 			close(done)
 		})
 
+		It("should load webhooks from directory", func() {
+			installOptions := WebhookInstallOptions{
+				Paths: []string{filepath.Join("testdata", "webhooks")},
+			}
+			err := parseWebhook(&installOptions)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(installOptions.MutatingWebhooks)).To(Equal(2))
+			Expect(len(installOptions.ValidatingWebhooks)).To(Equal(2))
+		})
+
 		It("should load webhooks from files", func() {
 			installOptions := WebhookInstallOptions{
-				DirectoryPaths: []string{filepath.Join("testdata", "webhooks")},
+				Paths: []string{filepath.Join("testdata", "webhooks", "manifests.yaml")},
 			}
-			err := parseWebhookDirs(&installOptions)
+			err := parseWebhook(&installOptions)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(installOptions.MutatingWebhooks)).To(Equal(2))
 			Expect(len(installOptions.ValidatingWebhooks)).To(Equal(2))


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes #1019 
This PR adds support to read webhook configurations from files for `WebhookInstallOptions`
