### PR TITLE
🐛 Use metav1.Object instead of Object

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -238,7 +238,7 @@ func mutate(f MutateFn, key client.ObjectKey, obj runtime.Object) error {
 type MutateFn func() error
 
 // AddFinalizer accepts an Object and adds the provided finalizer if not present.
-func AddFinalizer(o Object, finalizer string) {
+func AddFinalizer(o metav1.Object, finalizer string) {
 	f := o.GetFinalizers()
 	for _, e := range f {
 		if e == finalizer {
@@ -257,12 +257,12 @@ func AddFinalizerWithError(o runtime.Object, finalizer string) error {
 	if err != nil {
 		return err
 	}
-	AddFinalizer(m.(Object), finalizer)
+	AddFinalizer(m, finalizer)
 	return nil
 }
 
 // RemoveFinalizer accepts an Object and removes the provided finalizer if present.
-func RemoveFinalizer(o Object, finalizer string) {
+func RemoveFinalizer(o metav1.Object, finalizer string) {
 	f := o.GetFinalizers()
 	for i := 0; i < len(f); i++ {
 		if f[i] == finalizer {
@@ -282,12 +282,12 @@ func RemoveFinalizerWithError(o runtime.Object, finalizer string) error {
 	if err != nil {
 		return err
 	}
-	RemoveFinalizer(m.(Object), finalizer)
+	RemoveFinalizer(m, finalizer)
 	return nil
 }
 
 // ContainsFinalizer checks an Object that the provided finalizer is present.
-func ContainsFinalizer(o Object, finalizer string) bool {
+func ContainsFinalizer(o metav1.Object, finalizer string) bool {
 	f := o.GetFinalizers()
 	for _, e := range f {
 		if e == finalizer {


### PR DESCRIPTION
In order to allow for a broader adoption of ContainsFinalizer, RemoveFinalizer and AddFinalizer and remove a BC break introduced to 0.5.x I switched the method back to the `metav1.Object`.

After reading https://github.com/kubernetes-sigs/controller-runtime/issues/959 and https://github.com/kubernetes-sigs/controller-runtime/pull/962 I'm unable to understand the benefit of requiring `runtime.Object` so I propose to revert the BC break and possible panic on line 285.
