### PR TITLE
:bug: Avoid the redirection to `/healthz/` when calling `/healthz`

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -52,8 +52,8 @@ const (
 	defaultRetryPeriod            = 2 * time.Second
 	defaultGracefulShutdownPeriod = 30 * time.Second
 
-	defaultReadinessEndpoint = "/readyz/"
-	defaultLivenessEndpoint  = "/healthz/"
+	defaultReadinessEndpoint = "/readyz"
+	defaultLivenessEndpoint  = "/healthz"
 	defaultMetricsEndpoint   = "/metrics"
 )
 
@@ -414,9 +414,13 @@ func (cm *controllerManager) serveHealthProbes(stop <-chan struct{}) {
 
 	if cm.readyzHandler != nil {
 		mux.Handle(cm.readinessEndpointName, http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
+		// Append '/' suffix to handle subpaths
+		mux.Handle(cm.readinessEndpointName+"/", http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
 	}
 	if cm.healthzHandler != nil {
 		mux.Handle(cm.livenessEndpointName, http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
+		// Append '/' suffix to handle subpaths
+		mux.Handle(cm.livenessEndpointName+"/", http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
 	}
 
 	server := http.Server{

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"strings"
 	"sync"
 	"time"
 
@@ -970,10 +969,15 @@ var _ = Describe("manger.Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-			// Check readiness path without trailing slash
-			readinessEndpoint = fmt.Sprint("http://", listener.Addr().String(), strings.TrimSuffix(defaultReadinessEndpoint, "/"))
+			// Check readiness path without trailing slash without redirect
+			readinessEndpoint = fmt.Sprint("http://", listener.Addr().String(), defaultReadinessEndpoint)
 			res = nil
-			resp, err = http.Get(readinessEndpoint)
+			httpClient := http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse // Do not follow redirect
+				},
+			}
+			resp, err = httpClient.Get(readinessEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
@@ -1016,10 +1020,15 @@ var _ = Describe("manger.Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-			// Check liveness path without trailing slash
-			livenessEndpoint = fmt.Sprint("http://", listener.Addr().String(), strings.TrimSuffix(defaultLivenessEndpoint, "/"))
+			// Check liveness path without trailing slash without redirect
+			livenessEndpoint = fmt.Sprint("http://", listener.Addr().String(), defaultLivenessEndpoint)
 			res = nil
-			resp, err = http.Get(livenessEndpoint)
+			httpClient := http.Client{
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					return http.ErrUseLastResponse // Do not follow redirect
+				},
+			}
+			resp, err = httpClient.Get(livenessEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 


### PR DESCRIPTION
By https://github.com/kubernetes-sigs/controller-runtime/pull/1100, subpaths of `/healthz/` can be handled.
However, this change introduced the redirection from `/healthz` to `/healthz/` with 301 (Moved Permanently) when accessing `/healthz` endpoint like following. (Accessing `/healthz/` works fine without the redirect.)

```
→ curl -v -L http://localhost:8080/healthz
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /healthz HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 301 Moved Permanently
< Content-Type: text/html; charset=utf-8
< Location: /healthz/
< Date: Sun, 23 Aug 2020 08:41:59 GMT
< Content-Length: 44
<
* Ignoring the response-body
* Connection #0 to host localhost left intact
* Issue another request to this URL: 'http://localhost:8080/healthz/'
* Found bundle for host localhost: 0x7fe067900c00 [can pipeline]
* Re-using existing connection! (#0) with host localhost
* Connected to localhost (::1) port 8080 (#0)
> GET /healthz/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Sun, 23 Aug 2020 08:41:59 GMT
< Content-Length: 2
<
* Connection #0 to host localhost left intact
ok%
```

By this redirect behavior, the current implementation doesn't break anything, but I think that this is unnecessary overhead in the health checking.

So, this PR enables to access `/healthz` without the redirect with keeping that subpaths of `/healthz/` are accessible.

By this PR, `/healthz` endpoint's response becomes like following.

```
→ curl -v -L http://localhost:8080/healthz
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /healthz HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: text/plain; charset=utf-8
< X-Content-Type-Options: nosniff
< Date: Sun, 23 Aug 2020 08:59:45 GMT
< Content-Length: 2
<
* Connection #0 to host localhost left intact
ok%

→ curl -v -L http://localhost:8080/healthz/ping
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8080 (#0)
> GET /healthz/ping HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sun, 23 Aug 2020 09:02:27 GMT
< Content-Length: 2
< Content-Type: text/plain; charset=utf-8
<
* Connection #0 to host localhost left intact
ok%
```