### PR TITLE
:warning: Handler: Remove MapObject type and use client.Object directly

### DIFF
--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -26,7 +26,7 @@ import (
 
 // MapFunc is the signature required for enqueueing requests from a generic function.
 // This type is usually used with EnqueueRequestsFromMapFunc when registering an event handler.
-type MapFunc func(MapObject) []reconcile.Request
+type MapFunc func(client.Object) []reconcile.Request
 
 // EnqueueRequestsFromMapFunc enqueues Requests by running a transformation function that outputs a collection
 // of reconcile.Requests on each Event.  The reconcile.Requests may be for an arbitrary set of objects
@@ -53,26 +53,26 @@ type enqueueRequestsFromMapFunc struct {
 
 // Create implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, MapObject{Object: evt.Object})
+	e.mapAndEnqueue(q, evt.Object)
 }
 
 // Update implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, MapObject{Object: evt.ObjectOld})
-	e.mapAndEnqueue(q, MapObject{Object: evt.ObjectNew})
+	e.mapAndEnqueue(q, evt.ObjectOld)
+	e.mapAndEnqueue(q, evt.ObjectNew)
 }
 
 // Delete implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, MapObject{Object: evt.Object})
+	e.mapAndEnqueue(q, evt.Object)
 }
 
 // Generic implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, MapObject{Object: evt.Object})
+	e.mapAndEnqueue(q, evt.Object)
 }
 
-func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object MapObject) {
+func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object client.Object) {
 	for _, req := range e.toRequests(object) {
 		q.Add(req)
 	}
@@ -86,9 +86,4 @@ func (e *enqueueRequestsFromMapFunc) InjectFunc(f inject.Func) error {
 		return nil
 	}
 	return f(e.toRequests)
-}
-
-// MapObject contains information from an event to be transformed into a Request.
-type MapObject struct {
-	Object client.Object
 }

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -1,17 +1,17 @@
 /*
-Copyright 2018 The Kubernetes Authors.
+	Copyright 2018 The Kubernetes Authors.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+			http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
 */
 
 package handler_test
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -191,9 +192,9 @@ var _ = Describe("Eventhandler", func() {
 	Describe("EnqueueRequestsFromMapFunc", func() {
 		It("should enqueue a Request with the function applied to the CreateEvent.", func() {
 			req := []reconcile.Request{}
-			instance := handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+			instance := handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
-				Expect(a.Object).To(Equal(pod))
+				Expect(a).To(Equal(pod))
 				req = []reconcile.Request{
 					{
 						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"},
@@ -222,9 +223,9 @@ var _ = Describe("Eventhandler", func() {
 
 		It("should enqueue a Request with the function applied to the DeleteEvent.", func() {
 			req := []reconcile.Request{}
-			instance := handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+			instance := handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
-				Expect(a.Object).To(Equal(pod))
+				Expect(a).To(Equal(pod))
 				req = []reconcile.Request{
 					{
 						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"},
@@ -259,14 +260,14 @@ var _ = Describe("Eventhandler", func() {
 
 				req := []reconcile.Request{}
 
-				instance := handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+				instance := handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 					defer GinkgoRecover()
 					req = []reconcile.Request{
 						{
-							NamespacedName: types.NamespacedName{Namespace: "foo", Name: a.Object.GetName() + "-bar"},
+							NamespacedName: types.NamespacedName{Namespace: "foo", Name: a.GetName() + "-bar"},
 						},
 						{
-							NamespacedName: types.NamespacedName{Namespace: "biz", Name: a.Object.GetName() + "-baz"},
+							NamespacedName: types.NamespacedName{Namespace: "biz", Name: a.GetName() + "-baz"},
 						},
 					}
 					return req
@@ -298,9 +299,9 @@ var _ = Describe("Eventhandler", func() {
 
 		It("should enqueue a Request with the function applied to the GenericEvent.", func() {
 			req := []reconcile.Request{}
-			instance := handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+			instance := handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
-				Expect(a.Object).To(Equal(pod))
+				Expect(a).To(Equal(pod))
 				req = []reconcile.Request{
 					{
 						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"},

--- a/pkg/handler/example_test.go
+++ b/pkg/handler/example_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -65,15 +66,15 @@ func ExampleEnqueueRequestsFromMapFunc() {
 	// controller is a controller.controller
 	err := c.Watch(
 		&source.Kind{Type: &appsv1.Deployment{}},
-		handler.EnqueueRequestsFromMapFunc(func(a handler.MapObject) []reconcile.Request {
+		handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 			return []reconcile.Request{
 				{NamespacedName: types.NamespacedName{
-					Name:      a.Object.GetName() + "-1",
-					Namespace: a.Object.GetNamespace(),
+					Name:      a.GetName() + "-1",
+					Namespace: a.GetNamespace(),
 				}},
 				{NamespacedName: types.NamespacedName{
-					Name:      a.Object.GetName() + "-2",
-					Namespace: a.Object.GetNamespace(),
+					Name:      a.GetName() + "-2",
+					Namespace: a.GetNamespace(),
 				}},
 			}
 		}),


### PR DESCRIPTION
We updated the handlers MapObject type to not include a metav1.Object
and a runtime.Object representation of the same object but instead a
client.Object, which is a union of the two above.

The only reason for the MapObject type to exist in the first place
though was to hold these two fields. Now that there is only the
client.Object left, we can use that directly and get rid of the
MapObject type.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
