### PR TITLE
🏃 setup-envtest.sh: standalone script for setting up envtest

### DIFF
--- a/hack/common.sh
+++ b/hack/common.sh
@@ -51,12 +51,3 @@ fi
 function header_text {
   echo "$header$*$reset"
 }
-
-function setup_envs {
-  header_text "setting up env vars"
-
-  # Setup env vars
-  if [[ -z "${KUBEBUILDER_ASSETS}" ]]; then
-      export KUBEBUILDER_ASSETS=$kb_root_dir/bin
-  fi
-}

--- a/hack/setup-envtest.sh
+++ b/hack/setup-envtest.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+#  Copyright 2020 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+
+function setup_envtest_env {
+  # Setup env vars
+  if [[ -z "${KUBEBUILDER_ASSETS}" ]]; then
+    export KUBEBUILDER_ASSETS=$1/bin
+  fi
+}
+
+# fetch k8s API gen tools and make it available under envtest_root_dir/bin.
+function fetch_envtest_tools {
+  tmp_root=/tmp
+  envtest_root_dir=$tmp_root/envtest
+
+  k8s_version=1.16.4
+  goarch=amd64
+  goos="unknown"
+
+  if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    goos="linux"
+  elif [[ "$OSTYPE" == "darwin"* ]]; then
+    goos="darwin"
+  fi
+
+  if [[ "$goos" == "unknown" ]]; then
+    echo "OS '$OSTYPE' not supported. Aborting." >&2
+    return 1
+  fi
+
+  local dest_dir="${1}"
+
+  # use the pre-existing version in the temporary folder if it matches our k8s version
+  if [[ -x "${dest_dir}/bin/kube-apiserver" ]]; then
+    version=$("${dest_dir}"/bin/kube-apiserver --version)
+    if [[ $version == *"${k8s_version}"* ]]; then
+      return 0
+    fi
+  fi
+
+  envtest_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
+  envtest_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$envtest_tools_archive_name"
+
+  envtest_tools_archive_path="$tmp_root/$envtest_tools_archive_name"
+  if [ ! -f $envtest_tools_archive_path ]; then
+    curl -sL ${envtest_tools_download_url} -o "$envtest_tools_archive_path"
+  fi
+
+  mkdir -p "${dest_dir}"
+  tar -C "${dest_dir}" --strip-components=1 -zvxf "$envtest_tools_archive_path"
+}

--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -18,8 +18,6 @@ set -e
 
 source $(dirname ${BASH_SOURCE})/common.sh
 
-setup_envs
-
 header_text "running go test"
 
 go test -race ${MOD_OPT} ./...


### PR DESCRIPTION

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->
`envtest` is a test framework provided by `controller-runtime` that simplifies running integration tests for controllers.

Currently, it is not straightforward to setup envtest without also setting up kubebuilder. However, Kubebuilder is not a prerequisite to use `envtest`.

This PR splits out the envtest setup code from controller-runtime's CI scripts such that users could easily download and use the envtest setup code in their own CI scripts.

It would work like this:
```console
source <(curl -sfL https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh)

envtest_assets_dir=$(pwd)/test/assets
fetch_envtest_tools "$envtest_assets_dir"
setup_envtest_env "$envtest_assets_dir"
```
