### PR TITLE
[WIP] :warning: filtered cache prototype

### DIFF
--- a/pkg/cache/internal/filtered_informer.go
+++ b/pkg/cache/internal/filtered_informer.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"reflect"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ Informer = filteredInformers{}
+
+type filteredInformers []filteredInformer
+
+type filteredInformer struct {
+	informer cache.SharedIndexInformer
+	filter   listWatchFilter
+}
+
+func (fis filteredInformers) AddEventHandler(handler cache.ResourceEventHandler) {
+	for _, fi := range fis {
+		fi.informer.AddEventHandler(handler)
+	}
+}
+
+func (fis filteredInformers) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	for _, fi := range fis {
+		fi.informer.AddEventHandlerWithResyncPeriod(handler, resyncPeriod)
+	}
+}
+
+func (fis filteredInformers) AddIndexers(indexers cache.Indexers) error {
+	for _, fi := range fis {
+		if err := fi.informer.AddIndexers(indexers); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fis filteredInformers) HasSynced() bool {
+	for _, fi := range fis {
+		if !fi.informer.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+type listWatchFilter struct {
+	*client.ListOptions
+}
+
+func newListWatchFilter(opts []client.ListOption) (f listWatchFilter) {
+	f.ListOptions = &client.ListOptions{}
+	f.ApplyOptions(opts)
+	return f
+}
+
+func (f listWatchFilter) toListOptionsModifier() listOptionsModifier {
+	return func(opts *metav1.ListOptions) {
+		if f.ListOptions == nil {
+			return
+		}
+		if f.LabelSelector != nil {
+			opts.LabelSelector = f.LabelSelector.String()
+		}
+		if f.FieldSelector != nil {
+			opts.FieldSelector = f.FieldSelector.String()
+		}
+		// TODO(estroz): I don't think it is necessary to support limit or continue here.
+		// if !opts.Watch {
+		// 	opts.Limit = f.Limit
+		// 	opts.Continue = f.Continue
+		// }
+	}
+}
+
+func (f listWatchFilter) isEmpty() bool {
+	return f.LabelSelector == nil && f.FieldSelector == nil
+}
+
+func (f listWatchFilter) equals(m listWatchFilter) bool {
+	return reflect.DeepEqual(f, m)
+}

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -34,14 +34,17 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // clientListWatcherFunc knows how to create a ListWatcher
-type createListWatcherFunc func(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error)
+type createListWatcherFunc func(schema.GroupVersionKind, *specificInformersMap, listOptionsModifier) (*cache.ListWatch, error)
+
+type listOptionsModifier func(*metav1.ListOptions)
 
 // newSpecificInformersMap returns a new specificInformersMap (like
-// the generical InformersMap, except that it doesn't implement WaitForCacheSync).
+// the generic InformersMap, except that it doesn't implement WaitForCacheSync).
 func newSpecificInformersMap(config *rest.Config,
 	scheme *runtime.Scheme,
 	mapper meta.RESTMapper,
@@ -52,7 +55,7 @@ func newSpecificInformersMap(config *rest.Config,
 		config:            config,
 		Scheme:            scheme,
 		mapper:            mapper,
-		informersByGVK:    make(map[schema.GroupVersionKind]*MapEntry),
+		informersByGVK:    make(map[schema.GroupVersionKind]MappedInformer),
 		codecs:            serializer.NewCodecFactory(scheme),
 		paramCodec:        runtime.NewParameterCodec(scheme),
 		resync:            resync,
@@ -63,13 +66,125 @@ func newSpecificInformersMap(config *rest.Config,
 	return ip
 }
 
-// MapEntry contains the cached data for an Informer
-type MapEntry struct {
-	// Informer is the cached informer
-	Informer cache.SharedIndexInformer
+// MappedInformer is used internal for holding an InformerReader or InformerReaderPool.
+type MappedInformer interface {
+	Run(<-chan struct{})
+	HasSynced() bool
+}
 
-	// CacheReader wraps Informer and implements the CacheReader interface for a single type
-	Reader CacheReader
+// InformerReader can return both an Informer and CacheReader.
+type InformerReader interface {
+	GetInformer() Informer
+	GetReader() *CacheReader
+}
+
+// InformerReaderPool contains a set of InformerReaders indexed by an owner name string, typically that
+// of a controller. Filtered informers use this interface to identify which controller has established
+// an Informer.
+type InformerReaderPool interface {
+	Add(string, schema.GroupVersionKind, cache.SharedIndexInformer, listWatchFilter) InformerReader
+	Get(string) (InformerReader, bool)
+	HasFilter(string, listWatchFilter) bool
+}
+
+var _ MappedInformer = &globalInformerReader{}
+var _ InformerReader = &globalInformerReader{}
+
+type globalInformerReader struct {
+	// Reader wraps Informer and implements the client.Reader interface for a single type.
+	reader   *CacheReader
+	informer cache.SharedIndexInformer
+}
+
+func newGlobalInformerReader(gvk schema.GroupVersionKind, i cache.SharedIndexInformer) globalInformerReader {
+	return globalInformerReader{
+		reader: &CacheReader{
+			groupVersionKind: gvk,
+			indexers:         []cache.Indexer{i.GetIndexer()},
+		},
+		informer: i,
+	}
+}
+
+func (ir globalInformerReader) Run(stop <-chan struct{}) { ir.informer.Run(stop) }
+func (ir globalInformerReader) HasSynced() bool          { return ir.informer.HasSynced() }
+func (ir globalInformerReader) GetInformer() Informer    { return ir.informer }
+func (ir globalInformerReader) GetReader() *CacheReader  { return ir.reader }
+
+var _ MappedInformer = &informerReaderPool{}
+var _ InformerReaderPool = &informerReaderPool{}
+
+type informerReaderPool map[string]filteredInformerReader
+
+func (p informerReaderPool) Run(stop <-chan struct{}) {
+	for _, ir := range p {
+		for _, i := range ir.informers {
+			go i.informer.Run(stop)
+		}
+	}
+}
+
+func (p informerReaderPool) HasSynced() bool {
+	for _, ir := range p {
+		if !ir.informers.HasSynced() {
+			return false
+		}
+	}
+	return true
+}
+
+func (p informerReaderPool) Add(ownerName string, gvk schema.GroupVersionKind, i cache.SharedIndexInformer,
+	filter listWatchFilter) InformerReader {
+
+	e, ok := p[ownerName]
+	if ok {
+		for _, fi := range e.informers {
+			if fi.filter.equals(filter) {
+				return e
+			}
+		}
+	}
+	e.groupVersionKind = gvk
+	e.informers = append(e.informers, filteredInformer{informer: i, filter: filter})
+	return e
+}
+
+func (p informerReaderPool) Get(ownerName string) (InformerReader, bool) {
+	ir, ok := p[ownerName]
+	return ir, ok
+}
+
+func (p informerReaderPool) HasFilter(ownerName string, filter listWatchFilter) bool {
+	if ir, ok := p[ownerName]; ok {
+		for _, i := range ir.informers {
+			if filter.equals(i.filter) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+var _ InformerReader = &filteredInformerReader{}
+
+type filteredInformerReader struct {
+	groupVersionKind schema.GroupVersionKind
+	informers        filteredInformers
+}
+
+func (ir filteredInformerReader) GetInformer() Informer { return ir.informers }
+func (ir filteredInformerReader) GetReader() *CacheReader {
+	r := &CacheReader{
+		groupVersionKind: ir.groupVersionKind,
+		indexers:         make([]cache.Indexer, len(ir.informers)),
+	}
+	// TODO(estroz) r.indexers is populated each time this method is called so only current informer's indexers
+	// are added, which is inefficient. A better way should be found to handle adding/removing an indexer
+	// when its informer is added/removed from the filteredInformerReader.
+	for idx, i := range ir.informers {
+		r.indexers[idx] = i.informer.GetIndexer()
+	}
+	return r
 }
 
 // specificInformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
@@ -85,7 +200,7 @@ type specificInformersMap struct {
 	mapper meta.RESTMapper
 
 	// informersByGVK is the cache of informers keyed by groupVersionKind
-	informersByGVK map[schema.GroupVersionKind]*MapEntry
+	informersByGVK map[schema.GroupVersionKind]MappedInformer
 
 	// codecs is used to create a new REST client
 	codecs serializer.CodecFactory
@@ -132,8 +247,8 @@ func (ip *specificInformersMap) Start(stop <-chan struct{}) {
 		ip.stop = stop
 
 		// Start each informer
-		for _, informer := range ip.informersByGVK {
-			go informer.Informer.Run(stop)
+		for _, mi := range ip.informersByGVK {
+			go mi.Run(stop)
 		}
 
 		// Set started to true so we immediately start any informers added later.
@@ -157,77 +272,133 @@ func (ip *specificInformersMap) HasSyncedFuncs() []cache.InformerSynced {
 	ip.mu.RLock()
 	defer ip.mu.RUnlock()
 	syncedFuncs := make([]cache.InformerSynced, 0, len(ip.informersByGVK))
-	for _, informer := range ip.informersByGVK {
-		syncedFuncs = append(syncedFuncs, informer.Informer.HasSynced)
+	for _, mi := range ip.informersByGVK {
+		syncedFuncs = append(syncedFuncs, mi.HasSynced)
 	}
 	return syncedFuncs
 }
 
 // Get will create a new Informer and add it to the map of specificInformersMap if none exists.  Returns
 // the Informer from the map.
-func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *MapEntry, error) {
+func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object,
+	listOpts ...client.ListOption) (InformerReader, bool, error) {
+
+	// Extract owner context from ctx.
+	ownerName := ""
+	if ownerNameVal := ctx.Value(InformerOwnerNameKey{}); ownerNameVal != nil {
+		ownerName = ownerNameVal.(string)
+	}
+
+	// TODO(estroz): remove client.InNamespace list option.
+	filter := newListWatchFilter(listOpts)
+
 	// Return the informer if it is found
-	i, started, ok := func() (*MapEntry, bool, bool) {
+	ir, started, ok := func() (InformerReader, bool, bool) {
 		ip.mu.RLock()
 		defer ip.mu.RUnlock()
-		i, ok := ip.informersByGVK[gvk]
-		return i, ip.started, ok
+		mi, ok := ip.informersByGVK[gvk]
+		if ok {
+			switch t := mi.(type) {
+			case InformerReader:
+				return t, ip.started, ok
+			case InformerReaderPool:
+				if t.HasFilter(ownerName, filter) {
+					ir, hasIR := t.Get(ownerName)
+					return ir, ip.started, hasIR
+				}
+			default:
+				panic(fmt.Sprintf("type %T is not permitted in informer map", t))
+			}
+		}
+
+		return nil, ip.started, false
 	}()
 
 	if !ok {
 		var err error
-		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {
-			return started, nil, err
+		if ir, started, err = ip.addInformerToMap(ownerName, gvk, obj, filter); err != nil {
+			return nil, started, err
 		}
 	}
 
-	if started && !i.Informer.HasSynced() {
+	if started && !ir.GetInformer().HasSynced() {
 		// Wait for it to sync before returning the Informer so that folks don't read from a stale cache.
-		if !cache.WaitForCacheSync(ctx.Done(), i.Informer.HasSynced) {
-			return started, nil, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for %T Informer to sync", obj), 0)
+		if !cache.WaitForCacheSync(ctx.Done(), ir.GetInformer().HasSynced) {
+			return nil, started, apierrors.NewTimeoutError(fmt.Sprintf("failed waiting for %T Informer to sync", obj), 0)
 		}
 	}
 
-	return started, i, nil
+	return ir, started, nil
 }
 
-func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object) (*MapEntry, bool, error) {
+func (ip *specificInformersMap) addInformerToMap(ownerName string, gvk schema.GroupVersionKind, obj runtime.Object,
+	filter listWatchFilter) (InformerReader, bool, error) {
+
 	ip.mu.Lock()
 	defer ip.mu.Unlock()
 
-	// Check the cache to see if we already have an Informer.  If we do, return the Informer.
+	// Check the cache to see if we already have an Informer. If we do, return the Informer.
 	// This is for the case where 2 routines tried to get the informer when it wasn't in the map
 	// so neither returned early, but the first one created it.
-	if i, ok := ip.informersByGVK[gvk]; ok {
-		return i, ip.started, nil
+	mi, ok := ip.informersByGVK[gvk]
+	if ok {
+		switch t := mi.(type) {
+		case InformerReader:
+			return t, ip.started, nil
+		case InformerReaderPool:
+			if ir, hasIR := t.Get(ownerName); hasIR && t.HasFilter(ownerName, filter) {
+				return ir, ip.started, nil
+			}
+			i, err := ip.newSharedIndexInformer(gvk, obj, filter)
+			if err != nil {
+				return nil, false, err
+			}
+			ir := t.Add(ownerName, gvk, i, filter)
+			return ir, ip.started, nil
+		default:
+			panic(fmt.Sprintf("type %T is not permitted in informer map", t))
+		}
 	}
 
 	// Create a NewSharedIndexInformer and add it to the map.
-	var lw *cache.ListWatch
-	lw, err := ip.createListWatcher(gvk, ip)
+	i, err := ip.newSharedIndexInformer(gvk, obj, filter)
 	if err != nil {
 		return nil, false, err
 	}
-	ni := cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
-		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
-	})
-	i := &MapEntry{
-		Informer: ni,
-		Reader:   CacheReader{indexer: ni.GetIndexer(), groupVersionKind: gvk},
+
+	// TODO(estroz): either return an error or stop all filtered informers if a global informer is being added
+	// and filtered informers already exist.
+	var ir InformerReader
+	if ownerName == "" || filter.isEmpty() {
+		mi = newGlobalInformerReader(gvk, i)
+		ir = mi.(InformerReader)
+	} else {
+		mi = make(informerReaderPool)
+		ir = mi.(informerReaderPool).Add(ownerName, gvk, i, filter)
 	}
-	ip.informersByGVK[gvk] = i
+	ip.informersByGVK[gvk] = mi
 
 	// Start the Informer if need by
 	// TODO(seans): write thorough tests and document what happens here - can you add indexers?
 	// can you add eventhandlers?
 	if ip.started {
-		go i.Informer.Run(ip.stop)
+		go mi.Run(ip.stop)
 	}
-	return i, ip.started, nil
+	return ir, ip.started, nil
+}
+
+func (ip *specificInformersMap) newSharedIndexInformer(gvk schema.GroupVersionKind, obj runtime.Object, filter listWatchFilter) (cache.SharedIndexInformer, error) {
+	lw, err := ip.createListWatcher(gvk, ip, filter.toListOptionsModifier())
+	if err != nil {
+		return nil, err
+	}
+	return cache.NewSharedIndexInformer(lw, obj, resyncPeriod(ip.resync)(), cache.Indexers{
+		cache.NamespaceIndex: cache.MetaNamespaceIndexFunc,
+	}), nil
 }
 
 // newListWatch returns a new ListWatch object that can be used to create a SharedIndexInformer.
-func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap, optionsModifier listOptionsModifier) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
 	// groupVersionKind to the Resource API we will use.
 	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -251,6 +422,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			optionsModifier(&opts)
 			res := listObj.DeepCopyObject()
 			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
 			err := client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
@@ -258,6 +430,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		},
 		// Setup the watch function
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			optionsModifier(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
@@ -266,7 +439,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 	}, nil
 }
 
-func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap, optionsModifier listOptionsModifier) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
 	// groupVersionKind to the Resource API we will use.
 	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -284,6 +457,7 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
+			optionsModifier(&opts)
 			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
 				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
 			}
@@ -291,6 +465,7 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 		},
 		// Setup the watch function
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
+			optionsModifier(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
 			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -129,7 +129,7 @@ var _ = Describe("controller", func() {
 			pr2 := &predicate.Funcs{}
 			evthdl := &handler.EnqueueRequestForObject{}
 			started := false
-			src := source.Func(func(e handler.EventHandler, q workqueue.RateLimitingInterface, p ...predicate.Predicate) error {
+			src := source.Func(func(ctx context.Context, e handler.EventHandler, q workqueue.RateLimitingInterface, p ...predicate.Predicate) error {
 				defer GinkgoRecover()
 				Expect(e).To(Equal(evthdl))
 				Expect(q).To(Equal(ctrl.Queue))
@@ -149,7 +149,8 @@ var _ = Describe("controller", func() {
 
 		It("should return an error if there is an error starting sources", func() {
 			err := fmt.Errorf("Expected Error: could not start source")
-			src := source.Func(func(handler.EventHandler,
+			src := source.Func(func(context.Context,
+				handler.EventHandler,
 				workqueue.RateLimitingInterface,
 				...predicate.Predicate) error {
 				defer GinkgoRecover()

--- a/pkg/source/example_test.go
+++ b/pkg/source/example_test.go
@@ -18,6 +18,7 @@ package source_test
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -26,10 +27,11 @@ import (
 
 var ctrl controller.Controller
 
-// This example Watches for Pod Events (e.g. Create / Update / Delete) and enqueues a reconcile.Request
-// with the Name and Namespace of the Pod.
+// This example Watches for Events (e.g. Create / Update / Delete) on Pods with label "foo=bar"
+// and enqueues a reconcile.Request with the Name and Namespace of the Pod.
 func ExampleKind() {
-	err := ctrl.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{})
+	opts := []client.ListOption{client.MatchingLabels{"foo": "bar"}}
+	err := ctrl.Watch(&source.Kind{Type: &corev1.Pod{}, Filters: opts}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		// handle it
 	}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
@@ -54,7 +55,7 @@ const (
 type Source interface {
 	// Start is internal and should be called only by the Controller to register an EventHandler with the Informer
 	// to enqueue reconcile.Requests.
-	Start(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
+	Start(context.Context, handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 }
 
 // SyncingSource is a source that needs syncing prior to being usable. The controller
@@ -67,17 +68,20 @@ type SyncingSource interface {
 // NewKindWithCache creates a Source without InjectCache, so that it is assured that the given cache is used
 // and not overwritten. It can be used to watch objects in a different cluster by passing the cache
 // from that other cluster
-func NewKindWithCache(object runtime.Object, cache cache.Cache) SyncingSource {
-	return &kindWithCache{kind: Kind{Type: object, cache: cache}}
+func NewKindWithCache(object runtime.Object, cache cache.Cache, filters ...client.ListOption) SyncingSource {
+	return &kindWithCache{kind: Kind{Type: object, Filters: filters, cache: cache}}
 }
 
 type kindWithCache struct {
 	kind Kind
 }
 
-func (ks *kindWithCache) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (ks *kindWithCache) Start(ctx context.Context,
+	handler handler.EventHandler,
+	queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
-	return ks.kind.Start(handler, queue, prct...)
+
+	return ks.kind.Start(ctx, handler, queue, prct...)
 }
 
 func (ks *kindWithCache) WaitForSync(stop <-chan struct{}) error {
@@ -89,6 +93,8 @@ type Kind struct {
 	// Type is the type of object to watch.  e.g. &v1.Pod{}
 	Type runtime.Object
 
+	Filters []client.ListOption
+
 	// cache used to watch APIs
 	cache cache.Cache
 }
@@ -97,7 +103,9 @@ var _ SyncingSource = &Kind{}
 
 // Start is internal and should be called only by the Controller to register an EventHandler with the Informer
 // to enqueue reconcile.Requests.
-func (ks *Kind) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (ks *Kind) Start(ctx context.Context,
+	handler handler.EventHandler,
+	queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
 
 	// Type should have been specified by the user.
@@ -110,8 +118,16 @@ func (ks *Kind) Start(handler handler.EventHandler, queue workqueue.RateLimiting
 		return fmt.Errorf("must call CacheInto on Kind before calling Start")
 	}
 
+	if f, isFilter := ks.cache.(cache.Filter); isFilter {
+		if err := f.AddFilter(ctx, ks.Type, ks.Filters); err != nil {
+			return err
+		}
+	} else if len(ks.Filters) != 0 {
+		return fmt.Errorf("cache type %T does not support filtering", ks.cache)
+	}
+
 	// Lookup the Informer from the Cache and add an EventHandler which populates the Queue
-	i, err := ks.cache.GetInformer(context.TODO(), ks.Type)
+	i, err := ks.cache.GetInformer(ctx, ks.Type)
 	if err != nil {
 		if kindMatchErr, ok := err.(*meta.NoKindMatchError); ok {
 			log.Error(err, "if kind is a CRD, it should be installed before calling Start",
@@ -194,7 +210,7 @@ func (cs *Channel) InjectStopChannel(stop <-chan struct{}) error {
 }
 
 // Start implements Source and should only be called by the Controller.
-func (cs *Channel) Start(
+func (cs *Channel) Start(_ context.Context,
 	handler handler.EventHandler,
 	queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
@@ -289,7 +305,9 @@ var _ Source = &Informer{}
 
 // Start is internal and should be called only by the Controller to register an EventHandler with the Informer
 // to enqueue reconcile.Requests.
-func (is *Informer) Start(handler handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (is *Informer) Start(_ context.Context,
+	handler handler.EventHandler,
+	queue workqueue.RateLimitingInterface,
 	prct ...predicate.Predicate) error {
 
 	// Informer should have been specified by the user.
@@ -308,12 +326,14 @@ func (is *Informer) String() string {
 var _ Source = Func(nil)
 
 // Func is a function that implements Source
-type Func func(handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
+type Func func(context.Context, handler.EventHandler, workqueue.RateLimitingInterface, ...predicate.Predicate) error
 
 // Start implements Source
-func (f Func) Start(evt handler.EventHandler, queue workqueue.RateLimitingInterface,
+func (f Func) Start(ctx context.Context,
+	evt handler.EventHandler,
+	queue workqueue.RateLimitingInterface,
 	pr ...predicate.Predicate) error {
-	return f(evt, queue, pr...)
+	return f(ctx, evt, queue, pr...)
 }
 
 func (f Func) String() string {

--- a/pkg/source/source_integration_test.go
+++ b/pkg/source/source_integration_test.go
@@ -43,10 +43,11 @@ var _ = Describe("Source", func() {
 	var q workqueue.RateLimitingInterface
 	var c1, c2 chan interface{}
 	var ns string
+	var ctx context.Context
 	count := 0
-	ctx := context.TODO()
 
 	BeforeEach(func(done Done) {
+		ctx = context.TODO()
 		// Create the namespace for the test
 		ns = fmt.Sprintf("controller-source-kindsource-%v", count)
 		count++
@@ -133,8 +134,8 @@ var _ = Describe("Source", func() {
 				handler2 := newHandler(c2)
 
 				// Create 2 instances
-				Expect(instance1.Start(handler1, q)).To(Succeed())
-				Expect(instance2.Start(handler2, q)).To(Succeed())
+				Expect(instance1.Start(ctx, handler1, q)).To(Succeed())
+				Expect(instance2.Start(ctx, handler2, q)).To(Succeed())
 
 				By("Creating a Deployment and expecting the CreateEvent.")
 				created, err = client.Create(ctx, deployment, metav1.CreateOptions{})
@@ -255,7 +256,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
-				err := instance.Start(handler.Funcs{
+				err := instance.Start(ctx, handler.Funcs{
 					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						var err error
@@ -297,7 +298,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
-				err = instance.Start(handler.Funcs{
+				err = instance.Start(ctx, handler.Funcs{
 					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 					},
 					UpdateFunc: func(evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
@@ -335,7 +336,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
-				err := instance.Start(handler.Funcs{
+				err := instance.Start(ctx, handler.Funcs{
 					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
 					},
 					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {


### PR DESCRIPTION
This PR is a prototype of filtered informers via a cache that tracks informers on a per-controller basis. A `context.Context` value containing the controller name is passed to a `source.Source.Start()` method (the only breaking API change), which is percolated down to the underlying cache to match filters set up on the `source.Source` on controller setup.

Within the reconcile loop itself, the `cache.OwnedContext()` function will set the controller name on a parent context that can then be used to access controller-specific filtered caches. Without some controller-filter mapping, there would be no way to know which controller has created a filter, effectively making all filters global (not desirable). Most importantly, default behavior (if that function is not used on a context) is to use a global informer per gvk (current implementation).

Each cache contains either a set of filtered informers or a global informer; one informer per filter is created without modification to other filtered informers. Filters on informers are considered logically conjunctive (otherwise these filters would have been combined into one):
- On a `cache.Cache.Get()`, the first successfully returned object is returned to the caller, with informers being iterated through in order of creation.
- On a `cache.Cache.List()`, all results returned by each filter are combined (duplicates removed) and returned to the caller.

There is still quite a bit to do (see code TODO's), and this prototype doesn't quite work yet. Most importantly, filter interfaces (usage of `client.ListOption` in particular) are demonstrative and not necessarily what the actual interfaces will look like. The intent here is only to demonstrate one approach to mapping controller to filtered informers.

See #244 for relevant discussion