### PR TITLE
✨  Allow admission responses to send warnings

### DIFF
--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -107,3 +107,10 @@ func validationResponseFromStatus(allowed bool, status metav1.Status) Response {
 	}
 	return resp
 }
+
+// WithWarnings adds the given warnings to the Response.
+// If any warnings were already given, they will not be overwritten.
+func (r Response) WithWarnings(warnings ...string) Response {
+	r.AdmissionResponse.Warnings = append(r.AdmissionResponse.Warnings, warnings...)
+	return r
+}

--- a/pkg/webhook/admission/response_test.go
+++ b/pkg/webhook/admission/response_test.go
@@ -216,4 +216,30 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			Expect(resp).To(Equal(expected))
 		})
 	})
+
+	Describe("WithWarnings", func() {
+		It("should add the warnings to the existing response without removing any existing warnings", func() {
+			initialResponse := Response{
+				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+					Warnings: []string{"existing-warning"},
+				},
+			}
+			warnings := []string{"additional-warning-1", "additional-warning-2"}
+			expectedResponse := Response{
+				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Code: http.StatusOK,
+					},
+					Warnings: []string{"existing-warning", "additional-warning-1", "additional-warning-2"},
+				},
+			}
+
+			Expect(initialResponse.WithWarnings(warnings...)).To(Equal(expectedResponse))
+		})
+	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

[Warnings](https://kubernetes.io/blog/2020/09/03/warnings/#admission-webhooks) have been introduced with K8s 1.19. This allows people who are running webhooks to send a warning message if there is something wrong with a resource (eg not following best practice) that is not a fatal error.

This PR adds a `WithWarnings` helper function that allows you to extend a response with warnings in an easy way. For example: 

```
return admission.Allowed("Resource OK").WithWarnings([]string{"Something wasn't quite right"})
```

Not sure if this is a majorly required helper since people could easily write one themselves, though I thought it could be a useful helper and it only took five minutes to prep, so thought I'd raise the code for discussion, let me know what y'all think.