### PR TITLE
✨ Add ability to set/get logger in/from a context.Context

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -125,6 +125,11 @@ var (
 	// get any actual logging.
 	Log = log.Log
 
+	// LoggerFromContext returns a logger with predefined values from a context.Context.
+	//
+	// This is meant to be used with the context supplied in a struct that satisfies the Reconciler interface.
+	LoggerFromContext = log.FromContext
+
 	// SetLogger sets a concrete logging implementation for all deferred Loggers.
 	SetLogger = log.SetLogger
 )

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -34,7 +34,13 @@ limitations under the License.
 package log
 
 import (
+	"context"
+
 	"github.com/go-logr/logr"
+)
+
+var (
+	contextKey = &struct{}{}
 )
 
 // SetLogger sets a concrete logging implementation for all deferred Loggers.
@@ -46,3 +52,22 @@ func SetLogger(l logr.Logger) {
 // to another logr.Logger.  You *must* call SetLogger to
 // get any actual logging.
 var Log = NewDelegatingLogger(NullLogger{})
+
+// FromContext returns a logger with predefined values from a context.Context.
+func FromContext(ctx context.Context, keysAndValues ...interface{}) logr.Logger {
+	var log logr.Logger
+	if ctx == nil {
+		log = Log
+	} else {
+		lv := ctx.Value(contextKey)
+		log = lv.(logr.Logger)
+	}
+	log.WithValues(keysAndValues...)
+	return log
+}
+
+// IntoContext takes a context and sets the logger as one of its keys.
+// Use FromContext function to retrieve the logger.
+func IntoContext(ctx context.Context, log logr.Logger) context.Context {
+	return context.WithValue(ctx, contextKey, log)
+}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->


/assign @alvaroaleman @detiber 

This we might be able to merge now, given that's not a breaking change