### PR TITLE
:warning: Propagate context on Manager.Start(...)

### DIFF
--- a/designs/move-cluster-specific-code-out-of-manager.md
+++ b/designs/move-cluster-specific-code-out-of-manager.md
@@ -203,7 +203,7 @@ func NewSecretMirrorReconciler(mgr manager.Manager, mirrorCluster cluster.Cluste
 
 func main(){
 
-	mgr, err := manager.New(context.Background(), cfg1, manager.Options{})
+	mgr, err := manager.New( cfg1, manager.Options{})
 	if err != nil {
 		panic(err)
 	}

--- a/example_test.go
+++ b/example_test.go
@@ -38,7 +38,7 @@ import (
 func Example() {
 	var log = controllers.Log.WithName("builder-examples")
 
-	manager, err := controllers.NewManager(context.Background(), controllers.GetConfigOrDie(), controllers.Options{})
+	manager, err := controllers.NewManager(controllers.GetConfigOrDie(), controllers.Options{})
 	if err != nil {
 		log.Error(err, "could not create manager")
 		os.Exit(1)
@@ -79,7 +79,6 @@ func Example_updateLeaderElectionDurations() {
 	renewDeadline := 80 * time.Second
 	retryPeriod := 20 * time.Second
 	manager, err := controllers.NewManager(
-		context.Background(),
 		controllers.GetConfigOrDie(),
 		controllers.Options{
 			LeaseDuration: &leaseDuration,

--- a/examples/builtins/main.go
+++ b/examples/builtins/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -43,7 +42,7 @@ func main() {
 
 	// Setup a Manager
 	entryLog.Info("setting up manager")
-	mgr, err := manager.New(context.Background(), config.GetConfigOrDie(), manager.Options{})
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
 		entryLog.Error(err, "unable to set up overall controller manager")
 		os.Exit(1)

--- a/examples/crd/main.go
+++ b/examples/crd/main.go
@@ -104,7 +104,7 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func main() {
 	ctrl.SetLogger(zap.New())
 
-	mgr, err := ctrl.NewManager(context.Background(), ctrl.GetConfigOrDie(), ctrl.Options{})
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
 		os.Exit(1)

--- a/examples/scratch-env/main.go
+++ b/examples/scratch-env/main.go
@@ -3,10 +3,11 @@ package main
 import (
 	goflag "flag"
 	"fmt"
-	flag "github.com/spf13/pflag"
 	"io"
 	"io/ioutil"
 	"os"
+
+	flag "github.com/spf13/pflag"
 
 	"k8s.io/client-go/tools/clientcmd"
 	kcapi "k8s.io/client-go/tools/clientcmd/api"
@@ -102,7 +103,8 @@ func runMain() int {
 		log.Info("Wrote kubeconfig")
 	}
 
-	<-ctrl.SetupSignalHandler()
+	ctx := ctrl.SetupSignalHandler()
+	<-ctx.Done()
 
 	log.Info("Shutting down apiserver & etcd")
 	err = env.Stop()

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,6 @@ require (
 	k8s.io/apiextensions-apiserver v0.19.2
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
-	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
+	k8s.io/utils v0.0.0-20200912215256-4140de9c8800
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -632,6 +632,8 @@ k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 h1:+WnxoVtG8TMiudHBSEtrVL
 k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H64/qeyjQoUZhGpeFDVdxjTeEVN2o=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73 h1:uJmqzgNWG7XyClnU/mLPBWwfKKF1K8Hf8whTseBgJcg=
 k8s.io/utils v0.0.0-20200729134348-d5654de09c73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
+k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQWhovSofhqR73A6g=
+k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.9/go.mod h1:dzAXnQbTRyDlZPJX2SUPEqvnB+j7AJjtlox7PEwigU0=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.1 h1:YXTMot5Qz/X1iBRJhAt+vI+HVttY0WkSqqhKxQ0xVbA=

--- a/pkg/builder/example_test.go
+++ b/pkg/builder/example_test.go
@@ -45,7 +45,7 @@ func ExampleBuilder() {
 
 	var log = logf.Log.WithName("builder-examples")
 
-	mgr, err := manager.New(context.Background(), config.GetConfigOrDie(), manager.Options{})
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
 		log.Error(err, "could not create manager")
 		os.Exit(1)

--- a/pkg/builder/example_webhook_test.go
+++ b/pkg/builder/example_webhook_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package builder_test
 
 import (
-	"context"
 	"os"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -40,7 +39,7 @@ var _ admission.Validator = &examplegroup.ChaosPod{}
 func ExampleWebhookBuilder() {
 	var log = logf.Log.WithName("webhookbuilder-example")
 
-	mgr, err := manager.New(context.Background(), config.GetConfigOrDie(), manager.Options{})
+	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
 		log.Error(err, "could not create manager")
 		os.Exit(1)

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -51,7 +51,7 @@ var _ = Describe("webhook", func() {
 	Describe("New", func() {
 		It("should scaffold a defaulting webhook if the type implements the Defaulter interface", func() {
 			By("creating a controller manager")
-			m, err := manager.New(context.Background(), cfg, manager.Options{})
+			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("registering the type in the Scheme")
@@ -123,7 +123,7 @@ var _ = Describe("webhook", func() {
 
 		It("should scaffold a validating webhook if the type implements the Validator interface", func() {
 			By("creating a controller manager")
-			m, err := manager.New(context.Background(), cfg, manager.Options{})
+			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("registering the type in the Scheme")
@@ -196,7 +196,7 @@ var _ = Describe("webhook", func() {
 
 		It("should scaffold defaulting and validating webhooks if the type implements both Defaulter and Validator interfaces", func() {
 			By("creating a controller manager")
-			m, err := manager.New(context.Background(), cfg, manager.Options{})
+			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("registering the type in the Scheme")
@@ -273,7 +273,7 @@ var _ = Describe("webhook", func() {
 			By("creating a controller manager")
 			ctx, cancel := context.WithCancel(context.Background())
 
-			m, err := manager.New(ctx, cfg, manager.Options{})
+			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("registering the type in the Scheme")

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Test", func() {
 
 	Describe("Webhook", func() {
 		It("should reject create request for webhook that rejects all requests", func(done Done) {
-			m, err := manager.New(context.Background(), env.Config, manager.Options{
+			m, err := manager.New(env.Config, manager.Options{
 				Port:    env.WebhookInstallOptions.LocalServingPort,
 				Host:    env.WebhookInstallOptions.LocalServingHost,
 				CertDir: env.WebhookInstallOptions.LocalServingCertDir,

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -36,22 +36,10 @@ import (
 )
 
 var _ = Describe("recorder", func() {
-	var stop chan struct{}
-	ctx := context.Background()
-
-	BeforeEach(func() {
-		stop = make(chan struct{})
-		Expect(cfg).NotTo(BeNil())
-	})
-
-	AfterEach(func() {
-		close(stop)
-	})
-
 	Describe("recorder", func() {
 		It("should publish events", func(done Done) {
 			By("Creating the Manager")
-			cm, err := manager.New(ctx, cfg, manager.Options{})
+			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the Controller")
@@ -72,9 +60,11 @@ var _ = Describe("recorder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Starting the Manager")
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 			go func() {
 				defer GinkgoRecover()
-				Expect(cm.Start(stop)).NotTo(HaveOccurred())
+				Expect(cm.Start(ctx)).NotTo(HaveOccurred())
 			}()
 
 			deployment := &appsv1.Deployment{

--- a/pkg/manager/example_test.go
+++ b/pkg/manager/example_test.go
@@ -41,7 +41,7 @@ func ExampleNew() {
 		os.Exit(1)
 	}
 
-	mgr, err := manager.New(context.Background(), cfg, manager.Options{})
+	mgr, err := manager.New(cfg, manager.Options{})
 	if err != nil {
 		log.Error(err, "unable to set up manager")
 		os.Exit(1)
@@ -57,7 +57,7 @@ func ExampleNew_multinamespaceCache() {
 		os.Exit(1)
 	}
 
-	mgr, err := manager.New(context.Background(), cfg, manager.Options{
+	mgr, err := manager.New(cfg, manager.Options{
 		NewCache: cache.MultiNamespacedCacheBuilder([]string{"namespace1", "namespace2"}),
 	})
 	if err != nil {

--- a/pkg/manager/signals/signal.go
+++ b/pkg/manager/signals/signal.go
@@ -17,6 +17,7 @@ limitations under the License.
 package signals
 
 import (
+	"context"
 	"os"
 	"os/signal"
 )
@@ -26,18 +27,19 @@ var onlyOneSignalHandler = make(chan struct{})
 // SetupSignalHandler registers for SIGTERM and SIGINT. A stop channel is returned
 // which is closed on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
-func SetupSignalHandler() (stopCh <-chan struct{}) {
+func SetupSignalHandler() context.Context {
 	close(onlyOneSignalHandler) // panics when called twice
 
-	stop := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
 	c := make(chan os.Signal, 2)
 	signal.Notify(c, shutdownSignals...)
 	go func() {
 		<-c
-		close(stop)
+		cancel()
 		<-c
 		os.Exit(1) // second signal. Exit directly.
 	}()
 
-	return stop
+	return ctx
 }

--- a/pkg/manager/signals/signal_test.go
+++ b/pkg/manager/signals/signal_test.go
@@ -32,7 +32,7 @@ var _ = Describe("runtime signal", func() {
 	Context("SignalHandler Test", func() {
 
 		It("test signal handler", func() {
-			stop := SetupSignalHandler()
+			ctx := SetupSignalHandler()
 			task := &Task{
 				ticker: time.NewTicker(time.Second * 2),
 			}
@@ -47,7 +47,7 @@ var _ = Describe("runtime signal", func() {
 			select {
 			case sig := <-c:
 				fmt.Printf("Got %s signal. Aborting...\n", sig)
-			case _, ok := <-stop:
+			case _, ok := <-ctx.Done():
 				Expect(ok).To(BeFalse())
 			}
 		})

--- a/pkg/webhook/example_test.go
+++ b/pkg/webhook/example_test.go
@@ -46,7 +46,7 @@ func Example() {
 
 	// Create a manager
 	// Note: GetConfigOrDie will os.Exit(1) w/o any message if no kube-config can be found
-	mgr, err := ctrl.NewManager(context.Background(), ctrl.GetConfigOrDie(), ctrl.Options{})
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change reshuffles how the manager accepts and operates on
a context. With this change, the user experience is greatly improved,
users can now use `ctrl.SetupSignalHandler()` to create a context, enrich
it if they want to, and pass it to `manager.Start`.

In addition, this PR changes how the context and stop channel are
handled internally to ensure proper cancellation.

/assign @alvaroaleman 
/milestone v0.7.x
