### PR TITLE
:running: Allow specifying custom TLS Config for webhooks

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -262,9 +262,22 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDs = crds
 
 	log.V(1).Info("installing webhooks")
-	err = te.WebhookInstallOptions.Install(te.Config)
 
+	if te.WebhookInstallOptions.CustomTLSConfig != nil && te.WebhookInstallOptions.LocalServingCertDir != "" {
+		return nil, fmt.Errorf("Both Custom TLS Config and CertDir is provided in the test configuration")
+	}
+
+	if te.WebhookInstallOptions.CustomTLSConfig != nil {
+		err = te.WebhookInstallOptions.InstallWithCustomTLS(te.Config)
+	} else {
+		err = te.WebhookInstallOptions.Install(te.Config)
+	}
+
+	if err != nil {
+		return nil, err
+	}
 	return te.Config, err
+
 }
 
 func (te *Environment) startControlPlane() error {

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -2,6 +2,7 @@ package envtest
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -93,6 +94,73 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(installOptions.MutatingWebhooks)).To(Equal(2))
 			Expect(len(installOptions.ValidatingWebhooks)).To(Equal(2))
+		})
+	})
+	Describe("Webhook With Custom TLS", func() {
+		It("should reject requests due to bad certificate", func(done Done) {
+			_, err := env.WebhookInstallOptions.setupCA()
+			dir := env.WebhookInstallOptions.LocalServingCertDir
+			certFile := filepath.Join(dir, "tls.crt")
+			keyFile := filepath.Join(dir, "tls.key")
+			Expect(err).NotTo(HaveOccurred())
+			sCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			m, err := manager.New(env.Config, manager.Options{
+				Port: env.WebhookInstallOptions.LocalServingPort,
+				Host: env.WebhookInstallOptions.LocalServingHost,
+				// CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+				WebhookTLSConfig: &tls.Config{
+					NextProtos:   []string{"h2"},
+					Certificates: []tls.Certificate{sCert},
+					ClientAuth:   tls.NoClientCert,
+				},
+			}) // we need manager here just to leverage manager.SetFields
+			Expect(err).NotTo(HaveOccurred())
+			server := m.GetWebhookServer()
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			stopCh := make(chan struct{})
+			go func() {
+				_ = server.Start(stopCh)
+			}()
+
+			c, err := client.New(env.Config, client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			obj := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				// Bad Certificate shows up as InternalError
+				return errors.ReasonForError(err) == metav1.StatusReason("InternalError")
+			}, 1*time.Second).Should(BeTrue())
+
+			close(stopCh)
+			close(done)
 		})
 	})
 })

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -165,6 +166,11 @@ type controllerManager struct {
 	// if not set, webhook server would look up the server key and certificate in
 	// {TempDir}/k8s-webhook-server/serving-certs
 	certDir string
+
+	// WebhookTLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	webhookTLSConfig *tls.Config
 
 	webhookServer *webhook.Server
 
@@ -355,9 +361,10 @@ func (cm *controllerManager) GetAPIReader() client.Reader {
 func (cm *controllerManager) GetWebhookServer() *webhook.Server {
 	if cm.webhookServer == nil {
 		cm.webhookServer = &webhook.Server{
-			Port:    cm.port,
-			Host:    cm.host,
-			CertDir: cm.certDir,
+			Port:      cm.port,
+			Host:      cm.host,
+			CertDir:   cm.certDir,
+			TLSConfig: cm.webhookTLSConfig,
 		}
 		if err := cm.Add(cm.webhookServer); err != nil {
 			panic("unable to add webhookServer to the controller manager")

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -224,6 +225,11 @@ type Options struct {
 	CertDir string
 	// Functions to all for a user to customize the values that will be injected.
 
+	// WebhookTLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	WebhookTLSConfig *tls.Config
+
 	// NewCache is the function that will create the cache to be used
 	// by the manager. If not set this will use the default new cache function.
 	NewCache cache.NewCacheFunc
@@ -391,6 +397,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		port:                    options.Port,
 		host:                    options.Host,
 		certDir:                 options.CertDir,
+		webhookTLSConfig:        options.WebhookTLSConfig,
 		leaseDuration:           *options.LeaseDuration,
 		renewDeadline:           *options.RenewDeadline,
 		retryPeriod:             *options.RetryPeriod,

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -54,6 +54,11 @@ type Server struct {
 	// server key and certificate.
 	CertDir string
 
+	// TLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	TLSConfig *tls.Config
+
 	// CertName is the server certificate name. Defaults to tls.crt.
 	CertName string
 
@@ -169,24 +174,29 @@ func (s *Server) Start(stop <-chan struct{}) error {
 	certPath := filepath.Join(s.CertDir, s.CertName)
 	keyPath := filepath.Join(s.CertDir, s.KeyName)
 
-	certWatcher, err := certwatcher.New(certPath, keyPath)
-	if err != nil {
-		return err
-	}
-
-	go func() {
-		if err := certWatcher.Start(stop); err != nil {
-			log.Error(err, "certificate watcher error")
+	var cfg *tls.Config
+	if s.TLSConfig != nil {
+		cfg = s.TLSConfig
+	} else {
+		certWatcher, err := certwatcher.New(certPath, keyPath)
+		if err != nil {
+			return err
 		}
-	}()
 
-	cfg := &tls.Config{
-		NextProtos:     []string{"h2"},
-		GetCertificate: certWatcher.GetCertificate,
+		go func() {
+			if err := certWatcher.Start(stop); err != nil {
+				log.Error(err, "certificate watcher error")
+			}
+		}()
+
+		cfg = &tls.Config{
+			NextProtos:     []string{"h2"},
+			GetCertificate: certWatcher.GetCertificate,
+		}
 	}
 
 	// load CA to verify client certificate
-	if s.ClientCAName != "" {
+	if s.ClientCAName != "" && s.TLSConfig == nil {
 		certPool := x509.NewCertPool()
 		clientCABytes, err := ioutil.ReadFile(filepath.Join(s.CertDir, s.ClientCAName))
 		if err != nil {


### PR DESCRIPTION
Allow specifying custom TLS Config for webhooks

* This implements a Manager option WebhookTLSConfig which allows for
  specifying a custom TLS configuration when running webhooks using
  controller-runtime
* Added CustomTLSConfig attribute to WebhookInstallOptions
* Added test to show this config overrides the config generated by
  CertDir
* If cert-dir and tls-config are provided, custom tls-config is used

Authored by: Matt Smith (@alastor-erinyes)
Closes: #1135 #852 
Taken from: [PR 853](https://github.com/kubernetes-sigs/controller-runtime/pull/853#) 

c/c @alastor-erinyes

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
