### PR TITLE
:sparkles: Add metrics for total workers and active workers

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -44,6 +44,20 @@ var (
 		Name: "controller_runtime_reconcile_time_seconds",
 		Help: "Length of time per reconciliation per controller",
 	}, []string{"controller"})
+
+	// WorkerCount is a prometheus metric which holds the number of
+	// concurrent reconciles per controller
+	WorkerCount = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "controller_runtime_max_concurrent_reconciles",
+		Help: "Maximum number of concurrent reconciles per controller",
+	}, []string{"controller"})
+
+	// ActiveWorkers is a prometheus metric which holds the number
+	// of active workers per controller
+	ActiveWorkers = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "controller_runtime_active_workers",
+		Help: "Number of currently used workers per controller",
+	}, []string{"controller"})
 )
 
 func init() {
@@ -51,6 +65,8 @@ func init() {
 		ReconcileTotal,
 		ReconcileErrors,
 		ReconcileTime,
+		WorkerCount,
+		ActiveWorkers,
 		// expose process metrics like CPU, Memory, file descriptor usage etc.
 		prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{}),
 		// expose Go runtime metrics like GC stats, memory stats etc.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Helps debugging issues around reconciliation duration. Right now its impossible to find out the number of workers from metrics and its also impossible to find out the number of active workers. The only thing we have is `workqueue_unfinished_work_seconds` which if big is probably not good but its not clearly indicating if we have one worker that takes longer, if all workers are blocked etc.
