### PR TITLE
:bug: add error check when no apiType is provided for reconciliation

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -167,6 +167,10 @@ func (blder *Builder) Build(r reconcile.Reconciler) (controller.Controller, erro
 	if blder.forInput.err != nil {
 		return nil, blder.forInput.err
 	}
+	// Checking the reconcile type exist or not
+	if blder.forInput.object == nil {
+		return nil, fmt.Errorf("must provide an object for reconciliation")
+	}
 
 	// Set the Config
 	blder.loadRestConfig()

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -104,6 +104,18 @@ var _ = Describe("application", func() {
 			Expect(instance).To(BeNil())
 		})
 
+		It("should return an error if For function is not called", func() {
+			By("creating a controller manager")
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			instance, err := ControllerManagedBy(m).
+				Owns(&appsv1.ReplicaSet{}).
+				Build(noop)
+			Expect(err).To(MatchError(ContainSubstring("must provide an object for reconciliation")))
+			Expect(instance).To(BeNil())
+		})
+
 		It("should return an error if there is no GVK for an object, and thus we can't default the controller name", func() {
 			By("creating a controller manager")
 			m, err := manager.New(cfg, manager.Options{})


### PR DESCRIPTION
When no reconciliation type is provided in the For(...) function to the Builder, it used to panic. Added the error handling if no apiType is provided in the For(...) function.

Fixes #1181 
