### PR TITLE
:warning: Expose RESTMapper on Client interface

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -86,6 +86,7 @@ func New(config *rest.Config, options Options) (Client, error) {
 			paramCodec: noConversionParamCodec{},
 		},
 		scheme: options.Scheme,
+		mapper: options.Mapper,
 	}
 
 	return c, nil
@@ -99,6 +100,7 @@ type client struct {
 	typedClient        typedClient
 	unstructuredClient unstructuredClient
 	scheme             *runtime.Scheme
+	mapper             meta.RESTMapper
 }
 
 // resetGroupVersionKind is a helper function to restore and preserve GroupVersionKind on an object.
@@ -114,6 +116,11 @@ func (c *client) resetGroupVersionKind(obj runtime.Object, gvk schema.GroupVersi
 // Scheme returns the scheme this client is using.
 func (c *client) Scheme() *runtime.Scheme {
 	return c.scheme
+}
+
+// RESTMapper returns the scheme this client is using.
+func (c *client) RESTMapper() meta.RESTMapper {
+	return c.mapper
 }
 
 // Create implements client.Client

--- a/pkg/client/dryrun.go
+++ b/pkg/client/dryrun.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -38,6 +39,11 @@ type dryRunClient struct {
 // Scheme returns the scheme this client is using.
 func (c *dryRunClient) Scheme() *runtime.Scheme {
 	return c.client.Scheme()
+}
+
+// RESTMapper returns the rest mapper this client is using.
+func (c *dryRunClient) RESTMapper() meta.RESTMapper {
+	return c.client.RESTMapper()
 }
 
 // Create implements client.Client

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -228,6 +228,11 @@ func (c *fakeClient) Scheme() *runtime.Scheme {
 	return c.scheme
 }
 
+func (c *fakeClient) RESTMapper() meta.RESTMapper {
+	// TODO: Implement a fake RESTMapper.
+	return nil
+}
+
 func (c *fakeClient) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 	createOptions := &client.CreateOptions{}
 	createOptions.ApplyOptions(opts)

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -108,6 +108,8 @@ type Client interface {
 
 	// Scheme returns the scheme this client is using.
 	Scheme() *runtime.Scheme
+	// RESTMapper returns the rest this client is using.
+	RESTMapper() meta.RESTMapper
 }
 
 // IndexerFunc knows how to take an object and turn it into a series

--- a/pkg/runtime/inject/inject_test.go
+++ b/pkg/runtime/inject/inject_test.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var instance *testSource
@@ -86,7 +87,7 @@ var _ = Describe("runtime inject", func() {
 	})
 
 	It("should set client", func() {
-		client := client.NewDelegatingClient(client.NewDelegatingClientInput{})
+		client := client.NewDelegatingClient(client.NewDelegatingClientInput{Client: fake.NewFakeClient()})
 
 		By("Validating injecting client")
 		res, err := ClientInto(client, instance)
@@ -151,7 +152,7 @@ var _ = Describe("runtime inject", func() {
 	})
 
 	It("should set api reader", func() {
-		apiReader := client.NewDelegatingClient(client.NewDelegatingClientInput{})
+		apiReader := client.NewDelegatingClient(client.NewDelegatingClientInput{Client: fake.NewFakeClient()})
 
 		By("Validating injecting client")
 		res, err := APIReaderInto(apiReader, instance)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @alvaroaleman 
/milestone v0.7.x