### PR TITLE
:sparkles: Allow configuring LeaderElectionReleaseOnCancel

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -94,6 +94,10 @@ type controllerManager struct {
 	// resourceLock forms the basis for leader election
 	resourceLock resourcelock.Interface
 
+	// leaderElectionReleaseOnCancel defines if the manager should step back from the leader lease
+	// on shutdown
+	leaderElectionReleaseOnCancel bool
+
 	// mapper is used to map resources to kind, and map kind and version.
 	mapper meta.RESTMapper
 
@@ -640,6 +644,7 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 			},
 			OnStoppedLeading: cm.onStoppedLeading,
 		},
+		ReleaseOnCancel: cm.leaderElectionReleaseOnCancel,
 	})
 	if err != nil {
 		return err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -154,6 +154,13 @@ type Options struct {
 	// that is used to build the leader election client.
 	LeaderElectionConfig *rest.Config
 
+	// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+	// when the Manager ends. This requires the binary to immediately end when the
+	// Manager is stopped, otherwise this setting is unsafe. Setting this significantly
+	// speeds up voluntary leader transitions as the new leader doesn't have to wait
+	// LeaseDuration time first.
+	LeaderElectionReleaseOnCancel bool
+
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack. Default is 15 seconds.


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
```
	// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
	// when the Manager ends. This requires the binary to immediately end when the
	// Manager is stopped, otherwise this setting is unsafe. Setting this significantly
	// speeds up voluntary leader transitions as the new leader doesn't have to wait
	// LeaseDuration time first.
```

This is off by default because it might be unsafe.