### PR TITLE
:warning: Propagate context.Context through source and predicates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	go.uber.org/goleak v1.1.10
 	go.uber.org/zap v1.15.0
+	golang.org/x/net v0.0.0-20200707034311-ab3426394381
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gomodules.xyz/jsonpatch/v2 v2.1.0
 	google.golang.org/appengine v1.6.6 // indirect

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -309,7 +309,7 @@ var _ = Describe("application", func() {
 			)
 
 			deployPrct := predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
+				CreateFunc: func(ctx context.Context, e event.CreateEvent) bool {
 					defer GinkgoRecover()
 					// check that it was called only for deployment
 					Expect(e.Object).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
@@ -319,7 +319,7 @@ var _ = Describe("application", func() {
 			}
 
 			replicaSetPrct := predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
+				CreateFunc: func(ctx context.Context, e event.CreateEvent) bool {
 					defer GinkgoRecover()
 					// check that it was called only for replicaset
 					Expect(e.Object).To(BeAssignableToTypeOf(&appsv1.ReplicaSet{}))
@@ -329,7 +329,7 @@ var _ = Describe("application", func() {
 			}
 
 			allPrct := predicate.Funcs{
-				CreateFunc: func(e event.CreateEvent) bool {
+				CreateFunc: func(ctx context.Context, e event.CreateEvent) bool {
 					defer GinkgoRecover()
 					//check that it was called for all registered kinds
 					Expect(e.Object).Should(Or(

--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -17,6 +17,8 @@ limitations under the License.
 package handler
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -34,7 +36,7 @@ var _ EventHandler = &EnqueueRequestForObject{}
 type EnqueueRequestForObject struct{}
 
 // Create implements EventHandler
-func (e *EnqueueRequestForObject) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForObject) Create(ctx context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	if evt.Object == nil {
 		enqueueLog.Error(nil, "CreateEvent received with no metadata", "event", evt)
 		return
@@ -46,7 +48,7 @@ func (e *EnqueueRequestForObject) Create(evt event.CreateEvent, q workqueue.Rate
 }
 
 // Update implements EventHandler
-func (e *EnqueueRequestForObject) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForObject) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	if evt.ObjectOld != nil {
 		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      evt.ObjectOld.GetName(),
@@ -67,7 +69,7 @@ func (e *EnqueueRequestForObject) Update(evt event.UpdateEvent, q workqueue.Rate
 }
 
 // Delete implements EventHandler
-func (e *EnqueueRequestForObject) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForObject) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	if evt.Object == nil {
 		enqueueLog.Error(nil, "DeleteEvent received with no metadata", "event", evt)
 		return
@@ -79,7 +81,7 @@ func (e *EnqueueRequestForObject) Delete(evt event.DeleteEvent, q workqueue.Rate
 }
 
 // Generic implements EventHandler
-func (e *EnqueueRequestForObject) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForObject) Generic(ctx context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	if evt.Object == nil {
 		enqueueLog.Error(nil, "GenericEvent received with no metadata", "event", evt)
 		return

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -58,14 +59,14 @@ type EnqueueRequestForOwner struct {
 }
 
 // Create implements EventHandler
-func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForOwner) Create(ctx context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}
 }
 
 // Update implements EventHandler
-func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForOwner) Update(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range e.getOwnerReconcileRequest(evt.ObjectOld) {
 		q.Add(req)
 	}
@@ -75,14 +76,14 @@ func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateL
 }
 
 // Delete implements EventHandler
-func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForOwner) Delete(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}
 }
 
 // Generic implements EventHandler
-func (e *EnqueueRequestForOwner) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (e *EnqueueRequestForOwner) Generic(ctx context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
 		q.Add(req)
 	}

--- a/pkg/handler/eventhandler.go
+++ b/pkg/handler/eventhandler.go
@@ -17,6 +17,8 @@ limitations under the License.
 package handler
 
 import (
+	"context"
+
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 )
@@ -41,17 +43,17 @@ import (
 // Most users shouldn't need to implement their own EventHandler.
 type EventHandler interface {
 	// Create is called in response to an create event - e.g. Pod Creation.
-	Create(event.CreateEvent, workqueue.RateLimitingInterface)
+	Create(context.Context, event.CreateEvent, workqueue.RateLimitingInterface)
 
 	// Update is called in response to an update event -  e.g. Pod Updated.
-	Update(event.UpdateEvent, workqueue.RateLimitingInterface)
+	Update(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface)
 
 	// Delete is called in response to a delete event - e.g. Pod Deleted.
-	Delete(event.DeleteEvent, workqueue.RateLimitingInterface)
+	Delete(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface)
 
 	// Generic is called in response to an event of an unknown type or a synthetic event triggered as a cron or
 	// external trigger request - e.g. reconcile Autoscaling, or a Webhook.
-	Generic(event.GenericEvent, workqueue.RateLimitingInterface)
+	Generic(context.Context, event.GenericEvent, workqueue.RateLimitingInterface)
 }
 
 var _ EventHandler = Funcs{}
@@ -60,45 +62,45 @@ var _ EventHandler = Funcs{}
 type Funcs struct {
 	// Create is called in response to an add event.  Defaults to no-op.
 	// RateLimitingInterface is used to enqueue reconcile.Requests.
-	CreateFunc func(event.CreateEvent, workqueue.RateLimitingInterface)
+	CreateFunc func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface)
 
 	// Update is called in response to an update event.  Defaults to no-op.
 	// RateLimitingInterface is used to enqueue reconcile.Requests.
-	UpdateFunc func(event.UpdateEvent, workqueue.RateLimitingInterface)
+	UpdateFunc func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface)
 
 	// Delete is called in response to a delete event.  Defaults to no-op.
 	// RateLimitingInterface is used to enqueue reconcile.Requests.
-	DeleteFunc func(event.DeleteEvent, workqueue.RateLimitingInterface)
+	DeleteFunc func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface)
 
 	// GenericFunc is called in response to a generic event.  Defaults to no-op.
 	// RateLimitingInterface is used to enqueue reconcile.Requests.
-	GenericFunc func(event.GenericEvent, workqueue.RateLimitingInterface)
+	GenericFunc func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface)
 }
 
 // Create implements EventHandler
-func (h Funcs) Create(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+func (h Funcs) Create(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
 	if h.CreateFunc != nil {
-		h.CreateFunc(e, q)
+		h.CreateFunc(ctx, e, q)
 	}
 }
 
 // Delete implements EventHandler
-func (h Funcs) Delete(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+func (h Funcs) Delete(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
 	if h.DeleteFunc != nil {
-		h.DeleteFunc(e, q)
+		h.DeleteFunc(ctx, e, q)
 	}
 }
 
 // Update implements EventHandler
-func (h Funcs) Update(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+func (h Funcs) Update(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	if h.UpdateFunc != nil {
-		h.UpdateFunc(e, q)
+		h.UpdateFunc(ctx, e, q)
 	}
 }
 
 // Generic implements EventHandler
-func (h Funcs) Generic(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+func (h Funcs) Generic(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
 	if h.GenericFunc != nil {
-		h.GenericFunc(e, q)
+		h.GenericFunc(ctx, e, q)
 	}
 }

--- a/pkg/handler/example_test.go
+++ b/pkg/handler/example_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package handler_test
 
 import (
+	"context"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -65,7 +67,7 @@ func ExampleEnqueueRequestsFromMapFunc() {
 	// controller is a controller.controller
 	err := c.Watch(
 		&source.Kind{Type: &appsv1.Deployment{}},
-		handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+		handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a handler.MapObject) []reconcile.Request {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{
 					Name:      a.Object.GetName() + "-1",
@@ -89,25 +91,25 @@ func ExampleFuncs() {
 	err := c.Watch(
 		&source.Kind{Type: &corev1.Pod{}},
 		handler.Funcs{
-			CreateFunc: func(e event.CreateEvent, q workqueue.RateLimitingInterface) {
+			CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      e.Object.GetName(),
 					Namespace: e.Object.GetNamespace(),
 				}})
 			},
-			UpdateFunc: func(e event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			UpdateFunc: func(ctx context.Context, e event.UpdateEvent, q workqueue.RateLimitingInterface) {
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      e.ObjectNew.GetName(),
 					Namespace: e.ObjectNew.GetNamespace(),
 				}})
 			},
-			DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      e.Object.GetName(),
 					Namespace: e.Object.GetNamespace(),
 				}})
 			},
-			GenericFunc: func(e event.GenericEvent, q workqueue.RateLimitingInterface) {
+			GenericFunc: func(ctx context.Context, e event.GenericEvent, q workqueue.RateLimitingInterface) {
 				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 					Name:      e.Object.GetName(),
 					Namespace: e.Object.GetNamespace(),

--- a/pkg/predicate/example_test.go
+++ b/pkg/predicate/example_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package predicate_test
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -26,7 +28,7 @@ var p predicate.Predicate
 // This example creates a new Predicate to drop Update Events where the Generation has not changed.
 func ExampleFuncs() {
 	p = predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
+		UpdateFunc: func(ctx context.Context, e event.UpdateEvent) bool {
 			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
 		},
 	}

--- a/pkg/source/internal/internal_test.go
+++ b/pkg/source/internal/internal_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package internal_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/tools/cache"
@@ -40,35 +42,35 @@ var _ = Describe("Internal", func() {
 	var set bool
 	BeforeEach(func() {
 		funcs = &handler.Funcs{
-			CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+			CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Fail("Did not expect CreateEvent to be called.")
 			},
-			DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Fail("Did not expect DeleteEvent to be called.")
 			},
-			UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+			UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Fail("Did not expect UpdateEvent to be called.")
 			},
-			GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+			GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Fail("Did not expect GenericEvent to be called.")
 			},
 		}
 
 		setfuncs = &handler.Funcs{
-			CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+			CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 				set = true
 			},
-			DeleteFunc: func(e event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			DeleteFunc: func(ctx context.Context, e event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				set = true
 			},
-			UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+			UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 				set = true
 			},
-			GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+			GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 				set = true
 			},
 		}
@@ -92,7 +94,7 @@ var _ = Describe("Internal", func() {
 		})
 
 		It("should create a CreateEvent", func(done Done) {
-			funcs.CreateFunc = func(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+			funcs.CreateFunc = func(ctx context.Context, evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
 				Expect(evt.Object).To(Equal(pod))
@@ -109,38 +111,38 @@ var _ = Describe("Internal", func() {
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return false }},
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeTrue())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return false }},
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return false }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeTrue())
@@ -159,7 +161,7 @@ var _ = Describe("Internal", func() {
 		})
 
 		It("should create an UpdateEvent", func(done Done) {
-			funcs.UpdateFunc = func(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+			funcs.UpdateFunc = func(ctx context.Context, evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
 
@@ -178,38 +180,38 @@ var _ = Describe("Internal", func() {
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{UpdateFunc: func(updateEvent event.UpdateEvent) bool { return false }},
+				predicate.Funcs{UpdateFunc: func(ctx context.Context, updateEvent event.UpdateEvent) bool { return false }},
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{UpdateFunc: func(event.UpdateEvent) bool { return true }},
+				predicate.Funcs{UpdateFunc: func(context.Context, event.UpdateEvent) bool { return true }},
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeTrue())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{UpdateFunc: func(event.UpdateEvent) bool { return true }},
-				predicate.Funcs{UpdateFunc: func(event.UpdateEvent) bool { return false }},
+				predicate.Funcs{UpdateFunc: func(context.Context, event.UpdateEvent) bool { return true }},
+				predicate.Funcs{UpdateFunc: func(context.Context, event.UpdateEvent) bool { return false }},
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{UpdateFunc: func(event.UpdateEvent) bool { return false }},
-				predicate.Funcs{UpdateFunc: func(event.UpdateEvent) bool { return true }},
+				predicate.Funcs{UpdateFunc: func(context.Context, event.UpdateEvent) bool { return false }},
+				predicate.Funcs{UpdateFunc: func(context.Context, event.UpdateEvent) bool { return true }},
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
-				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
+				predicate.Funcs{CreateFunc: func(context.Context, event.CreateEvent) bool { return true }},
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeTrue())
@@ -230,7 +232,7 @@ var _ = Describe("Internal", func() {
 		})
 
 		It("should create a DeleteEvent", func(done Done) {
-			funcs.DeleteFunc = func(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			funcs.DeleteFunc = func(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
 
@@ -248,38 +250,38 @@ var _ = Describe("Internal", func() {
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return false }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return false }},
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return true }},
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeTrue())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }},
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return false }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return true }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return false }},
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return false }},
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return false }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return true }},
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance.Predicates = []predicate.Predicate{
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }},
-				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return true }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return true }},
+				predicate.Funcs{DeleteFunc: func(context.Context, event.DeleteEvent) bool { return true }},
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeTrue())
@@ -302,7 +304,7 @@ var _ = Describe("Internal", func() {
 			tombstone := cache.DeletedFinalStateUnknown{
 				Obj: pod,
 			}
-			funcs.DeleteFunc = func(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+			funcs.DeleteFunc = func(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
 				Expect(evt.Object).To(Equal(pod))

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -226,14 +226,14 @@ func (cs *Channel) Start(
 		for evt := range dst {
 			shouldHandle := true
 			for _, p := range prct {
-				if !p.Generic(evt) {
+				if !p.Generic(ctx, evt) {
 					shouldHandle = false
 					break
 				}
 			}
 
 			if shouldHandle {
-				handler.Generic(evt, queue)
+				handler.Generic(ctx, evt, queue)
 			}
 		}
 	}()
@@ -298,7 +298,7 @@ func (is *Informer) Start(ctx context.Context, handler handler.EventHandler, que
 		return fmt.Errorf("must specify Informer.Informer")
 	}
 
-	is.Informer.AddEventHandler(internal.EventHandler{Queue: queue, EventHandler: handler, Predicates: prct})
+	is.Informer.AddEventHandler(internal.EventHandler{Context: ctx, Queue: queue, EventHandler: handler, Predicates: prct})
 	return nil
 }
 

--- a/pkg/source/source_integration_test.go
+++ b/pkg/source/source_integration_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package source_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -110,17 +111,17 @@ var _ = Describe("Source", func() {
 				// Create an event handler to verify the events
 				newHandler := func(c chan interface{}) handler.Funcs {
 					return handler.Funcs{
-						CreateFunc: func(evt event.CreateEvent, rli workqueue.RateLimitingInterface) {
+						CreateFunc: func(ctx context.Context, evt event.CreateEvent, rli workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
 							Expect(rli).To(Equal(q))
 							c <- evt
 						},
-						UpdateFunc: func(evt event.UpdateEvent, rli workqueue.RateLimitingInterface) {
+						UpdateFunc: func(ctx context.Context, evt event.UpdateEvent, rli workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
 							Expect(rli).To(Equal(q))
 							c <- evt
 						},
-						DeleteFunc: func(evt event.DeleteEvent, rli workqueue.RateLimitingInterface) {
+						DeleteFunc: func(ctx context.Context, evt event.DeleteEvent, rli workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
 							Expect(rli).To(Equal(q))
 							c <- evt
@@ -254,7 +255,7 @@ var _ = Describe("Source", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+					CreateFunc: func(ctx context.Context, evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						var err error
 						rs, err := clientset.AppsV1().ReplicaSets("default").Get(ctx, rs.Name, metav1.GetOptions{})
@@ -264,15 +265,15 @@ var _ = Describe("Source", func() {
 						Expect(evt.Object).To(Equal(rs))
 						close(c)
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},
@@ -296,9 +297,9 @@ var _ = Describe("Source", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
 				err = instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+					CreateFunc: func(ctx context.Context, evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 					},
-					UpdateFunc: func(evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
+					UpdateFunc: func(ctx context.Context, evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						var err error
 						rs2, err := clientset.AppsV1().ReplicaSets("default").Get(ctx, rs.Name, metav1.GetOptions{})
@@ -311,11 +312,11 @@ var _ = Describe("Source", func() {
 
 						close(c)
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},
@@ -334,17 +335,17 @@ var _ = Describe("Source", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := &source.Informer{Informer: depInformer}
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 					},
-					DeleteFunc: func(evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
+					DeleteFunc: func(ctx context.Context, evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(Equal(q))
 						Expect(evt.Object.GetName()).To(Equal(rs.Name))
 						close(c)
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -70,21 +70,21 @@ var _ = Describe("Source", func() {
 				}
 				Expect(inject.CacheInto(ic, instance)).To(BeTrue())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+					CreateFunc: func(ctx context.Context, evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(Equal(q))
 						Expect(evt.Object).To(Equal(p))
 						close(c)
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},
@@ -110,11 +110,11 @@ var _ = Describe("Source", func() {
 				}
 				Expect(instance.InjectCache(ic)).To(Succeed())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
+					CreateFunc: func(ctx context.Context, evt event.CreateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
+					UpdateFunc: func(ctx context.Context, evt event.UpdateEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.ObjectOld).To(Equal(p))
@@ -123,11 +123,11 @@ var _ = Describe("Source", func() {
 
 						close(c)
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},
@@ -158,21 +158,21 @@ var _ = Describe("Source", func() {
 				}
 				Expect(inject.CacheInto(ic, instance)).To(BeTrue())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
+					DeleteFunc: func(ctx context.Context, evt event.DeleteEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Object).To(Equal(p))
 						close(c)
 					},
-					GenericFunc: func(event.GenericEvent, workqueue.RateLimitingInterface) {
+					GenericFunc: func(context.Context, event.GenericEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected GenericEvent")
 					},
@@ -312,7 +312,7 @@ var _ = Describe("Source", func() {
 
 				// Predicate to filter out empty event
 				prct := predicate.Funcs{
-					GenericFunc: func(e event.GenericEvent) bool {
+					GenericFunc: func(ctx context.Context, e event.GenericEvent) bool {
 						return e.Object != nil
 					},
 				}
@@ -321,19 +321,19 @@ var _ = Describe("Source", func() {
 				instance := &source.Channel{Source: ch}
 				Expect(inject.StopChannelInto(ctx.Done(), instance)).To(BeTrue())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
+					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						// The empty event should have been filtered out by the predicates,
 						// and will not be passed to the handler.
@@ -362,19 +362,19 @@ var _ = Describe("Source", func() {
 				instance.DestBufferSize = 1
 				Expect(inject.StopChannelInto(ctx.Done(), instance)).To(BeTrue())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
+					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						// Block for the first time
 						if eventCount == 0 {
@@ -422,19 +422,19 @@ var _ = Describe("Source", func() {
 				Expect(inject.StopChannelInto(ctx.Done(), instance)).To(BeTrue())
 
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
+					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 
 						close(processed)
@@ -481,19 +481,19 @@ var _ = Describe("Source", func() {
 				instance := &source.Channel{Source: ch}
 				Expect(inject.StopChannelInto(ctx.Done(), instance)).To(BeTrue())
 				err := instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
+					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Object).To(Equal(p))
@@ -504,19 +504,19 @@ var _ = Describe("Source", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				err = instance.Start(ctx, handler.Funcs{
-					CreateFunc: func(event.CreateEvent, workqueue.RateLimitingInterface) {
+					CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected CreateEvent")
 					},
-					UpdateFunc: func(event.UpdateEvent, workqueue.RateLimitingInterface) {
+					UpdateFunc: func(context.Context, event.UpdateEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected UpdateEvent")
 					},
-					DeleteFunc: func(event.DeleteEvent, workqueue.RateLimitingInterface) {
+					DeleteFunc: func(context.Context, event.DeleteEvent, workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Fail("Unexpected DeleteEvent")
 					},
-					GenericFunc: func(evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
+					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q2 workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
 						Expect(q2).To(BeIdenticalTo(q))
 						Expect(evt.Object).To(Equal(p))


### PR DESCRIPTION
This PR propagates a context on sources and predicates. The reasoning behind this is to allow for MapFunc, or predicate functions to get a context and pass it through for use cases like when using a client, or to get a logger.

/assign @alvaroaleman @DirectXMan12 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
