### PR TITLE
✨ ComponentConfig alias for cfg.File()

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	cfg "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -90,6 +91,11 @@ var (
 	//
 	// * $HOME/.kube/config if exists
 	GetConfig = config.GetConfig
+
+	// ConfigFile returns the cfg.File function for deferred config file loading,
+	// this is passed into Options{}.From() to populate the Options fields for
+	// the manager.
+	ConfigFile = cfg.File
 
 	// NewControllerManagedBy returns a new controller builder that will be started by the provided Manager
 	NewControllerManagedBy = builder.ControllerManagedBy


### PR DESCRIPTION
This adds an alias for using ComponentConfig deferred file loader. This also helps to keep the same number of imports in `main.go` while configuring https://github.com/kubernetes-sigs/kubebuilder/issues/722

Closes #1243 

Signed-off-by: Chris Hein <me@chrishein.com>