### PR TITLE
✨ Make leader election resourcelock configurable

### DIFF
--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -37,20 +37,30 @@ type Options struct {
 	// starting the manager.
 	LeaderElection bool
 
+	// LeaderElectionResourceLock determines which resource lock to use for leader election,
+	// defaults to "configmapsleases".
+	LeaderElectionResourceLock string
+
 	// LeaderElectionNamespace determines the namespace in which the leader
-	// election configmap will be created.
+	// election resource will be created.
 	LeaderElectionNamespace string
 
-	// LeaderElectionID determines the name of the configmap that leader election
+	// LeaderElectionID determines the name of the resource that leader election
 	// will use for holding the leader lock.
 	LeaderElectionID string
 }
 
-// NewResourceLock creates a new config map resource lock for use in a leader
-// election loop
+// NewResourceLock creates a new resource lock for use in a leader election loop.
 func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, options Options) (resourcelock.Interface, error) {
 	if !options.LeaderElection {
 		return nil, nil
+	}
+
+	// Default resource lock to "configmapsleases". We must keep this default until we are sure all controller-runtime
+	// users have upgraded from the original default ConfigMap lock to a controller-runtime version that has this new
+	// default. Many users of controller-runtime skip versions, so we should be extremely conservative here.
+	if options.LeaderElectionResourceLock == "" {
+		options.LeaderElectionResourceLock = resourcelock.ConfigMapsLeasesResourceLock
 	}
 
 	// LeaderElectionID must be provided to prevent clashes
@@ -80,8 +90,7 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 		return nil, err
 	}
 
-	// TODO(JoelSpeed): switch to leaderelection object in 1.12
-	return resourcelock.New(resourcelock.ConfigMapsLeasesResourceLock,
+	return resourcelock.New(options.LeaderElectionResourceLock,
 		options.LeaderElectionNamespace,
 		options.LeaderElectionID,
 		client.CoreV1(),


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR makes the leader election resource lock configurable via `manager.Options.LeaderElectionResourceLock`.
It can be set to one of the lock types supported by client-go ([ref](https://github.com/kubernetes/client-go/blob/release-1.19/tools/leaderelection/resourcelock/interface.go#L31-L35)):
- `endpoints`
- `configmaps`
- `leases `
- `endpointsleases`
- `configmapsleases`

It keeps the default of `configmapsleases` introduced by #1144, but allows folks to explicitly configure other LE strategies.

Fixes #460

/assign @alvaroaleman 