### PR TITLE
:sparkles: Add options to configure a logger for manager and controllers

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -45,6 +47,7 @@ type Builder struct {
 	config           *rest.Config
 	ctrl             controller.Controller
 	ctrlOptions      controller.Options
+	log              logr.Logger
 	name             string
 }
 
@@ -155,6 +158,12 @@ func (blder *Builder) Named(name string) *Builder {
 	return blder
 }
 
+// WithLogger overrides the controller options's logger used.
+func (blder *Builder) WithLogger(log logr.Logger) *Builder {
+	blder.log = log
+	return blder
+}
+
 // Complete builds the Application ControllerManagedBy.
 func (blder *Builder) Complete(r reconcile.Reconciler) error {
 	_, err := blder.Build(r)
@@ -228,26 +237,33 @@ func (blder *Builder) loadRestConfig() {
 	}
 }
 
-func (blder *Builder) getControllerName() (string, error) {
+func (blder *Builder) getControllerName(gvk schema.GroupVersionKind) string {
 	if blder.name != "" {
-		return blder.name, nil
+		return blder.name
 	}
-	gvk, err := getGvk(blder.forInput.object, blder.mgr.GetScheme())
-	if err != nil {
-		return "", err
-	}
-	return strings.ToLower(gvk.Kind), nil
+	return strings.ToLower(gvk.Kind)
 }
 
 func (blder *Builder) doController(r reconcile.Reconciler) error {
-	name, err := blder.getControllerName()
-	if err != nil {
-		return err
-	}
 	ctrlOptions := blder.ctrlOptions
 	if ctrlOptions.Reconciler == nil {
 		ctrlOptions.Reconciler = r
 	}
-	blder.ctrl, err = newController(name, blder.mgr, ctrlOptions)
+
+	// Retrieve the GVK from the object we're reconciling
+	// to prepopulate logger information, and to optionally generate a default name.
+	gvk, err := getGvk(blder.forInput.object, blder.mgr.GetScheme())
+	if err != nil {
+		return err
+	}
+
+	// Setup the logger.
+	if ctrlOptions.Log == nil {
+		ctrlOptions.Log = blder.mgr.GetLogger()
+	}
+	ctrlOptions.Log = ctrlOptions.Log.WithValues("reconcilerGroup", gvk.Group, "reconcilerKind", gvk.Kind)
+
+	// Build the controller and return.
+	blder.ctrl, err = newController(blder.getControllerName(gvk), blder.mgr, ctrlOptions)
 	return err
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,10 +19,10 @@ package controller
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/internal/controller"
-	"sigs.k8s.io/controller-runtime/pkg/internal/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
@@ -42,6 +42,9 @@ type Options struct {
 	// Defaults to MaxOfRateLimiter which has both overall and per-item rate limiting.
 	// The overall is a token bucket and the per-item is exponential.
 	RateLimiter ratelimiter.RateLimiter
+
+	// Log is the logger used for this controller.
+	Log logr.Logger
 }
 
 // Controller implements a Kubernetes API.  A Controller manages a work queue fed reconcile.Requests
@@ -96,13 +99,17 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		options.RateLimiter = workqueue.DefaultControllerRateLimiter()
 	}
 
+	if options.Log == nil {
+		options.Log = mgr.GetLogger()
+	}
+
 	// Inject dependencies into Reconciler
 	if err := mgr.SetFields(options.Reconciler); err != nil {
 		return nil, err
 	}
 
 	// Create controller with dependencies set
-	c := &controller.Controller{
+	return &controller.Controller{
 		Do: options.Reconciler,
 		MakeQueue: func() workqueue.RateLimitingInterface {
 			return workqueue.NewNamedRateLimitingQueue(options.RateLimiter, name)
@@ -110,8 +117,6 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
 		SetFields:               mgr.SetFields,
 		Name:                    name,
-		Log:                     log.RuntimeLog.WithName("controller").WithValues("controller", name),
-	}
-
-	return c, nil
+		Log:                     options.Log.WithName("controller").WithValues("controller", name),
+	}, nil
 }

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -228,11 +228,13 @@ func (c *Controller) reconcileHandler(obj interface{}) bool {
 		return true
 	}
 
+	log := c.Log.WithValues("name", req.Name, "namespace", req.Namespace)
+
 	// RunInformersAndControllers the syncHandler, passing it the namespace/Name string of the
 	// resource to be synced.
 	if result, err := c.Do.Reconcile(req); err != nil {
 		c.Queue.AddRateLimited(req)
-		c.Log.Error(err, "Reconciler error", "name", req.Name, "namespace", req.Namespace)
+		log.Error(err, "Reconciler error")
 		ctrlmetrics.ReconcileErrors.WithLabelValues(c.Name).Inc()
 		ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, "error").Inc()
 		return false
@@ -256,7 +258,7 @@ func (c *Controller) reconcileHandler(obj interface{}) bool {
 	c.Queue.Forget(obj)
 
 	// TODO(directxman12): What does 1 mean?  Do we want level constants?  Do we want levels at all?
-	c.Log.V(1).Info("Successfully Reconciled", "name", req.Name, "namespace", req.Namespace)
+	log.V(1).Info("Successfully Reconciled")
 
 	ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, "success").Inc()
 	// Return true, don't take a break

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -132,6 +133,10 @@ type controllerManager struct {
 	// internalStopper is the write side of the internal stop channel, allowing us to close it.
 	// It and `internalStop` should point to the same channel.
 	internalStopper chan<- struct{}
+
+	// Logger is the logger that should be used by this manager.
+	// If none is set, it defaults to log.Log global logger.
+	logger logr.Logger
 
 	// leaderElectionCancel is used to cancel the leader election. It is distinct from internalStopper,
 	// because for safety reasons we need to os.Exit() when we lose the leader election, meaning that
@@ -355,6 +360,10 @@ func (cm *controllerManager) GetWebhookServer() *webhook.Server {
 		}
 	}
 	return cm.webhookServer
+}
+
+func (cm *controllerManager) GetLogger() logr.Logger {
+	return cm.logger
 }
 
 func (cm *controllerManager) serveMetrics(stop <-chan struct{}) {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @alvaroaleman @detiber 

Made these changes also backward compatible to be able to go in v0.6.2
