### PR TITLE
:sparkles: Add controllerutil.IsOwner functions to check that object has existing reference

### DIFF
--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -257,6 +257,32 @@ var _ = Describe("Controllerutil", func() {
 		})
 	})
 
+	Describe("IsOwner", func() {
+		It("should get false if validate ownerRef on an empty list", func() {
+			rs := &appsv1.ReplicaSet{}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid"},
+			}
+
+			result, err := controllerutil.IsOwner(dep, rs, scheme.Scheme)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(false))
+		})
+
+		It("should get true if ownerRef already set", func() {
+			rs := &appsv1.ReplicaSet{}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid"},
+			}
+
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			result, err := controllerutil.IsOwner(dep, rs, scheme.Scheme)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(true))
+
+		})
+	})
+
 	Describe("CreateOrUpdate", func() {
 		var deploy *appsv1.Deployment
 		var deplSpec appsv1.DeploymentSpec


### PR DESCRIPTION
IsOwner is a helper method to validate if existing object has provided owner as reference
It prevents object from unnecessary updates in case of the owner has not changed

Fixes #1114