### PR TITLE
 🌱 Add back error logging for Reconcile implementation

### DIFF
--- a/TMP-LOGGING.md
+++ b/TMP-LOGGING.md
@@ -90,6 +90,9 @@ It's acceptable to log call `log.Error` with a nil error object.  This
 conveys that an error occurred in some capacity, but that no actual
 `error` object was involved.
 
+Errors returned by the `Reconcile` implementation of the `Reconciler` interface are commonly logged as a `Reconciler error`.
+It's a developer choice to create an additional error log in the `Reconcile` implementation so a more specific file name and line for the error are returned. 
+
 ## Logging messages
 
 - Don't put variable content in your messages -- use key-value pairs for

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -264,6 +264,7 @@ func (c *Controller) reconcileHandler(ctx context.Context, obj interface{}) {
 		c.Queue.AddRateLimited(req)
 		ctrlmetrics.ReconcileErrors.WithLabelValues(c.Name).Inc()
 		ctrlmetrics.ReconcileTotal.WithLabelValues(c.Name, "error").Inc()
+		log.Error(err, "Reconciler error")
 		return
 	} else if result.RequeueAfter > 0 {
 		// The result.RequeueAfter request will be lost, if it is returned


### PR DESCRIPTION
This https://github.com/kubernetes-sigs/controller-runtime/pull/1054/files#diff-3f86588ef108e53ef346d3223ca106ccaa8efe72cb1055489665d7675f3da7b4R242 degaded the log level for the Reconcile implementation.

Then this completely remove the error logging https://github.com/kubernetes-sigs/controller-runtime/pull/1096/files#diff-3f86588ef108e53ef346d3223ca106ccaa8efe72cb1055489665d7675f3da7b4L242

When developing new controllers feels counterintuitive that controller runtime eats the error returned by the Reconcile implementation.

This proposes to log the error and let developers to create an additional log in the implementation if they choose to.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
