### PR TITLE
:sparkles: Allow passing the assets path bin via the env config

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -62,14 +62,22 @@ const (
 	defaultKubebuilderControlPlaneStopTimeout  = 20 * time.Second
 )
 
-// Default binary path for test framework
-func defaultAssetPath(binary string) string {
-	assetPath := os.Getenv(envKubebuilderPath)
-	if assetPath == "" {
-		assetPath = defaultKubebuilderPath
+// getBinAssetPath returns a path for binary from the following list of locations,
+// ordered by precedence:
+// 0. KUBEBUILDER_ASSETS
+// 1. Environment.BinaryAssetsDirectory
+// 2. The default path, "/usr/local/kubebuilder/bin"
+func (te *Environment) getBinAssetPath(binary string) string {
+	valueFromEnvVar := os.Getenv(envKubebuilderPath)
+	if valueFromEnvVar != "" {
+		return filepath.Join(valueFromEnvVar, binary)
 	}
-	return filepath.Join(assetPath, binary)
 
+	if te.BinaryAssetsDirectory != "" {
+		return filepath.Join(te.BinaryAssetsDirectory, binary)
+	}
+
+	return filepath.Join(defaultKubebuilderPath, binary)
 }
 
 // ControlPlane is the re-exported ControlPlane type from the internal integration package
@@ -112,6 +120,10 @@ type Environment struct {
 	// If both this field and Paths field in CRDInstallOptions are specified, the
 	// values are merged.
 	CRDDirectoryPaths []string
+
+	// BinaryAssetsDirectory is the path where the binaries required for the envtest are
+	// located in the local environment. This field can be overridden by setting KUBEBUILDER_ASSETS.
+	BinaryAssetsDirectory string
 
 	// UseExisting indicates that this environments should use an
 	// existing kubeconfig, instead of trying to stand up a new control plane.
@@ -217,14 +229,14 @@ func (te *Environment) Start() (*rest.Config, error) {
 		}
 
 		if os.Getenv(envKubeAPIServerBin) == "" {
-			te.ControlPlane.APIServer.Path = defaultAssetPath("kube-apiserver")
+			te.ControlPlane.APIServer.Path = te.getBinAssetPath("kube-apiserver")
 		}
 		if os.Getenv(envEtcdBin) == "" {
-			te.ControlPlane.Etcd.Path = defaultAssetPath("etcd")
+			te.ControlPlane.Etcd.Path = te.getBinAssetPath("etcd")
 		}
 		if os.Getenv(envKubectlBin) == "" {
 			// we can't just set the path manually (it's behind a function), so set the environment variable instead
-			if err := os.Setenv(envKubectlBin, defaultAssetPath("kubectl")); err != nil {
+			if err := os.Setenv(envKubectlBin, te.getBinAssetPath("kubectl")); err != nil {
 				return nil, err
 			}
 		}


### PR DESCRIPTION
**Description**
- Allow passing the assets path bin via the env config

```go
        By("bootstrapping test environment")
	testEnv = &envtest.Environment{
		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
                BinaryAssetsDirectory: "filepath.Join("..", "bin")" // See here
	}
```

The priority here is: 


0. the specific envvars for each binary: `TEST_ASSET_KUBE_APISERVER`, `TEST_ASSET_ETCD`, `TEST_ASSET_KUBECTL`
1. the path for all env var: `KUBEBUILDER_ASSETS `
2. the value set via the structure in this case `Environment{}` 
3. the default value which is currently `/usr/local/kubebuilder/bin`


**Motivation**

Allow passing the bin path to simplify the required implementation to config the EnvTest when the bin is not in the default path. Currently, if a developer would like to try to get the bins from a specific dir if they exist would be required an implementation such as: 

```go
var _ = BeforeSuite(func(done Done) {
	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))

	By("bootstrapping test environment")
	testEnv = &envtest.Environment{
		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
	}

	By("configuring env test binaries")
	configEnvTestBinaries()

	var err error
	cfg, err = testEnv.Start()
	Expect(err).ToNot(HaveOccurred())
	Expect(cfg).ToNot(BeNil())

	err = crewv1.AddToScheme(scheme.Scheme)
	Expect(err).NotTo(HaveOccurred())

	// +kubebuilder:scaffold:scheme

	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
	Expect(err).ToNot(HaveOccurred())
	Expect(k8sClient).ToNot(BeNil())

	close(done)
}, 60)

var _ = AfterSuite(func() {
	By("tearing down the test environment")
	err := testEnv.Stop()
	Expect(err).ToNot(HaveOccurred())
})

// configEnvTestBinaries will check if the required binaries are in the bin directory
// of the project and configure to use them.
func configEnvTestBinaries() {
	binPath := filepath.Join("..", "..", "bin")
	if hasEnvTestBinaries(binPath) {
		os.Setenv("KUBEBUILDER_ASSETS", binPath)
	}
}

// hasEnvTestBinaries will return true when the kubebuilder tools binaries are found
// in the path informed
func hasEnvTestBinaries(path string) bool {
	if _, err := os.Stat(path); os.IsNotExist(err) {
		return false
	}
	if _, err := os.Stat(filepath.Join(path, "etcd")); os.IsNotExist(err) {
		return false
	}
	if _, err := os.Stat(filepath.Join(path, "kube-apiserver")); os.IsNotExist(err) {
		return false
	}
	if _, err := os.Stat(filepath.Join(path, "kubectl")); os.IsNotExist(err) {
		return false
	}
	return true
}
```

With this change we can just:

```go
var _ = BeforeSuite(func(done Done) {
	logf.SetLogger(zap.LoggerTo(GinkgoWriter, true))

	By("bootstrapping test environment")
	testEnv = &envtest.Environment{
		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
                BinaryAssetsDirectory: "filepath.Join("..", "bin")" // See here
	}

	var err error
	cfg, err = testEnv.Start()
	Expect(err).ToNot(HaveOccurred())
	Expect(cfg).ToNot(BeNil())

	err = crewv1.AddToScheme(scheme.Scheme)
	Expect(err).NotTo(HaveOccurred())

	// +kubebuilder:scaffold:scheme

	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
	Expect(err).ToNot(HaveOccurred())
	Expect(k8sClient).ToNot(BeNil())

	close(done)
}, 60)

var _ = AfterSuite(func() {
	By("tearing down the test environment")
	err := testEnv.Stop()
	Expect(err).ToNot(HaveOccurred())
})
```
