### PR TITLE
:sparkles: metadata-only watches

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,6 @@ linters:
   - unparam
   - ineffassign
   - nakedret
-  - interfacer
   - gocyclo
   - lll
   - dupl

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -76,3 +76,36 @@ var _ OwnsOption = &Predicates{}
 var _ WatchesOption = &Predicates{}
 
 // }}}
+
+// {{{ For & Owns Dual-Type options
+
+// asProjection configures the projection (currently only metadata) on the input.
+// Currently only metadata is supported.  We might want to expand
+// this to arbitrary non-special local projections in the future.
+type projectAs objectProjection
+
+// ApplyToFor applies this configuration to the given ForInput options.
+func (p projectAs) ApplyToFor(opts *ForInput) {
+	opts.objectProjection = objectProjection(p)
+}
+
+// ApplyToOwns applies this configuration to the given OwnsInput options.
+func (p projectAs) ApplyToOwns(opts *OwnsInput) {
+	opts.objectProjection = objectProjection(p)
+}
+
+var (
+	// OnlyMetadata tells the controller to *only* cache metadata, and to watch
+	// the the API server in metadata-only form.  This is useful when watching
+	// lots of objects, really big objects, or objects for which you only know
+	// the the GVK, but not the structure.  You'll need to pass
+	// metav1.PartialObjectMetadata to the client when fetching objects in your
+	// reconciler, otherwise you'll end up with a duplicate structured or
+	// unstructured cache.
+	OnlyMetadata = projectAs(projectAsMetadata)
+
+	_ ForOption  = OnlyMetadata
+	_ OwnsOption = OnlyMetadata
+)
+
+// }}}

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,10 +32,12 @@ import (
 // InformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
 // It uses a standard parameter codec constructed based on the given generated Scheme.
 type InformersMap struct {
-	// we abstract over the details of structured vs unstructured with the specificInformerMaps
+	// we abstract over the details of structured/unstructured/metadata with the specificInformerMaps
+	// TODO(directxman12): genericize this over different projections now that we have 3 different maps
 
 	structured   *specificInformersMap
 	unstructured *specificInformersMap
+	metadata     *specificInformersMap
 
 	// Scheme maps runtime.Objects to GroupVersionKinds
 	Scheme *runtime.Scheme
@@ -51,6 +54,7 @@ func NewInformersMap(config *rest.Config,
 	return &InformersMap{
 		structured:   newStructuredInformersMap(config, scheme, mapper, resync, namespace),
 		unstructured: newUnstructuredInformersMap(config, scheme, mapper, resync, namespace),
+		metadata:     newMetadataInformersMap(config, scheme, mapper, resync, namespace),
 
 		Scheme: scheme,
 	}
@@ -60,6 +64,7 @@ func NewInformersMap(config *rest.Config,
 func (m *InformersMap) Start(ctx context.Context) error {
 	go m.structured.Start(ctx)
 	go m.unstructured.Start(ctx)
+	go m.metadata.Start(ctx)
 	<-ctx.Done()
 	return nil
 }
@@ -75,21 +80,27 @@ func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 	if !m.unstructured.waitForStarted(ctx) {
 		return false
 	}
+	if !m.metadata.waitForStarted(ctx) {
+		return false
+	}
 	return cache.WaitForCacheSync(ctx.Done(), syncedFuncs...)
 }
 
 // Get will create a new Informer and add it to the map of InformersMap if none exists.  Returns
 // the Informer from the map.
 func (m *InformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
-	_, isUnstructured := obj.(*unstructured.Unstructured)
-	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
-	isUnstructured = isUnstructured || isUnstructuredList
-
-	if isUnstructured {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return m.unstructured.Get(ctx, gvk, obj)
+	case *unstructured.UnstructuredList:
+		return m.unstructured.Get(ctx, gvk, obj)
+	case *metav1.PartialObjectMetadata:
+		return m.metadata.Get(ctx, gvk, obj)
+	case *metav1.PartialObjectMetadataList:
+		return m.metadata.Get(ctx, gvk, obj)
+	default:
+		return m.structured.Get(ctx, gvk, obj)
 	}
-
-	return m.structured.Get(ctx, gvk, obj)
 }
 
 // newStructuredInformersMap creates a new InformersMap for structured objects.
@@ -100,4 +111,9 @@ func newStructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapp
 // newUnstructuredInformersMap creates a new InformersMap for unstructured objects.
 func newUnstructuredInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
 	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createUnstructuredListWatch)
+}
+
+// newMetadataInformersMap creates a new InformersMap for metadata-only objects.
+func newMetadataInformersMap(config *rest.Config, scheme *runtime.Scheme, mapper meta.RESTMapper, resync time.Duration, namespace string) *specificInformersMap {
+	return newSpecificInformersMap(config, scheme, mapper, resync, namespace, createMetadataListWatch)
 }

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -48,6 +49,27 @@ func NewDiscoveryRESTMapper(c *rest.Config) (meta.RESTMapper, error) {
 
 // GVKForObject finds the GroupVersionKind associated with the given object, if there is only a single such GVK.
 func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
+	// TODO(directxman12): do we want to generalize this to arbitrary container types?
+	// I think we'd need a generalized form of scheme or something.  It's a
+	// shame there's not a reliable "GetGVK" interface that works by default
+	// for unpopulated static types and populated "dynamic" types
+	// (unstructured, partial, etc)
+
+	// check for PartialObjectMetadata, which is analogous to unstructured, but isn't handled by ObjectKinds
+	_, isPartial := obj.(*metav1.PartialObjectMetadata)
+	_, isPartialList := obj.(*metav1.PartialObjectMetadataList)
+	if isPartial || isPartialList {
+		// we require that the GVK be populated in order to recognize the object
+		gvk := obj.GetObjectKind().GroupVersionKind()
+		if len(gvk.Kind) == 0 {
+			return schema.GroupVersionKind{}, runtime.NewMissingKindErr("unstructured object has no kind")
+		}
+		if len(gvk.Version) == 0 {
+			return schema.GroupVersionKind{}, runtime.NewMissingVersionErr("unstructured object has no version")
+		}
+		return gvk, nil
+	}
+
 	gvks, isUnversioned, err := scheme.ObjectKinds(obj)
 	if err != nil {
 		return schema.GroupVersionKind{}, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -21,12 +21,15 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -76,6 +79,11 @@ func New(config *rest.Config, options Options) (Client, error) {
 		resourceByType: make(map[schema.GroupVersionKind]*resourceMeta),
 	}
 
+	rawMetaClient, err := metadata.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("unable to construct metadata-only client for use as part of client: %w", err)
+	}
+
 	c := &client{
 		typedClient: typedClient{
 			cache:      clientcache,
@@ -84,6 +92,10 @@ func New(config *rest.Config, options Options) (Client, error) {
 		unstructuredClient: unstructuredClient{
 			cache:      clientcache,
 			paramCodec: noConversionParamCodec{},
+		},
+		metadataClient: metadataClient{
+			client:     rawMetaClient,
+			restMapper: options.Mapper,
 		},
 		scheme: options.Scheme,
 		mapper: options.Mapper,
@@ -99,6 +111,7 @@ var _ Client = &client{}
 type client struct {
 	typedClient        typedClient
 	unstructuredClient unstructuredClient
+	metadataClient     metadataClient
 	scheme             *runtime.Scheme
 	mapper             meta.RESTMapper
 }
@@ -125,67 +138,88 @@ func (c *client) RESTMapper() meta.RESTMapper {
 
 // Create implements client.Client
 func (c *client) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.Create(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot create using only metadata")
+	default:
+		return c.typedClient.Create(ctx, obj, opts...)
 	}
-	return c.typedClient.Create(ctx, obj, opts...)
 }
 
 // Update implements client.Client
 func (c *client) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
 	defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.Update(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update using only metadata -- did you mean to patch?")
+	default:
+		return c.typedClient.Update(ctx, obj, opts...)
 	}
-	return c.typedClient.Update(ctx, obj, opts...)
 }
 
 // Delete implements client.Client
 func (c *client) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.Delete(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.Delete(ctx, obj, opts...)
+	default:
+		return c.typedClient.Delete(ctx, obj, opts...)
 	}
-	return c.typedClient.Delete(ctx, obj, opts...)
 }
 
 // DeleteAllOf implements client.Client
 func (c *client) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.DeleteAllOf(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.DeleteAllOf(ctx, obj, opts...)
+	default:
+		return c.typedClient.DeleteAllOf(ctx, obj, opts...)
 	}
-	return c.typedClient.DeleteAllOf(ctx, obj, opts...)
 }
 
 // Patch implements client.Client
 func (c *client) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
 	defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.Patch(ctx, obj, patch, opts...)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.Patch(ctx, obj, patch, opts...)
+	default:
+		return c.typedClient.Patch(ctx, obj, patch, opts...)
 	}
-	return c.typedClient.Patch(ctx, obj, patch, opts...)
 }
 
 // Get implements client.Client
 func (c *client) Get(ctx context.Context, key ObjectKey, obj Object) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.Get(ctx, key, obj)
+	case *metav1.PartialObjectMetadata:
+		return c.metadataClient.Get(ctx, key, obj)
+	default:
+		return c.typedClient.Get(ctx, key, obj)
 	}
-	return c.typedClient.Get(ctx, key, obj)
 }
 
 // List implements client.Client
 func (c *client) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
-	_, ok := obj.(*unstructured.UnstructuredList)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return c.unstructuredClient.List(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadataList:
+		return c.metadataClient.List(ctx, obj, opts...)
+	default:
+		return c.typedClient.List(ctx, obj, opts...)
 	}
-	return c.typedClient.List(ctx, obj, opts...)
 }
 
 // Status implements client.StatusClient
@@ -204,19 +238,25 @@ var _ StatusWriter = &statusWriter{}
 // Update implements client.StatusWriter
 func (sw *statusWriter) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
 	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return sw.client.unstructuredClient.UpdateStatus(ctx, obj, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
+	default:
+		return sw.client.typedClient.UpdateStatus(ctx, obj, opts...)
 	}
-	return sw.client.typedClient.UpdateStatus(ctx, obj, opts...)
 }
 
 // Patch implements client.Client
 func (sw *statusWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
 	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
-	_, ok := obj.(*unstructured.Unstructured)
-	if ok {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
 		return sw.client.unstructuredClient.PatchStatus(ctx, obj, patch, opts...)
+	case *metav1.PartialObjectMetadata:
+		return sw.client.metadataClient.PatchStatus(ctx, obj, patch, opts...)
+	default:
+		return sw.client.typedClient.PatchStatus(ctx, obj, patch, opts...)
 	}
-	return sw.client.typedClient.PatchStatus(ctx, obj, patch, opts...)
 }

--- a/pkg/client/metadata_client.go
+++ b/pkg/client/metadata_client.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
+)
+
+// TODO(directxman12): we could rewrite this on top of the low-level REST
+// client to avoid the extra shallow copy at the end, but I'm not sure it's
+// worth it -- the metadata client deals with falling back to loading the whole
+// object on older API servers, etc, and we'd have to reproduce that.
+
+// metadataClient is a client that reads & writes metadata-only requests to/from the API server.
+type metadataClient struct {
+	client     metadata.Interface
+	restMapper meta.RESTMapper
+}
+
+func (mc *metadataClient) getResourceInterface(gvk schema.GroupVersionKind, ns string) (metadata.ResourceInterface, error) {
+	mapping, err := mc.restMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return nil, err
+	}
+	if mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		return mc.client.Resource(mapping.Resource), nil
+	}
+	return mc.client.Resource(mapping.Resource).Namespace(ns), nil
+}
+
+// Delete implements client.Client
+func (mc *metadataClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	resInt, err := mc.getResourceInterface(metadata.GroupVersionKind(), metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	deleteOpts := DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	return resInt.Delete(ctx, metadata.Name, *deleteOpts.AsDeleteOptions())
+}
+
+// DeleteAllOf implements client.Client
+func (mc *metadataClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	deleteAllOfOpts := DeleteAllOfOptions{}
+	deleteAllOfOpts.ApplyOptions(opts)
+
+	resInt, err := mc.getResourceInterface(metadata.GroupVersionKind(), deleteAllOfOpts.ListOptions.Namespace)
+	if err != nil {
+		return err
+	}
+
+	return resInt.DeleteCollection(ctx, *deleteAllOfOpts.AsDeleteOptions(), *deleteAllOfOpts.AsListOptions())
+}
+
+// Patch implements client.Client
+func (mc *metadataClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	resInt, err := mc.getResourceInterface(gvk, metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &PatchOptions{}
+	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions())
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+// Get implements client.Client
+func (mc *metadataClient) Get(ctx context.Context, key ObjectKey, obj Object) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+
+	resInt, err := mc.getResourceInterface(gvk, key.Namespace)
+	if err != nil {
+		return err
+	}
+
+	res, err := resInt.Get(ctx, key.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+// List implements client.Client
+func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadataList)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	if strings.HasSuffix(gvk.Kind, "List") {
+		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	}
+
+	listOpts := ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	resInt, err := mc.getResourceInterface(gvk, listOpts.Namespace)
+	if err != nil {
+		return err
+	}
+
+	res, err := resInt.List(ctx, *listOpts.AsListOptions())
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}
+
+func (mc *metadataClient) PatchStatus(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	metadata, ok := obj.(*metav1.PartialObjectMetadata)
+	if !ok {
+		return fmt.Errorf("metadata client did not understand object: %T", obj)
+	}
+
+	gvk := metadata.GroupVersionKind()
+	resInt, err := mc.getResourceInterface(gvk, metadata.Namespace)
+	if err != nil {
+		return err
+	}
+
+	data, err := patch.Data(obj)
+	if err != nil {
+		return err
+	}
+
+	patchOpts := &PatchOptions{}
+	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions(), "status")
+	if err != nil {
+		return err
+	}
+	*metadata = *res
+	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	return nil
+}


### PR DESCRIPTION
This introduces metadata-only support (PartialObjectMetadata) to the client, cache, and controller builder.  It works much like unstructured does, with an end-use of:

```go
.Owns(&corev1.Pod{}, builder.OnlyMetadata)
// or
.Owns(&metav1.PartialObjectMetadata{/* GVK for corev1.Pod filled out here */})

// ...

var pods metav1.PartialObjectMetadataList
pods.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("PodList"))
cl.List(ctx, &pods, client.MatchingLabels{...})
```

Note that like unstructured, the caches are *completely* separate -- asking for an unstructured object or concrete object will end up constructing a separate cache.

Fixes #1159 