### PR TITLE
 🌱 Use lowercase space separated keys

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -128,7 +128,7 @@ var (
 	// LoggerFrom returns a logger with predefined values from a context.Context.
 	// The logger, when used with controllers, can be expected to contain basic information about the object
 	// that's being reconciled like:
-	// - `reconcilerGroup` and `reconcilerKind` coming from the For(...) object passed in when building a controller.
+	// - `reconciler group` and `reconciler kind` coming from the For(...) object passed in when building a controller.
 	// - `name` and `namespace` injected from the reconciliation request.
 	//
 	// This is meant to be used with the context supplied in a struct that satisfies the Reconciler interface.

--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -293,7 +293,7 @@ func (blder *Builder) doController(r reconcile.Reconciler) error {
 	if ctrlOptions.Log == nil {
 		ctrlOptions.Log = blder.mgr.GetLogger()
 	}
-	ctrlOptions.Log = ctrlOptions.Log.WithValues("reconcilerGroup", gvk.Group, "reconcilerKind", gvk.Kind)
+	ctrlOptions.Log = ctrlOptions.Log.WithValues("reconciler group", gvk.Group, "reconciler kind", gvk.Kind)
 
 	// Build the controller and return.
 	blder.ctrl, err = newController(blder.getControllerName(gvk), blder.mgr, ctrlOptions)


### PR DESCRIPTION
Change built-in logging keys to be consistent with https://github.com/kubernetes-sigs/controller-runtime/blob/master/TMP-LOGGING.md#logging-structured-values-key-value-pairs

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
