### PR TITLE
:warning: Remove deprecated pkg/client options

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Client", func() {
 					Expect(cl).NotTo(BeNil())
 
 					By("creating the object (with DryRun)")
-					err = cl.Create(context.TODO(), dep, client.CreateDryRunAll)
+					err = cl.Create(context.TODO(), dep, client.DryRunAll)
 					Expect(err).NotTo(HaveOccurred())
 
 					actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
@@ -422,7 +422,7 @@ var _ = Describe("Client", func() {
 				})
 
 				By("creating the object")
-				err = cl.Create(context.TODO(), u, client.CreateDryRunAll)
+				err = cl.Create(context.TODO(), u, client.DryRunAll)
 				Expect(err).NotTo(HaveOccurred())
 
 				actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
@@ -1339,7 +1339,7 @@ var _ = Describe("Client", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				By("patching the Deployment with dry-run")
-				err = cl.Patch(context.TODO(), dep, client.RawPatch(types.MergePatchType, mergePatch), client.PatchDryRunAll)
+				err = cl.Patch(context.TODO(), dep, client.RawPatch(types.MergePatchType, mergePatch), client.DryRunAll)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("validating patched Deployment doesn't have the new annotation")
@@ -1470,7 +1470,7 @@ var _ = Describe("Client", func() {
 					Kind:    "Deployment",
 					Version: "v1",
 				})
-				err = cl.Patch(context.TODO(), u, client.RawPatch(types.MergePatchType, mergePatch), client.PatchDryRunAll)
+				err = cl.Patch(context.TODO(), u, client.RawPatch(types.MergePatchType, mergePatch), client.DryRunAll)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("validating patched Deployment does not have the new annotation")

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -173,11 +173,6 @@ func (o *CreateOptions) ApplyToCreate(co *CreateOptions) {
 
 var _ CreateOption = &CreateOptions{}
 
-// CreateDryRunAll sets the "dry run" option to "all".
-//
-// Deprecated: Use DryRunAll
-var CreateDryRunAll = DryRunAll
-
 // }}}
 
 // {{{ Delete Options
@@ -460,14 +455,6 @@ func (m MatchingLabelsSelector) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
 	m.ApplyToList(&opts.ListOptions)
 }
 
-// MatchingField filters the list operation on the given field selector
-// (or index in the case of cached lists).
-//
-// Deprecated: Use MatchingFields
-func MatchingField(name, val string) MatchingFields {
-	return MatchingFields{name: val}
-}
-
 // MatchingFields filters the list/delete operation on the given field Set
 // (or index in the case of cached lists).
 type MatchingFields fields.Set
@@ -595,11 +582,6 @@ func (o *UpdateOptions) ApplyToUpdate(uo *UpdateOptions) {
 	}
 }
 
-// UpdateDryRunAll sets the "dry run" option to "all".
-//
-// Deprecated: Use DryRunAll
-var UpdateDryRunAll = DryRunAll
-
 // }}}
 
 // {{{ Patch Options
@@ -681,11 +663,6 @@ func (forceOwnership) ApplyToPatch(opts *PatchOptions) {
 	definitelyTrue := true
 	opts.Force = &definitelyTrue
 }
-
-// PatchDryRunAll sets the "dry run" option to "all".
-//
-// Deprecated: Use DryRunAll
-var PatchDryRunAll = DryRunAll
 
 // }}}
 


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @alvaroaleman 
/milestone v0.7.x