### PR TITLE
🐛 Fix use of `UnstructuredList` with unregistered typed

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -213,7 +213,7 @@ func (c *client) Get(ctx context.Context, key ObjectKey, obj Object) error {
 // List implements client.Client
 func (c *client) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
 	switch obj.(type) {
-	case *unstructured.Unstructured:
+	case *unstructured.UnstructuredList:
 		return c.unstructuredClient.List(ctx, obj, opts...)
 	case *metav1.PartialObjectMetadataList:
 		return c.metadataClient.List(ctx, obj, opts...)


### PR DESCRIPTION
Before this change, passing an `unstructured.UnstructuredList` to
`client.List()` would erroneously delegate to the typed client, causing an error
if the target type isn't registered with the client's scheme, violating the
purpose of using `unstructured`.

This patch fixes the client so that the `unstructured.UnstructuredList` is
delegated to the internal unstructured client.
