### PR TITLE
:warning: Remove deprecated client.ConstantPatch function

### DIFF
--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -56,13 +56,6 @@ func RawPatch(patchType types.PatchType, data []byte) Patch {
 	return &patch{patchType, data}
 }
 
-// ConstantPatch constructs a new Patch with the given PatchType and data.
-//
-// Deprecated: use RawPatch instead
-func ConstantPatch(patchType types.PatchType, data []byte) Patch {
-	return RawPatch(patchType, data)
-}
-
 // MergeFromWithOptimisticLock can be used if clients want to make sure a patch
 // is being applied to the latest resource version of an object.
 //


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🏃 (:running:, other) -->

<!-- What does this do, and why do we need it? -->

/milestone v0.7.x