### PR TITLE
:warning: Use application/vnd.kubernetes.protobuf as content-type if possible

### DIFF
--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -236,7 +236,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		return nil, err
 	}
 
-	client, err := apiutil.RESTClientForGVK(gvk, ip.config, ip.codecs)
+	client, err := apiutil.RESTClientForGVK(gvk, false, ip.config, ip.codecs)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -21,6 +21,7 @@ package apiutil
 
 import (
 	"fmt"
+	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,9 +29,32 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/discovery"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 )
+
+var (
+	protobufScheme     = runtime.NewScheme()
+	protobufSchemeLock sync.RWMutex
+)
+
+func init() {
+	// Currently only enabled for built-in resources which are guaranteed to implement Protocol Buffers.
+	// For custom resources, CRDs can not support Protocol Buffers but Aggregated API can.
+	// See doc: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#advanced-features-and-flexibility
+	if err := clientgoscheme.AddToScheme(protobufScheme); err != nil {
+		panic(err)
+	}
+}
+
+// AddToProtobufScheme add the given SchemeBuilder into protobufScheme, which should
+// be additional types that do support protobuf.
+func AddToProtobufScheme(builder runtime.SchemeBuilder) error {
+	protobufSchemeLock.Lock()
+	defer protobufSchemeLock.Unlock()
+	return builder.AddToScheme(protobufScheme)
+}
 
 // NewDiscoveryRESTMapper constructs a new RESTMapper based on discovery
 // information fetched by a new client with the given config.
@@ -93,8 +117,8 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 // RESTClientForGVK constructs a new rest.Interface capable of accessing the resource associated
 // with the given GroupVersionKind. The REST client will be configured to use the negotiated serializer from
 // baseConfig, if set, otherwise a default serializer will be set.
-func RESTClientForGVK(gvk schema.GroupVersionKind, baseConfig *rest.Config, codecs serializer.CodecFactory) (rest.Interface, error) {
-	cfg := createRestConfig(gvk, baseConfig)
+func RESTClientForGVK(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config, codecs serializer.CodecFactory) (rest.Interface, error) {
+	cfg := createRestConfig(gvk, isUnstructured, baseConfig)
 	if cfg.NegotiatedSerializer == nil {
 		cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
 	}
@@ -102,7 +126,7 @@ func RESTClientForGVK(gvk schema.GroupVersionKind, baseConfig *rest.Config, code
 }
 
 //createRestConfig copies the base config and updates needed fields for a new rest config
-func createRestConfig(gvk schema.GroupVersionKind, baseConfig *rest.Config) *rest.Config {
+func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config) *rest.Config {
 	gv := gvk.GroupVersion()
 
 	cfg := rest.CopyConfig(baseConfig)
@@ -114,6 +138,14 @@ func createRestConfig(gvk schema.GroupVersionKind, baseConfig *rest.Config) *res
 	}
 	if cfg.UserAgent == "" {
 		cfg.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	// TODO(FillZpp): In the long run, we want to check discovery or something to make sure that this is actually true.
+	if cfg.ContentType == "" && !isUnstructured {
+		protobufSchemeLock.RLock()
+		if protobufScheme.Recognizes(gvk) {
+			cfg.ContentType = runtime.ContentTypeProtobuf
+		}
+		protobufSchemeLock.RUnlock()
 	}
 	return cfg
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -72,11 +72,13 @@ func New(config *rest.Config, options Options) (Client, error) {
 	}
 
 	clientcache := &clientCache{
-		config:         config,
-		scheme:         options.Scheme,
-		mapper:         options.Mapper,
-		codecs:         serializer.NewCodecFactory(options.Scheme),
-		resourceByType: make(map[schema.GroupVersionKind]*resourceMeta),
+		config: config,
+		scheme: options.Scheme,
+		mapper: options.Mapper,
+		codecs: serializer.NewCodecFactory(options.Scheme),
+
+		structuredResourceByType:   make(map[schema.GroupVersionKind]*resourceMeta),
+		unstructuredResourceByType: make(map[schema.GroupVersionKind]*resourceMeta),
 	}
 
 	rawMetaClient, err := metadata.NewForConfig(config)

--- a/pkg/client/client_cache.go
+++ b/pkg/client/client_cache.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -43,20 +44,22 @@ type clientCache struct {
 	// codecs are used to create a REST client for a gvk
 	codecs serializer.CodecFactory
 
-	// resourceByType caches type metadata
-	resourceByType map[schema.GroupVersionKind]*resourceMeta
-	mu             sync.RWMutex
+	// structuredResourceByType caches structured type metadata
+	structuredResourceByType map[schema.GroupVersionKind]*resourceMeta
+	// unstructuredResourceByType caches unstructured type metadata
+	unstructuredResourceByType map[schema.GroupVersionKind]*resourceMeta
+	mu                         sync.RWMutex
 }
 
 // newResource maps obj to a Kubernetes Resource and constructs a client for that Resource.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientCache) newResource(gvk schema.GroupVersionKind, isList bool) (*resourceMeta, error) {
+func (c *clientCache) newResource(gvk schema.GroupVersionKind, isList, isUnstructured bool) (*resourceMeta, error) {
 	if strings.HasSuffix(gvk.Kind, "List") && isList {
 		// if this was a list, treat it as a request for the item's resource
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
 
-	client, err := apiutil.RESTClientForGVK(gvk, c.config, c.codecs)
+	client, err := apiutil.RESTClientForGVK(gvk, isUnstructured, c.config, c.codecs)
 	if err != nil {
 		return nil, err
 	}
@@ -75,10 +78,18 @@ func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
 		return nil, err
 	}
 
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+	isUnstructured = isUnstructured || isUnstructuredList
+
 	// It's better to do creation work twice than to not let multiple
 	// people make requests at once
 	c.mu.RLock()
-	r, known := c.resourceByType[gvk]
+	resourceByType := c.structuredResourceByType
+	if isUnstructured {
+		resourceByType = c.unstructuredResourceByType
+	}
+	r, known := resourceByType[gvk]
 	c.mu.RUnlock()
 
 	if known {
@@ -88,11 +99,11 @@ func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
 	// Initialize a new Client
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	r, err = c.newResource(gvk, meta.IsListType(obj))
+	r, err = c.newResource(gvk, meta.IsListType(obj), isUnstructured)
 	if err != nil {
 		return nil, err
 	}
-	c.resourceByType[gvk] = r
+	resourceByType[gvk] = r
 	return r, err
 }
 


### PR DESCRIPTION
Signed-off-by: Siyu Wang <FillZpp.pub@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Use `application/vnd.kubernetes.protobuf` as content-type if it is possible, currently for those native resources defined in client-go.


