### PR TITLE
:warning: client.ObjectKeyFromObject now uses client.Client

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -30,12 +30,8 @@ import (
 type ObjectKey = types.NamespacedName
 
 // ObjectKeyFromObject returns the ObjectKey given a runtime.Object
-func ObjectKeyFromObject(obj runtime.Object) (ObjectKey, error) {
-	accessor, err := meta.Accessor(obj)
-	if err != nil {
-		return ObjectKey{}, err
-	}
-	return ObjectKey{Namespace: accessor.GetNamespace(), Name: accessor.GetName()}, nil
+func ObjectKeyFromObject(obj Object) ObjectKey {
+	return ObjectKey{Namespace: obj.GetNamespace(), Name: obj.GetName()}
 }
 
 // Patch is a patch that can be applied to a Kubernetes object.

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -195,11 +195,7 @@ const ( // They should complete the sentence "Deployment default/foo has been ..
 //
 // It returns the executed operation and an error.
 func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f MutateFn) (OperationResult, error) {
-	key, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return OperationResultNone, err
-	}
-
+	key := client.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {
 		if !errors.IsNotFound(err) {
 			return OperationResultNone, err
@@ -236,11 +232,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f M
 //
 // It returns the executed operation and an error.
 func CreateOrPatch(ctx context.Context, c client.Client, obj client.Object, f MutateFn) (OperationResult, error) {
-	key, err := client.ObjectKeyFromObject(obj)
-	if err != nil {
-		return OperationResultNone, err
-	}
-
+	key := client.ObjectKeyFromObject(obj)
 	if err := c.Get(ctx, key, obj); err != nil {
 		if !errors.IsNotFound(err) {
 			return OperationResultNone, err
@@ -331,11 +323,11 @@ func CreateOrPatch(ctx context.Context, c client.Client, obj client.Object, f Mu
 }
 
 // mutate wraps a MutateFn and applies validation to its result
-func mutate(f MutateFn, key client.ObjectKey, obj runtime.Object) error {
+func mutate(f MutateFn, key client.ObjectKey, obj client.Object) error {
 	if err := f(); err != nil {
 		return err
 	}
-	if newKey, err := client.ObjectKeyFromObject(obj); err != nil || key != newKey {
+	if newKey := client.ObjectKeyFromObject(obj); key != newKey {
 		return fmt.Errorf("MutateFn cannot mutate object name and/or object namespace")
 	}
 	return nil


### PR DESCRIPTION
This change removes the need to get an accessor from the runtime object,
because the object interface already has all the information needed.

It also removes the need to return an error, which makes it a little
easier to use.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

/assign @alvaroaleman 
/milestone v0.7.x
