### PR TITLE
:sparkles: Add namespace enforcing wrapper for client.Client

### DIFF
--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewNamespacedClient wraps an existing client enforcing the namespace value.
+// All functions using this client will have the same namespace declared here.
+func NewNamespacedClient(c Client, ns string, rmp meta.RESTMapper, sch *runtime.Scheme) Client {
+	return &namespacedClient{
+		client:     c,
+		namespace:  ns,
+		restmapper: rmp,
+		scheme:     *sch,
+	}
+}
+
+var _ Client = &namespacedClient{}
+
+// namespacedClient is a Client that wraps another Client in order to enforce the specified namespace value.
+type namespacedClient struct {
+	namespace  string
+	client     Client
+	restmapper meta.RESTMapper
+	scheme     runtime.Scheme
+}
+
+func getNamespace(restmapper meta.RESTMapper, obj runtime.Object, sch *runtime.Scheme) (bool, error) {
+	// var sch = runtime.NewScheme()
+	// // appsv1.AddToScheme(sch)
+	// rbacv1.AddToScheme(sch)
+	gvk, err := apiutil.GVKForObject(obj, sch)
+	if err != nil {
+		return false, err
+	}
+	if restmapper == nil {
+		return false, err
+	}
+
+	// gvk := schema.GroupKind{
+	// 	Group: obj.GetObjectKind().GroupVersionKind().Group,
+	// 	Kind:  obj.GetObjectKind().GroupVersionKind().Kind,
+	// }
+	restmapping, err := restmapper.RESTMapping(gvk.GroupKind())
+	if err != nil {
+		return false, fmt.Errorf("error here restmapping %v", obj)
+	}
+	scope := restmapping.Scope.Name()
+
+	if scope == "" {
+		return false, nil
+	}
+
+	if scope != meta.RESTScopeNameNamespace {
+		return true, nil
+	}
+	return false, nil
+}
+
+// Create implements clinet.Client
+func (n *namespacedClient) Create(ctx context.Context, obj runtime.Object, opts ...CreateOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	isNamespaceScoped, err := getNamespace(n.restmapper, obj, &n.scheme)
+	if err != nil {
+		return fmt.Errorf("erroring Here, %v", err)
+	}
+	if isNamespaceScoped {
+		metaObj.SetNamespace(n.namespace)
+	}
+	return n.client.Create(ctx, obj, opts...)
+}
+
+// Update implements client.Client
+func (n *namespacedClient) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if n.namespace != "" && metaObj.GetNamespace() != n.namespace {
+		metaObj.SetNamespace(n.namespace)
+	}
+	return n.client.Update(ctx, obj, opts...)
+}
+
+// Delete implements client.Client
+func (n *namespacedClient) Delete(ctx context.Context, obj runtime.Object, opts ...DeleteOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if n.namespace != "" && metaObj.GetNamespace() != n.namespace {
+		metaObj.SetNamespace(n.namespace)
+	}
+	return n.client.Delete(ctx, obj, opts...)
+}
+
+// DeleteAllOf implements client.Client
+func (n *namespacedClient) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...DeleteAllOfOption) error {
+	if n.namespace != "" {
+		opts = append(opts, InNamespace(n.namespace))
+	}
+	return n.client.DeleteAllOf(ctx, obj, opts...)
+}
+
+// Patch implements client.Client
+func (n *namespacedClient) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if n.namespace != "" && metaObj.GetNamespace() != n.namespace {
+		metaObj.SetNamespace(n.namespace)
+	}
+	return n.client.Patch(ctx, obj, patch, opts...)
+}
+
+// Get implements client.Client
+func (n *namespacedClient) Get(ctx context.Context, key ObjectKey, obj runtime.Object) error {
+	isNamespaceScoped, err := getNamespace(n.restmapper, obj, &n.scheme)
+	if err != nil {
+		return fmt.Errorf("erroring Here, %v %v", err, obj.GetObjectKind())
+	}
+	if isNamespaceScoped {
+		key.Namespace = n.namespace
+	}
+	return n.client.Get(ctx, key, obj)
+}
+
+// List implements client.Client
+func (n *namespacedClient) List(ctx context.Context, obj runtime.Object, opts ...ListOption) error {
+	if n.namespace != "" {
+		opts = append(opts, InNamespace(n.namespace))
+	}
+	return n.client.List(ctx, obj, opts...)
+}
+
+// Status implements client.StatusClient
+func (n *namespacedClient) Status() StatusWriter {
+	return &namespacedClientStatusWriter{client: n.client.Status(), namespace: n.namespace}
+}
+
+// ensure namespacedClientStatusWriter implements client.StatusWriter
+var _ StatusWriter = &namespacedClientStatusWriter{}
+
+type namespacedClientStatusWriter struct {
+	client    StatusWriter
+	namespace string
+}
+
+// Update implements client.StatusWriter
+func (nsw *namespacedClientStatusWriter) Update(ctx context.Context, obj runtime.Object, opts ...UpdateOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if nsw.namespace != "" && metaObj.GetNamespace() != nsw.namespace {
+		metaObj.SetNamespace(nsw.namespace)
+	}
+	return nsw.client.Update(ctx, obj, opts...)
+}
+
+// Patch implements client.StatusWriter
+func (nsw *namespacedClientStatusWriter) Patch(ctx context.Context, obj runtime.Object, patch Patch, opts ...PatchOption) error {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	if nsw.namespace != "" && metaObj.GetNamespace() != nsw.namespace {
+		metaObj.SetNamespace(nsw.namespace)
+	}
+	return nsw.client.Patch(ctx, obj, patch, opts...)
+}

--- a/pkg/client/namespaced_client_test.go
+++ b/pkg/client/namespaced_client_test.go
@@ -1,0 +1,476 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+var _ = Describe("NamespacedClient", func() {
+	var dep *appsv1.Deployment
+	var ns = "default"
+	ctx := context.Background()
+	var count uint64 = 0
+	var replicaCount int32 = 2
+	var restmapper meta.RESTMapper
+
+	getClient := func() client.Client {
+		var sch runtime.Scheme
+		sch.AddKnownTypes(dep.GroupVersionKind().GroupVersion())
+		nonNamespacedClient, err := client.New(cfg, client.Options{Scheme: &sch})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(&sch).NotTo(BeNil())
+		Expect(nonNamespacedClient).NotTo(BeNil())
+		restmapper, err = apiutil.NewDynamicRESTMapper(cfg)
+		Expect(err).To(BeNil())
+		return client.NewNamespacedClient(nonNamespacedClient, ns, restmapper, &sch)
+	}
+
+	BeforeEach(func() {
+		atomic.AddUint64(&count, 1)
+		dep = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   fmt.Sprintf("namespaced-deployment-%v", count),
+				Labels: map[string]string{"name": fmt.Sprintf("namespaced-deployment-%v", count)},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicaCount,
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+				},
+			},
+		}
+	})
+
+	// Describe("Get", func() {
+
+	// 	BeforeEach(func() {
+	// 		var err error
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+	// 	It("should successfully Get a namespace-scoped object", func() {
+	// 		name := types.NamespacedName{Name: dep.Name}
+	// 		result := &appsv1.Deployment{}
+
+	// 		Expect(getClient().Get(ctx, name, result)).NotTo(HaveOccurred())
+	// 		Expect(result).To(BeEquivalentTo(dep))
+	// 	})
+
+	// 	It("should get the objects from namespace specified in the client", func() {
+	// 		name := types.NamespacedName{Name: dep.Name, Namespace: "non-default"}
+	// 		result := &appsv1.Deployment{}
+
+	// 		Expect(getClient().Get(ctx, name, result)).NotTo(HaveOccurred())
+	// 		Expect(result).To(BeEquivalentTo(dep))
+	// 	})
+	// })
+
+	// Describe("List", func() {
+	// 	BeforeEach(func() {
+	// 		var err error
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+
+	// 	It("should successfully List objects when namespace is not specified with the object", func() {
+	// 		result := &appsv1.DeploymentList{}
+	// 		opts := client.MatchingLabels(dep.Labels)
+
+	// 		Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
+	// 		Expect(len(result.Items)).To(BeEquivalentTo(1))
+	// 		Expect(result.Items[0]).To(BeEquivalentTo(*dep))
+	// 	})
+
+	// 	It("should List objects from the namespace specified in the client", func() {
+	// 		result := &appsv1.DeploymentList{}
+	// 		opts := client.InNamespace("non-default")
+
+	// 		Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
+	// 		Expect(len(result.Items)).To(BeEquivalentTo(1))
+	// 		Expect(result.Items[0]).To(BeEquivalentTo(*dep))
+	// 	})
+	// })
+
+	Describe("Create", func() {
+		AfterEach(func() {
+			deleteDeployment(ctx, dep, ns)
+		})
+
+		// It("should successfully create object in the right namespace", func() {
+		// 	By("creating the object initially")
+		// 	err := getClient().Create(ctx, dep)
+		// 	Expect(err).NotTo(HaveOccurred())
+
+		// 	By("checking if the object was created in the right namespace")
+		// 	res, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+		// 	Expect(err).NotTo(HaveOccurred())
+		// 	Expect(res.GetNamespace()).To(BeEquivalentTo(ns))
+		// })
+
+		It("should create an object in the namespace specified with the client", func() {
+			cr := &rbacv1.ClusterRole{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("clusterRole-%v", count),
+					Namespace: ns,
+					Labels:    map[string]string{"name": fmt.Sprintf("clusterRole-%v", count)},
+				},
+			}
+
+			By("creating the object initially")
+			err := getClient().Create(ctx, cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			// By("checking if the object was created in the right namespace")
+			// res, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+			// Expect(err).NotTo(HaveOccurred())
+			// Expect(res.GetNamespace()).To(BeEquivalentTo(ns))
+		})
+	})
+
+	// Describe("Update", func() {
+	// 	var err error
+	// 	BeforeEach(func() {
+	// 		dep.Annotations = map[string]string{"foo": "bar"}
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+
+	// 	It("should successfully update the provided object", func() {
+	// 		By("updating the Deployment")
+	// 		err = getClient().Update(ctx, dep)
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating if the updated Deployment has new annotation")
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual).NotTo(BeNil())
+	// 		Expect(actual.GetNamespace()).To(Equal(ns))
+	// 		Expect(actual.Annotations["foo"]).To(Equal("bar"))
+	// 	})
+
+	// 	It("should update the object in the namespace specified in the client", func() {
+	// 		By("updating the Deployment")
+	// 		dep.SetNamespace("non-default")
+	// 		err = getClient().Update(ctx, dep)
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating if the updated Deployment has new annotation")
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual).NotTo(BeNil())
+	// 		Expect(actual.GetNamespace()).To(Equal(ns))
+	// 		Expect(actual.Annotations["foo"]).To(Equal("bar"))
+	// 	})
+
+	// 	It("should not update any object from other namespace", func() {
+	// 		By("creating a new namespace")
+	// 		tns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "non-default-1"}}
+	// 		_, err := clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		changedDep := &appsv1.Deployment{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "changed-dep",
+	// 				Namespace: tns.Name,
+	// 				Labels:    map[string]string{"name": "changed-dep"},
+	// 			},
+	// 			Spec: appsv1.DeploymentSpec{
+	// 				Replicas: &replicaCount,
+	// 				Selector: &metav1.LabelSelector{
+	// 					MatchLabels: map[string]string{"foo": "bar"},
+	// 				},
+	// 				Template: corev1.PodTemplateSpec{
+	// 					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+	// 					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+	// 				},
+	// 			},
+	// 		}
+	// 		changedDep.Annotations = map[string]string{"foo": "bar"}
+
+	// 		By("creating the object initially")
+	// 		_, err = clientset.AppsV1().Deployments(tns.Name).Create(ctx, changedDep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("updating the object")
+	// 		err = getClient().Update(ctx, changedDep)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		deleteDeployment(ctx, changedDep, tns.Name)
+	// 		deleteNamespace(ctx, tns)
+	// 	})
+
+	// })
+
+	// Describe("Patch", func() {
+	// 	var err error
+	// 	BeforeEach(func() {
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+	// 	It("should successfully modify the object using Patch", func() {
+	// 		By("Applying Patch")
+	// 		err = getClient().Patch(ctx, dep, client.RawPatch(types.MergePatchType, generatePatch()))
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating patched Deployment has new annotations")
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual.Annotations["foo"]).To(Equal("bar"))
+	// 		Expect(actual.GetNamespace()).To(Equal(ns))
+	// 	})
+	// 	It("should successfully modify the object with namespace specified in the client", func() {
+	// 		dep.SetNamespace("non-default")
+	// 		By("Applying Patch")
+	// 		err = getClient().Patch(ctx, dep, client.RawPatch(types.MergePatchType, generatePatch()))
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating patched Deployment has new annotations")
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual.Annotations["foo"]).To(Equal("bar"))
+	// 		Expect(actual.GetNamespace()).To(Equal(ns))
+	// 	})
+
+	// 	It("should not modify an object from a different namespace", func() {
+	// 		By("creating a new namespace")
+	// 		tns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "non-default-2"}}
+	// 		_, err := clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		changedDep := &appsv1.Deployment{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "changed-dep",
+	// 				Namespace: tns.Name,
+	// 				Labels:    map[string]string{"name": "changed-dep"},
+	// 			},
+	// 			Spec: appsv1.DeploymentSpec{
+	// 				Replicas: &replicaCount,
+	// 				Selector: &metav1.LabelSelector{
+	// 					MatchLabels: map[string]string{"foo": "bar"},
+	// 				},
+	// 				Template: corev1.PodTemplateSpec{
+	// 					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+	// 					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+	// 				},
+	// 			},
+	// 		}
+
+	// 		By("creating the object initially")
+	// 		changedDep, err = clientset.AppsV1().Deployments(tns.Name).Create(ctx, changedDep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		err = getClient().Patch(ctx, changedDep, client.RawPatch(types.MergePatchType, generatePatch()))
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		deleteDeployment(ctx, changedDep, tns.Name)
+	// 		deleteNamespace(ctx, tns)
+	// 	})
+	// })
+
+	// Describe("Delete and DeleteAllOf", func() {
+	// 	var err error
+	// 	BeforeEach(func() {
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+	// 	It("should successfully delete an object when namespace is not specified", func() {
+	// 		By("deleting the object")
+	// 		dep.SetNamespace("")
+	// 		err = getClient().Delete(ctx, dep)
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating the Deployment no longer exists")
+	// 		_, err = clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).To(HaveOccurred())
+	// 	})
+
+	// 	It("should successfully delete all of the deployments in the given namespace", func() {
+	// 		By("Deleting all objects in the namespace")
+	// 		err = getClient().DeleteAllOf(ctx, dep)
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating the Deployment no longer exists")
+	// 		_, err = clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).To(HaveOccurred())
+	// 	})
+
+	// 	It("should not delete deployments in other namespaces", func() {
+	// 		tns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "non-default-3"}}
+	// 		_, err = clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		changedDep := &appsv1.Deployment{
+	// 			ObjectMeta: metav1.ObjectMeta{
+	// 				Name:      "changed-dep",
+	// 				Namespace: tns.Name,
+	// 				Labels:    map[string]string{"name": "changed-dep"},
+	// 			},
+	// 			Spec: appsv1.DeploymentSpec{
+	// 				Replicas: &replicaCount,
+	// 				Selector: &metav1.LabelSelector{
+	// 					MatchLabels: map[string]string{"foo": "bar"},
+	// 				},
+	// 				Template: corev1.PodTemplateSpec{
+	// 					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+	// 					Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "nginx", Image: "nginx"}}},
+	// 				},
+	// 			},
+	// 		}
+
+	// 		By("creating the object initially in other namespace")
+	// 		changedDep, err = clientset.AppsV1().Deployments(tns.Name).Create(ctx, changedDep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		err = getClient().DeleteAllOf(ctx, dep)
+	// 		Expect(err).NotTo(HaveOccurred())
+
+	// 		By("validating the Deployment exists")
+	// 		actual, err := clientset.AppsV1().Deployments(tns.Name).Get(ctx, changedDep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual).To(BeEquivalentTo(changedDep))
+
+	// 		deleteDeployment(ctx, changedDep, tns.Name)
+	// 		deleteNamespace(ctx, tns)
+	// 	})
+	// })
+
+	// Describe("StatusWriter", func() {
+	// 	var err error
+	// 	BeforeEach(func() {
+	// 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 	})
+
+	// 	AfterEach(func() {
+	// 		deleteDeployment(ctx, dep, ns)
+	// 	})
+
+	// 	It("should change objects via update status", func() {
+	// 		changedDep := dep.DeepCopy()
+	// 		changedDep.SetNamespace("test")
+	// 		changedDep.Status.Replicas = 99
+
+	// 		Expect(getClient().Status().Update(ctx, changedDep)).NotTo(HaveOccurred())
+
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual).NotTo(BeNil())
+	// 		Expect(actual.GetNamespace()).To(BeEquivalentTo(ns))
+	// 		Expect(actual.Status.Replicas).To(BeEquivalentTo(99))
+	// 	})
+
+	// 	It("should change objects via status patch", func() {
+	// 		changedDep := dep.DeepCopy()
+	// 		changedDep.Status.Replicas = 99
+	// 		changedDep.SetNamespace("test")
+
+	// 		Expect(getClient().Status().Patch(ctx, changedDep, client.MergeFrom(dep))).ToNot(HaveOccurred())
+
+	// 		actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
+	// 		Expect(err).NotTo(HaveOccurred())
+	// 		Expect(actual).NotTo(BeNil())
+	// 		Expect(actual.GetNamespace()).To(BeEquivalentTo(ns))
+	// 		Expect(actual.Status.Replicas).To(BeEquivalentTo(99))
+	// 	})
+	// })
+
+	// Describe("Test on invalid objects", func() {
+	// 	It("should refuse to perform operations on invalid object", func() {
+	// 		err := getClient().Create(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		name := types.NamespacedName{Name: dep.Name}
+	// 		err = getClient().Get(ctx, name, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().List(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().Patch(ctx, nil, client.MergeFrom(dep))
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().Update(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().Delete(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().DeleteAllOf(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().Status().Patch(ctx, nil, client.MergeFrom(dep))
+	// 		Expect(err).To(HaveOccurred())
+
+	// 		err = getClient().Status().Update(ctx, nil)
+	// 		Expect(err).To(HaveOccurred())
+
+	// 	})
+
+	// })
+})
+
+func generatePatch() []byte {
+	mergePatch, err := json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]interface{}{
+				"foo": "bar",
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return mergePatch
+}


### PR DESCRIPTION
This PR adds a namespace enforcing wrapper for client.Client.
This helps while dealing with namespace-scoped objects, where the
namespace value need not be specified in every operation.

This PR addresses the issue: #1073 

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
