### PR TITLE
✨ Add an option to set ReleaseOnCancel for leader election

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -173,6 +173,9 @@ type controllerManager struct {
 	// retryPeriod is the duration the LeaderElector clients should wait
 	// between tries of actions.
 	retryPeriod time.Duration
+	// releaseOnCancel specifies whether the lock should be released
+	// when the run context is cancelled.
+	releaseOnCancel bool
 
 	// waitForRunnable is holding the number of runnables currently running so that
 	// we can wait for them to exit before quitting the manager
@@ -629,10 +632,11 @@ func (cm *controllerManager) startLeaderElection() (err error) {
 		}
 	}
 	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
-		Lock:          cm.resourceLock,
-		LeaseDuration: cm.leaseDuration,
-		RenewDeadline: cm.renewDeadline,
-		RetryPeriod:   cm.retryPeriod,
+		Lock:            cm.resourceLock,
+		ReleaseOnCancel: cm.releaseOnCancel,
+		LeaseDuration:   cm.leaseDuration,
+		RenewDeadline:   cm.renewDeadline,
+		RetryPeriod:     cm.retryPeriod,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(_ context.Context) {
 				close(cm.elected)

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -164,6 +164,9 @@ type Options struct {
 	// RetryPeriod is the duration the LeaderElector clients should wait
 	// between tries of actions. Default is 2 seconds.
 	RetryPeriod *time.Duration
+	// ReleaseOnCancel specifies whether the lock should be released
+	// when the run context is cancelled. Default if False
+	ReleaseOnCancel bool
 
 	// Namespace if specified restricts the manager's cache to watch objects in
 	// the desired namespace Defaults to all namespaces
@@ -362,6 +365,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		leaseDuration:           *options.LeaseDuration,
 		renewDeadline:           *options.RenewDeadline,
 		retryPeriod:             *options.RetryPeriod,
+		releaseOnCancel:         options.ReleaseOnCancel,
 		healthProbeListener:     healthProbeListener,
 		readinessEndpointName:   options.ReadinessEndpointName,
 		livenessEndpointName:    options.LivenessEndpointName,


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Allow to specify `ReleaseOnCancel` option in `manager.Options` which gives an opportunity to reduce writes at `etcd` in idle for acquiring `leader-election` resource lock. Gives an ability to increase the values for `LeaseDuration`, `RenewDeadline`, and `RetryPeriod`, and not experience long pod downtimes at the times when the `leader` replica was downscaled, and a new one is still waiting for `LeaseDuration` to attempt to become one.

Copying implementation from https://github.com/openshift/cloud-credential-operator/pull/231, thanks to @dgoodwin, who implemented it first.