### PR TITLE
✨ Added the LabelSelectorPredicate function for filtering events

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -17,6 +17,8 @@ limitations under the License.
 package predicate
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
@@ -267,4 +269,16 @@ func (o or) Generic(e event.GenericEvent) bool {
 		}
 	}
 	return false
+}
+
+// LabelSelectorPredicate constructs a Predicate from a LabelSelector.
+// Only objects matching the LabelSelector will be admitted.
+func LabelSelectorPredicate(s metav1.LabelSelector) (Predicate, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&s)
+	if err != nil {
+		return Funcs{}, err
+	}
+	return NewPredicateFuncs(func(o controllerutil.Object) bool {
+		return selector.Matches(labels.Set(o.GetLabels()))
+	}), nil
 }

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -516,4 +516,35 @@ var _ = Describe("Predicate", func() {
 			})
 		})
 	})
+
+	Describe("When checking a LabelSelectorPredicate", func() {
+		instance, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{"foo": "bar"}})
+		if err != nil {
+			Fail("Improper Label Selector passed during predicate instantiation.")
+		}
+
+		Context("When the Selector does not match the event labels", func() {
+			It("should return false", func() {
+				failMatch := &corev1.Pod{}
+				Expect(instance.Create(event.CreateEvent{Object: failMatch})).To(BeFalse())
+				Expect(instance.Delete(event.DeleteEvent{Object: failMatch})).To(BeFalse())
+				Expect(instance.Generic(event.GenericEvent{Object: failMatch})).To(BeFalse())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: failMatch})).To(BeFalse())
+			})
+		})
+
+		Context("When the Selector matches the event labels", func() {
+			It("should return true", func() {
+				successMatch := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"foo": "bar"},
+					},
+				}
+				Expect(instance.Create(event.CreateEvent{Object: successMatch})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{Object: successMatch})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{Object: successMatch})).To(BeTrue())
+				Expect(instance.Update(event.UpdateEvent{ObjectNew: successMatch})).To(BeTrue())
+			})
+		})
+	})
 })


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
The LabelSelectorPredicate function implements predicate functions to only reconcile events that contain certain labels.

This allows a user to pre-determine which events will undergo reconciliation via a Selector object that will compare against an event's labels, thereby "filtering" events.