### PR TITLE
:book: Improve docs for manager.Options.SyncPeriod

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -140,6 +140,8 @@ type Options struct {
 	// there will a 10 percent jitter between the SyncPeriod of all controllers
 	// so that all controllers will not send list requests simultaneously.
 	//
+	// This applies to all controllers.
+	//
 	// A period sync happens for two reasons:
 	// 1. To insure against a bug in the controller that causes an object to not
 	// be requeued, when it otherwise should be requeued.

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -145,7 +145,7 @@ type Options struct {
 	// A period sync happens for two reasons:
 	// 1. To insure against a bug in the controller that causes an object to not
 	// be requeued, when it otherwise should be requeued.
-	// 2. To insure against a bug in controller-runtime, or its dependencies,
+	// 2. To insure against an unknown bug in controller-runtime, or its dependencies,
 	// that causes an object to not be requeued, when it otherwise should be
 	// requeued, or to be removed from the queue, when it otherwise should not
 	// be removed.

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -139,6 +139,23 @@ type Options struct {
 	// value only if you know what you are doing. Defaults to 10 hours if unset.
 	// there will a 10 percent jitter between the SyncPeriod of all controllers
 	// so that all controllers will not send list requests simultaneously.
+	//
+	// A period sync happens for two reasons:
+	// 1. To insure against a bug in the controller that causes an object to not
+	// be requeued, when it otherwise should be requeued.
+	// 2. To insure against a bug in controller-runtime, or its dependencies,
+	// that causes an object to not be requeued, when it otherwise should be
+	// requeued, or to be removed from the queue, when it otherwise should not
+	// be removed.
+	//
+	// If you want
+	// 1. to insure against missed watch events, or
+	// 2. to poll services that cannot be watched,
+	// then we recommend that, instead of changing the default period, the
+	// controller requeue, with a constant duration `t`, whenever the controller
+	// is "done" with an object, and would otherwise not requeue it, i.e., we
+	// recommend the `Reconcile` function return `reconcile.Result{RequeueAfter: t}`,
+	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
 	// Logger is the logger that should be used by this manager.


### PR DESCRIPTION
The comment tries to capture more of the thoughts exchanged in #88.

It explains why a period sync happens. It also addresses two (common?) reasons for making the period shorter, and recommends an alternative.

The current comment includes this warning: "Change this value only if you know what you are doing." I found this unsatisfying, and wanted to add more context to the comment. I'm not an authority on the behavior/history of `SyncPeriod`, and I welcome feedback :slightly_smiling_face:.