### PR TITLE
:warning: admission responses with raw Status

### DIFF
--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -80,6 +80,17 @@ func ValidationResponse(allowed bool, reason string) Response {
 	return resp
 }
 
+// ValidationResponseFromStatus returns a response for admitting a request with provided Status object.
+func ValidationResponseFromStatus(allowed bool, status *metav1.Status) Response {
+	resp := Response{
+		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+			Allowed: allowed,
+			Result: status,
+		},
+	}
+	return resp
+}
+
 // PatchResponseFromRaw takes 2 byte arrays and returns a new response with json patch.
 // The original object should be passed in as raw bytes to avoid the roundtripping problem
 // described in https://github.com/kubernetes-sigs/kubebuilder/issues/510.

--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -107,3 +107,14 @@ func PatchResponseFromRaw(original, current []byte) Response {
 		},
 	}
 }
+
+// validationResponseFromStatus returns a response for admitting a request with provided Status object.
+func validationResponseFromStatus(allowed bool, status metav1.Status) Response {
+	resp := Response{
+		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+			Allowed: allowed,
+			Result:  &status,
+		},
+	}
+	return resp
+}

--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -80,17 +80,6 @@ func ValidationResponse(allowed bool, reason string) Response {
 	return resp
 }
 
-// ValidationResponseFromStatus returns a response for admitting a request with provided Status object.
-func ValidationResponseFromStatus(allowed bool, status *metav1.Status) Response {
-	resp := Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
-			Allowed: allowed,
-			Result: status,
-		},
-	}
-	return resp
-}
-
 // PatchResponseFromRaw takes 2 byte arrays and returns a new response with json patch.
 // The original object should be passed in as raw bytes to avoid the roundtripping problem
 // described in https://github.com/kubernetes-sigs/kubebuilder/issues/510.

--- a/pkg/webhook/admission/validator_test.go
+++ b/pkg/webhook/admission/validator_test.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-var _ = FDescribe("validatingHandler", func() {
+var _ = Describe("validatingHandler", func() {
 	Describe("Handle", func() {
 
 		When("create succeeds", func() {

--- a/pkg/webhook/admission/validator_test.go
+++ b/pkg/webhook/admission/validator_test.go
@@ -18,233 +18,206 @@ import (
 
 var _ = Describe("validatingHandler", func() {
 	Describe("Handle", func() {
+		It("should return 200 in response when create succeeds", func() {
 
-		When("create succeeds", func() {
-			It("should return allowed in response", func() {
+			handler := createSucceedingValidatingHandler()
 
-				handler := createSucceedingValidatingHandler()
-
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Create,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+				},
 			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
 		})
 
-		When("create fails on decode", func() {
-			It("should return 400 in response", func() {
-				//TODO
-			})
+		It("should return 400 in response when create fails on decode", func() {
+			//TODO
 		})
 
-		When("ValidateCreate returns APIStatus error", func() {
-			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
+		It("should return response built with the Status object when ValidateCreate returns APIStatus error", func() {
 
-				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+			handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
 
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Create,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-
-				apiStatus, ok := expectedError.(apierrs.APIStatus)
-				Expect(ok).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
-				Expect(*response.Result).Should(Equal(apiStatus.Status()))
-
+				},
 			})
+			Expect(response.Allowed).Should(BeFalse())
+
+			apiStatus, ok := expectedError.(apierrs.APIStatus)
+			Expect(ok).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+			Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
 		})
 
-		When("ValidateCreate returns any error", func() {
-			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+		It("should return 403 response when ValidateCreate returns non-APIStatus error", func() {
 
-				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+			handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
 
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Create,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Create,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
-				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
-
+				},
 			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+			Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
 		})
 
-		When("update succeeds", func() {
-			It("should return allowed in response", func() {
+		It("should return 200 in response when update succeeds", func() {
 
-				handler := createSucceedingValidatingHandler()
+			handler := createSucceedingValidatingHandler()
 
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Update,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
-			})
-		})
-
-		When("update fails on decoding new object", func() {
-			It("should return 400 in response", func() {
-				//TODO
-			})
-		})
-
-		When("update fails on decoding old object", func() {
-			It("should return 400 in response", func() {
-				//TODO
-			})
-		})
-
-		When("ValidateUpdate returns APIStatus error", func() {
-			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
-
-				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
-
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Update,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-
-				apiStatus, ok := expectedError.(apierrs.APIStatus)
-				Expect(ok).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
-				Expect(*response.Result).Should(Equal(apiStatus.Status()))
-
+				},
 			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
 		})
 
-		When("ValidateUpdate returns any error", func() {
-			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+		It("should return 400 in response when update fails on decoding new object", func() {
+			//TODO
+		})
 
-				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+		It("should return 400 in response when update fails on decoding old object", func() {
+			//TODO
+		})
 
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Update,
-						Object: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+		It("should return response built with the Status object when ValidateUpdate returns APIStatus error", func() {
+
+			handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
-				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
-
-			})
-		})
-
-		When("delete succeeds", func() {
-			It("should return allowed in response", func() {
-
-				handler := createSucceedingValidatingHandler()
-
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Delete,
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+				},
 			})
+			Expect(response.Allowed).Should(BeFalse())
+
+			apiStatus, ok := expectedError.(apierrs.APIStatus)
+			Expect(ok).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+			Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
 		})
 
-		When("delete fails on decode", func() {
-			It("should return 400 in response", func() {
-				//TODO
-			})
-		})
+		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func() {
 
-		When("ValidateDelete returns APIStatus error", func() {
-			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
+			handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
 
-				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
-
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Delete,
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Update,
+					Object: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-
-				apiStatus, ok := expectedError.(apierrs.APIStatus)
-				Expect(ok).Should(BeTrue())
-				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
-				Expect(*response.Result).Should(Equal(apiStatus.Status()))
-
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
+					},
+				},
 			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+			Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
 		})
 
-		When("ValidateDelete returns any error", func() {
-			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+		It("should return 200 in response when delete succeeds", func() {
 
-				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+			handler := createSucceedingValidatingHandler()
 
-				response := handler.Handle(context.TODO(), Request{
-					AdmissionRequest: v1beta1.AdmissionRequest{
-						Operation: v1beta1.Delete,
-						OldObject: runtime.RawExtension{
-							Raw:    []byte("{}"),
-							Object: handler.validator,
-						},
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
 					},
-				})
-				Expect(response.Allowed).Should(BeFalse())
-				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
-				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
-
+				},
 			})
+			Expect(response.Allowed).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+		})
+
+		It("should return 400 in response when delete fails on decode", func() {
+			//TODO
+		})
+
+		It("should return response built with the Status object when ValidateDelete returns APIStatus error", func() {
+
+			handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeFalse())
+
+			apiStatus, ok := expectedError.(apierrs.APIStatus)
+			Expect(ok).Should(BeTrue())
+			Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+			Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
+		})
+
+		It("should return 403 response when ValidateDelete returns non-APIStatus error", func() {
+
+			handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+
+			response := handler.Handle(context.TODO(), Request{
+				AdmissionRequest: v1beta1.AdmissionRequest{
+					Operation: v1beta1.Delete,
+					OldObject: runtime.RawExtension{
+						Raw:    []byte("{}"),
+						Object: handler.validator,
+					},
+				},
+			})
+			Expect(response.Allowed).Should(BeFalse())
+			Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+			Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
 		})
 	})
 })

--- a/pkg/webhook/admission/validator_test.go
+++ b/pkg/webhook/admission/validator_test.go
@@ -1,0 +1,307 @@
+package admission
+
+import (
+	"context"
+	goerrors "errors"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/api/admission/v1beta1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var _ = FDescribe("validatingHandler", func() {
+	Describe("Handle", func() {
+
+		When("create succeeds", func() {
+			It("should return allowed in response", func() {
+
+				handler := createSucceedingValidatingHandler()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Create,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+			})
+		})
+
+		When("create fails on decode", func() {
+			It("should return 400 in response", func() {
+				//TODO
+			})
+		})
+
+		When("ValidateCreate returns APIStatus error", func() {
+			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Create,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+
+				apiStatus, ok := expectedError.(apierrs.APIStatus)
+				Expect(ok).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+				Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
+			})
+		})
+
+		When("ValidateCreate returns any error", func() {
+			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Create,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
+			})
+		})
+
+		When("update succeeds", func() {
+			It("should return allowed in response", func() {
+
+				handler := createSucceedingValidatingHandler()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Update,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+			})
+		})
+
+		When("update fails on decoding new object", func() {
+			It("should return 400 in response", func() {
+				//TODO
+			})
+		})
+
+		When("update fails on decoding old object", func() {
+			It("should return 400 in response", func() {
+				//TODO
+			})
+		})
+
+		When("ValidateUpdate returns APIStatus error", func() {
+			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Update,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+
+				apiStatus, ok := expectedError.(apierrs.APIStatus)
+				Expect(ok).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+				Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
+			})
+		})
+
+		When("ValidateUpdate returns any error", func() {
+			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Update,
+						Object: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
+			})
+		})
+
+		When("delete succeeds", func() {
+			It("should return allowed in response", func() {
+
+				handler := createSucceedingValidatingHandler()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
+			})
+		})
+
+		When("delete fails on decode", func() {
+			It("should return 400 in response", func() {
+				//TODO
+			})
+		})
+
+		When("ValidateDelete returns APIStatus error", func() {
+			It("should return Status.Code and embed the Status object from APIStatus in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsStatusError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+
+				apiStatus, ok := expectedError.(apierrs.APIStatus)
+				Expect(ok).Should(BeTrue())
+				Expect(response.Result.Code).Should(Equal(apiStatus.Status().Code))
+				Expect(*response.Result).Should(Equal(apiStatus.Status()))
+
+			})
+		})
+
+		When("ValidateDelete returns any error", func() {
+			It("should return 403 and embed the error message in a generated Status object in the response", func() {
+
+				handler, expectedError := createValidatingHandlerWhichReturnsRegularError()
+
+				response := handler.Handle(context.TODO(), Request{
+					AdmissionRequest: v1beta1.AdmissionRequest{
+						Operation: v1beta1.Delete,
+						OldObject: runtime.RawExtension{
+							Raw:    []byte("{}"),
+							Object: handler.validator,
+						},
+					},
+				})
+				Expect(response.Allowed).Should(BeFalse())
+				Expect(response.Result.Code).Should(Equal(int32(http.StatusForbidden)))
+				Expect(string(response.Result.Reason)).Should(Equal(expectedError.Error()))
+
+			})
+		})
+	})
+})
+
+type fakeValidator struct {
+	ErrorToReturn error `json:"ErrorToReturn,omitempty"`
+}
+
+var _ Validator = &fakeValidator{}
+
+var fakeValidatorVK = schema.GroupVersionKind{Group: "foo.test.org", Version: "v1", Kind: "fakeValidator"}
+
+func (v *fakeValidator) ValidateCreate() error {
+	return v.ErrorToReturn
+}
+
+func (v *fakeValidator) ValidateUpdate(old runtime.Object) error {
+	return v.ErrorToReturn
+}
+
+func (v *fakeValidator) ValidateDelete() error {
+	return v.ErrorToReturn
+}
+
+func (v *fakeValidator) GetObjectKind() schema.ObjectKind { return v }
+
+func (v *fakeValidator) DeepCopyObject() runtime.Object {
+	return &fakeValidator{ErrorToReturn: v.ErrorToReturn}
+}
+
+func (v *fakeValidator) GroupVersionKind() schema.GroupVersionKind {
+	return fakeValidatorVK
+}
+
+func (v *fakeValidator) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
+
+func createSucceedingValidatingHandler() *validatingHandler {
+	decoder, _ := NewDecoder(scheme.Scheme)
+	f := &fakeValidator{ErrorToReturn: nil}
+	return &validatingHandler{f, decoder}
+}
+
+func createValidatingHandlerWhichReturnsRegularError() (validatingHandler, error) {
+	decoder, _ := NewDecoder(scheme.Scheme)
+	errToReturn := goerrors.New("some error")
+	f := &fakeValidator{ErrorToReturn: errToReturn}
+	return validatingHandler{f, decoder}, errToReturn
+}
+
+func createValidatingHandlerWhichReturnsStatusError() (validatingHandler, error) {
+	decoder, _ := NewDecoder(scheme.Scheme)
+	errToReturn := &apierrs.StatusError{
+		ErrStatus: v1.Status{
+			Message: "some message",
+			Code:    http.StatusUnprocessableEntity,
+		},
+	}
+	f := &fakeValidator{ErrorToReturn: errToReturn}
+	return validatingHandler{f, decoder}, errToReturn
+}


### PR DESCRIPTION
If a custom webhook validator returns a metav1.Status object as the error, the validation handler will build an admission response with this Status object as is, instead of building a new Status object based on err.Error()

This might be considered as a breaking change since the behaviour of the
validation handler is going to be slightly different from what the users
might expect based on the previous version of the code

<!-- please add a icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
