### PR TITLE
:sparkles: Allow to use builder.OnlyMetadata option with Watches

### DIFF
--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -94,6 +94,11 @@ func (p projectAs) ApplyToOwns(opts *OwnsInput) {
 	opts.objectProjection = objectProjection(p)
 }
 
+// ApplyToWatches applies this configuration to the given WatchesInput options.
+func (p projectAs) ApplyToWatches(opts *WatchesInput) {
+	opts.objectProjection = objectProjection(p)
+}
+
 var (
 	// OnlyMetadata tells the controller to *only* cache metadata, and to watch
 	// the the API server in metadata-only form.  This is useful when watching
@@ -104,8 +109,9 @@ var (
 	// unstructured cache.
 	OnlyMetadata = projectAs(projectAsMetadata)
 
-	_ ForOption  = OnlyMetadata
-	_ OwnsOption = OnlyMetadata
+	_ ForOption     = OnlyMetadata
+	_ OwnsOption    = OnlyMetadata
+	_ WatchesOption = OnlyMetadata
 )
 
 // }}}


### PR DESCRIPTION
This change allows builders to use builder.OnlyMetadata when creating
extra watches with .Watches(...). The code inspects the passed
source.Source, and if it's of type *source.Kind, it calls the internal
project method that allows to use metav1.PartialObjectMetadata in
mapping functions.

/assign @alvaroaleman @DirectXMan12 
/milestone v0.7.x
