### PR TITLE
:bug: Handle empty contexts in log.FromContext

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -55,15 +55,15 @@ var Log = NewDelegatingLogger(NullLogger{})
 
 // FromContext returns a logger with predefined values from a context.Context.
 func FromContext(ctx context.Context, keysAndValues ...interface{}) logr.Logger {
-	var log logr.Logger
-	if ctx == nil {
-		log = Log
-	} else {
-		lv := ctx.Value(contextKey)
-		log = lv.(logr.Logger)
+	var log logr.Logger = Log
+
+	if ctx != nil {
+		if lv := ctx.Value(contextKey); lv != nil {
+			log = lv.(logr.Logger)
+		}
 	}
-	log.WithValues(keysAndValues...)
-	return log
+
+	return log.WithValues(keysAndValues...)
 }
 
 // IntoContext takes a context and sets the logger as one of its keys.


### PR DESCRIPTION
This fixes a couple of bugs in the `log.FromContext` function:
- If the passed in context doesn't contain a logger, it attempts to cast a nil value as `logr.Logger` -- which causes a panic.
- The `keysAndValues` argument has no effect because the logger returned from the `WithValues` method is ignored in the return value.

Fixes #1140 