### PR TITLE
:book: fix minor typo for the GracefulShutdownTimeout field comments

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -254,7 +254,7 @@ type Options struct {
 	// GracefulShutdownTimeout is the duration given to runnable to stop before the manager actually returns on stop.
 	// To disable graceful shutdown, set to time.Duration(0)
 	// To use graceful shutdown without timeout, set to a negative duration, e.G. time.Duration(-1)
-	// The graceful shutdown is skipped for safety reasons in case the leadere election lease is lost.
+	// The graceful shutdown is skipped for safety reasons in case the leader election lease is lost.
 	GracefulShutdownTimeout *time.Duration
 
 	// makeBroadcaster allows deferring the creation of the broadcaster to


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Related to https://github.com/kubernetes-sigs/controller-runtime/issues/1185

This PR is really a very minor fix, just a typo in the `manager.go` file comments.
