### PR TITLE
:book: Fix typo

### DIFF
--- a/pkg/leaderelection/doc.go
+++ b/pkg/leaderelection/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 /*
-Package leaderelection contains a constructors for a leader election resource lock.
+Package leaderelection contains a constructor for a leader election resource lock.
 This is used to ensure that multiple copies of a controller manager can be run with
 only one active set of controllers, for active-passive HA.
 


### PR DESCRIPTION
Reading the documentation for the leaderelection pkg I got confused whether the package provides one constructor or multiple constructors. Currently, I can only see one constructur, so hopefully the patch makes sense. Otherwise, please correct me and we can fix it in the other direction :-)