### PR TITLE
:bug: Source.Channel: Cope with pre-existing events in the channel

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -213,12 +213,14 @@ func (cs *Channel) Start(
 		cs.DestBufferSize = defaultBufferSize
 	}
 
+	dst := make(chan event.GenericEvent, cs.DestBufferSize)
+	cs.dest = append(cs.dest, dst)
+
 	cs.once.Do(func() {
 		// Distribute GenericEvents to all EventHandler / Queue pairs Watching this source
 		go cs.syncLoop()
 	})
 
-	dst := make(chan event.GenericEvent, cs.DestBufferSize)
 	go func() {
 		for evt := range dst {
 			shouldHandle := true
@@ -237,8 +239,6 @@ func (cs *Channel) Start(
 
 	cs.destLock.Lock()
 	defer cs.destLock.Unlock()
-
-	cs.dest = append(cs.dest, dst)
 
 	return nil
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/942
