### PR TITLE
✨  Add godoc example for zap logger usage.

### DIFF
--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -506,3 +506,13 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 	})
 })
+
+// This Example shows usage of command line arguments
+// to pass options for zap logger options.
+func ExampleUseFlagOptions() {
+	opts := Options{}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+	log := New(UseFlagOptions(&opts))
+	log.Info("This is a test message")
+}


### PR DESCRIPTION
Description: Add go doc example for command line usage for Zap logger.