### PR TITLE
:seedling: Add controller.GetLogger

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -68,6 +68,9 @@ type Controller interface {
 	// Start starts the controller.  Start blocks until the context is closed or a
 	// controller has an error starting.
 	Start(ctx context.Context) error
+
+	// GetLogger returns this controller logger prefilled with basic information.
+	GetLogger() logr.Logger
 }
 
 // New returns a new Controller registered with the Manager.  The Manager will ensure that shared Caches have

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -287,6 +287,11 @@ func (c *Controller) reconcileHandler(ctx context.Context, obj interface{}) {
 	ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, "success").Inc()
 }
 
+// GetLogger returns this controller's logger.
+func (c *Controller) GetLogger() logr.Logger {
+	return c.Log
+}
+
 // InjectFunc implement SetFields.Injector
 func (c *Controller) InjectFunc(f inject.Func) error {
 	c.SetFields = f


### PR DESCRIPTION
Adds a new GetLogger method required on the controller interface. For
folks using controller without managers it's a good way to get a logger
pre-filled with information about the controller itself and avoid
duplication.

/assign @alvaroaleman