### PR TITLE
:sparkles: Zap: Add JSONEncoder and ConsoleEncoder opts

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -71,12 +71,26 @@ func Encoder(encoder zapcore.Encoder) func(o *Options) {
 	}
 }
 
+// JSONEncoder configures the logger to use a JSON Encoder
+func JSONEncoder(opts ...EncoderConfigOption) func(o *Options) {
+	return func(o *Options) {
+		o.Encoder = newJSONEncoder(opts...)
+	}
+}
+
 func newJSONEncoder(opts ...EncoderConfigOption) zapcore.Encoder {
 	encoderConfig := zap.NewProductionEncoderConfig()
 	for _, opt := range opts {
 		opt(&encoderConfig)
 	}
 	return zapcore.NewJSONEncoder(encoderConfig)
+}
+
+// ConsoleEncoder configures the logger to use a Console encoder
+func ConsoleEncoder(opts ...EncoderConfigOption) func(o *Options) {
+	return func(o *Options) {
+		o.Encoder = newConsoleEncoder(opts...)
+	}
 }
 
 func newConsoleEncoder(opts ...EncoderConfigOption) zapcore.Encoder {


### PR DESCRIPTION
Currently, setting the encoding is pretty annoying and requires to
import two more packages apart from log/zap:

```
encoderConfig := uberzap.NewProductionEncoderConfig()
zap.New(zap.Encoder(zapcore.NewJSONEncoder(encoderConfig)))
```

This PR adds a JSONEncoder and ConsoleEncoder opt to simplify this

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
