### PR TITLE
:seedling: Use client.Object interface in envtest

### DIFF
--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -45,7 +44,7 @@ type CRDInstallOptions struct {
 	Paths []string
 
 	// CRDs is a list of CRDs to install
-	CRDs []runtime.Object
+	CRDs []client.Object
 
 	// ErrorIfPathMissing will cause an error if a Path does not exist
 	ErrorIfPathMissing bool
@@ -66,7 +65,7 @@ const defaultPollInterval = 100 * time.Millisecond
 const defaultMaxWait = 10 * time.Second
 
 // InstallCRDs installs a collection of CRDs into a cluster by reading the crd yaml files from a directory
-func InstallCRDs(config *rest.Config, options CRDInstallOptions) ([]runtime.Object, error) {
+func InstallCRDs(config *rest.Config, options CRDInstallOptions) ([]client.Object, error) {
 	defaultCRDOptions(&options)
 
 	// Read the CRD yamls into options.CRDs
@@ -111,7 +110,7 @@ func defaultCRDOptions(o *CRDInstallOptions) {
 }
 
 // WaitForCRDs waits for the CRDs to appear in discovery
-func WaitForCRDs(config *rest.Config, crds []runtime.Object, options CRDInstallOptions) error {
+func WaitForCRDs(config *rest.Config, crds []client.Object, options CRDInstallOptions) error {
 	// Add each CRD to a map of GroupVersion to Resource
 	waitingFor := map[schema.GroupVersion]*sets.String{}
 	for _, crd := range runtimeCRDListToUnstructured(crds) {
@@ -244,7 +243,7 @@ func UninstallCRDs(config *rest.Config, options CRDInstallOptions) error {
 }
 
 // CreateCRDs creates the CRDs
-func CreateCRDs(config *rest.Config, crds []runtime.Object) error {
+func CreateCRDs(config *rest.Config, crds []client.Object) error {
 	cs, err := client.New(config, client.Options{})
 	if err != nil {
 		return err
@@ -274,7 +273,7 @@ func CreateCRDs(config *rest.Config, crds []runtime.Object) error {
 }
 
 // renderCRDs iterate through options.Paths and extract all CRD files.
-func renderCRDs(options *CRDInstallOptions) ([]runtime.Object, error) {
+func renderCRDs(options *CRDInstallOptions) ([]client.Object, error) {
 	var (
 		err   error
 		info  os.FileInfo
@@ -325,7 +324,7 @@ func renderCRDs(options *CRDInstallOptions) ([]runtime.Object, error) {
 	}
 
 	// Converting map to a list to return
-	var res []runtime.Object
+	var res []client.Object
 	for _, obj := range crds {
 		res = append(res, obj)
 	}

--- a/pkg/envtest/envtest_suite_test.go
+++ b/pkg/envtest/envtest_suite_test.go
@@ -24,7 +24,7 @@ import (
 	admissionv1 "k8s.io/api/admissionregistration/v1"
 	admissionv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -61,7 +61,7 @@ func initializeWebhookInEnvironment() {
 	webhookPathV1 := "/failing"
 
 	env.WebhookInstallOptions = WebhookInstallOptions{
-		ValidatingWebhooks: []runtime.Object{
+		ValidatingWebhooks: []client.Object{
 			&admissionv1beta1.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "deployment-validation-webhook-config",

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 var _ = Describe("Test", func() {
-	var crds []runtime.Object
+	var crds []client.Object
 	var err error
 	var s *runtime.Scheme
 	var c client.Client
@@ -44,7 +44,7 @@ var _ = Describe("Test", func() {
 
 	// Initialize the client
 	BeforeEach(func(done Done) {
-		crds = []runtime.Object{}
+		crds = []client.Object{}
 		s = runtime.NewScheme()
 		err = v1beta1.AddToScheme(s)
 		Expect(err).NotTo(HaveOccurred())
@@ -114,7 +114,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -196,7 +196,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Config"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&v1beta1.CustomResourceDefinition{
 					Spec: v1beta1.CustomResourceDefinitionSpec{
 						Group:   "foo.example.com",
@@ -240,7 +240,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -296,7 +296,7 @@ var _ = Describe("Test", func() {
 		It("should return an error if the resource group version isn't found", func(done Done) {
 			// Wait for a CRD where the Group and Version don't exist
 			err := WaitForCRDs(env.Config,
-				[]runtime.Object{
+				[]client.Object{
 					&v1beta1.CustomResourceDefinition{
 						Spec: v1beta1.CustomResourceDefinitionSpec{
 							Version: "v1",
@@ -319,7 +319,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			// Wait for a CRD that doesn't exist, but the Group and Version do
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&v1beta1.CustomResourceDefinition{
 					Spec: v1beta1.CustomResourceDefinitionSpec{
 						Group:   "qux.example.com",
@@ -377,7 +377,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -479,7 +479,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -570,7 +570,7 @@ var _ = Describe("Test", func() {
 		// Store resource version for comparison later on
 		firstRV := crd.ResourceVersion
 
-		err = WaitForCRDs(env.Config, []runtime.Object{
+		err = WaitForCRDs(env.Config, []client.Object{
 			&v1beta1.CustomResourceDefinition{
 				Spec: v1beta1.CustomResourceDefinitionSpec{
 					Group: "crew.example.com",
@@ -610,7 +610,7 @@ var _ = Describe("Test", func() {
 		Expect(len(crd.Spec.Versions)).To(BeEquivalentTo(3))
 		Expect(crd.ResourceVersion).NotTo(BeEquivalentTo(firstRV))
 
-		err = WaitForCRDs(env.Config, []runtime.Object{
+		err = WaitForCRDs(env.Config, []client.Object{
 			&v1beta1.CustomResourceDefinition{
 				Spec: v1beta1.CustomResourceDefinitionSpec{
 					Group: "crew.example.com",
@@ -678,7 +678,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []runtime.Object{
+			err = WaitForCRDs(env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",

--- a/pkg/envtest/helper.go
+++ b/pkg/envtest/helper.go
@@ -5,6 +5,7 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -38,7 +39,7 @@ func mergePaths(s1, s2 []string) []string {
 
 // mergeCRDs merges two CRD slices using their names.
 // This function makes no guarantees about order of the merged slice.
-func mergeCRDs(s1, s2 []runtime.Object) []runtime.Object {
+func mergeCRDs(s1, s2 []client.Object) []client.Object {
 	m := make(map[string]*unstructured.Unstructured)
 	for _, obj := range runtimeCRDListToUnstructured(s1) {
 		m[obj.GetName()] = obj
@@ -46,7 +47,7 @@ func mergeCRDs(s1, s2 []runtime.Object) []runtime.Object {
 	for _, obj := range runtimeCRDListToUnstructured(s2) {
 		m[obj.GetName()] = obj
 	}
-	merged := make([]runtime.Object, len(m))
+	merged := make([]client.Object, len(m))
 	i := 0
 	for _, obj := range m {
 		merged[i] = obj
@@ -55,7 +56,7 @@ func mergeCRDs(s1, s2 []runtime.Object) []runtime.Object {
 	return merged
 }
 
-func runtimeCRDListToUnstructured(l []runtime.Object) []*unstructured.Unstructured {
+func runtimeCRDListToUnstructured(l []client.Object) []*unstructured.Unstructured {
 	res := []*unstructured.Unstructured{}
 	for _, obj := range l {
 		u := &unstructured.Unstructured{}

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -23,8 +23,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration"
 
@@ -106,7 +106,7 @@ type Environment struct {
 	// CRDs is a list of CRDs to install.
 	// If both this field and CRDs field in CRDInstallOptions are specified, the
 	// values are merged.
-	CRDs []runtime.Object
+	CRDs []client.Object
 
 	// CRDDirectoryPaths is a list of paths containing CRD yaml or json configs.
 	// If both this field and Paths field in CRDInstallOptions are specified, the

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -44,10 +44,10 @@ type WebhookInstallOptions struct {
 	Paths []string
 
 	// MutatingWebhooks is a list of MutatingWebhookConfigurations to install
-	MutatingWebhooks []runtime.Object
+	MutatingWebhooks []client.Object
 
 	// ValidatingWebhooks is a list of ValidatingWebhookConfigurations to install
-	ValidatingWebhooks []runtime.Object
+	ValidatingWebhooks []client.Object
 
 	// IgnoreErrorIfPathMissing will ignore an error if a DirectoryPath does not exist when set to true
 	IgnoreErrorIfPathMissing bool
@@ -195,8 +195,8 @@ func (o *WebhookInstallOptions) Cleanup() error {
 
 // WaitForWebhooks waits for the Webhooks to be available through API server
 func WaitForWebhooks(config *rest.Config,
-	mutatingWebhooks []runtime.Object,
-	validatingWebhooks []runtime.Object,
+	mutatingWebhooks []client.Object,
+	validatingWebhooks []client.Object,
 	options WebhookInstallOptions) error {
 
 	waitingFor := map[schema.GroupVersionKind]*sets.String{}
@@ -293,7 +293,7 @@ func (o *WebhookInstallOptions) setupCA() ([]byte, error) {
 	return certData, nil
 }
 
-func createWebhooks(config *rest.Config, mutHooks []runtime.Object, valHooks []runtime.Object) error {
+func createWebhooks(config *rest.Config, mutHooks []client.Object, valHooks []client.Object) error {
 	cs, err := client.New(config, client.Options{})
 	if err != nil {
 		return err
@@ -360,7 +360,7 @@ func parseWebhook(options *WebhookInstallOptions) error {
 
 // readWebhooks reads the Webhooks from files and Unmarshals them into structs
 // returns slice of mutating and validating webhook configurations
-func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
+func readWebhooks(path string) ([]client.Object, []client.Object, error) {
 	// Get the webhook files
 	var files []os.FileInfo
 	var err error
@@ -380,8 +380,8 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 	// file extensions that may contain Webhooks
 	resourceExtensions := sets.NewString(".json", ".yaml", ".yml")
 
-	var mutHooks []runtime.Object
-	var valHooks []runtime.Object
+	var mutHooks []client.Object
+	var valHooks []client.Object
 	for _, file := range files {
 		// Only parse allowlisted file types
 		if !resourceExtensions.Has(filepath.Ext(file.Name())) {
@@ -433,7 +433,7 @@ func readWebhooks(path string) ([]runtime.Object, []runtime.Object, error) {
 	return mutHooks, valHooks, nil
 }
 
-func runtimeListToUnstructured(l []runtime.Object) []*unstructured.Unstructured {
+func runtimeListToUnstructured(l []client.Object) []*unstructured.Unstructured {
 	res := []*unstructured.Unstructured{}
 	for _, obj := range l {
 		m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj.DeepCopyObject())


### PR DESCRIPTION
This is a follow-up from an earlier PR that introduced the
client.Object interface. While working in Cluster API downstream,
noticed that this was missing from the envtest codebase.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/milestone v0.7.x