### PR TITLE
⚠ Change leaderlock from ConfigMap to ConfigMapsLeasesResourceLock

### DIFF
--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -81,7 +81,7 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 	}
 
 	// TODO(JoelSpeed): switch to leaderelection object in 1.12
-	return resourcelock.New(resourcelock.ConfigMapsResourceLock,
+	return resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
 		options.LeaderElectionNamespace,
 		options.LeaderElectionID,
 		client.CoreV1(),


### PR DESCRIPTION
This commit changes the leaderlock to ConfigMapsLeasesResourceLock,
which is intended to transition ppl from the ConfigMap to the more
modern Leases. It is breaking because additional RBAC is required.

Related issue is https://github.com/kubernetes-sigs/controller-runtime/issues/460

PRing this now because this change is breaking, so must happen before we cut 0.7.0. Adding an option to override the default is non-breaking, so not as important to happen ASAP.

/assign @vincepri 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
