### PR TITLE
:sparkles: Make individual readiness and liveness checks accessible

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -52,8 +52,8 @@ const (
 	defaultRetryPeriod            = 2 * time.Second
 	defaultGracefulShutdownPeriod = 30 * time.Second
 
-	defaultReadinessEndpoint = "/readyz"
-	defaultLivenessEndpoint  = "/healthz"
+	defaultReadinessEndpoint = "/readyz/"
+	defaultLivenessEndpoint  = "/healthz/"
 	defaultMetricsEndpoint   = "/metrics"
 )
 


### PR DESCRIPTION
When a named readiness/liveness check is registered it should be available under /readyz/<name>.
This PR enables this by adding a trailing slash to the default readyz and healthz endpoints, configuring
the server to handle existing path (`/readyz`) and subpaths (`/readyz/my-check`).
