### PR TITLE
✨ rename GetControllerManagerConfiguration to Complete

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,8 +32,8 @@ import (
 type ControllerManagerConfiguration interface {
 	runtime.Object
 
-	// GetControllerManagerConfiguration returns the versioned configuration
-	GetControllerManagerConfiguration() (v1alpha1.ControllerManagerConfigurationSpec, error)
+	// Complete returns the versioned configuration
+	Complete() (v1alpha1.ControllerManagerConfigurationSpec, error)
 }
 
 // DeferredFileLoader is used to configure the decoder for loading controller
@@ -62,13 +62,13 @@ func File() *DeferredFileLoader {
 	}
 }
 
-// GetControllerManagerConfiguration will use sync.Once to set the scheme
-func (d *DeferredFileLoader) GetControllerManagerConfiguration() (v1alpha1.ControllerManagerConfigurationSpec, error) {
+// Complete will use sync.Once to set the scheme
+func (d *DeferredFileLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) {
 	d.once.Do(d.loadFile)
 	if d.err != nil {
 		return v1alpha1.ControllerManagerConfigurationSpec{}, d.err
 	}
-	return d.ControllerManagerConfiguration.GetControllerManagerConfiguration()
+	return d.ControllerManagerConfiguration.Complete()
 }
 
 // AtPath will set the path to load the file for the decoder

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,7 +28,7 @@ var _ = Describe("config", func() {
 
 		It("should error loading from non existent file", func() {
 			loader := config.File()
-			_, err := loader.GetControllerManagerConfiguration()
+			_, err := loader.Complete()
 			Expect(err).ToNot(BeNil())
 		})
 
@@ -37,7 +37,7 @@ var _ = Describe("config", func() {
 			loader := config.File().AtPath("./testdata/config.yaml").OfKind(&conf)
 			Expect(conf.CacheNamespace).To(Equal(""))
 
-			_, err := loader.GetControllerManagerConfiguration()
+			_, err := loader.Complete()
 			Expect(err).To(BeNil())
 
 			Expect(*conf.LeaderElection.LeaderElect).To(Equal(true))

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -32,12 +32,12 @@ func init() {
 	_ = v1alpha1.AddToScheme(scheme)
 }
 
-// This example will load a file using GetControllerManagerConfiguration with only
+// This example will load a file using Complete with only
 // defaults set.
 func ExampleFile() {
 	// This will load a config file from ./config.yaml
 	loader := config.File()
-	_, err := loader.GetControllerManagerConfiguration()
+	_, err := loader.Complete()
 	if err != nil {
 		fmt.Println("failed to load config")
 		os.Exit(1)
@@ -47,7 +47,7 @@ func ExampleFile() {
 // This example will load the file from a custom path
 func ExampleDeferredFileLoader_atPath() {
 	loader := config.File().AtPath("/var/run/controller-runtime/config.yaml")
-	_, err := loader.GetControllerManagerConfiguration()
+	_, err := loader.Complete()
 	if err != nil {
 		fmt.Println("failed to load config")
 		os.Exit(1)
@@ -63,7 +63,7 @@ func ExampleDeferredFileLoader_injectScheme() {
 		os.Exit(1)
 	}
 
-	_, err = loader.GetControllerManagerConfiguration()
+	_, err = loader.Complete()
 	if err != nil {
 		fmt.Println("failed to load config")
 		os.Exit(1)
@@ -78,7 +78,7 @@ func ExampleDeferredFileLoader_ofKind() {
 		fmt.Println("failed to inject scheme")
 		os.Exit(1)
 	}
-	_, err = loader.GetControllerManagerConfiguration()
+	_, err = loader.Complete()
 	if err != nil {
 		fmt.Println("failed to load config")
 		os.Exit(1)

--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -121,7 +121,7 @@ type ControllerManagerConfiguration struct {
 	ControllerManagerConfigurationSpec `json:",inline"`
 }
 
-// GetControllerManagerConfiguration returns the configuration for controller-runtime
-func (c *ControllerManagerConfigurationSpec) GetControllerManagerConfiguration() (ControllerManagerConfigurationSpec, error) {
+// Complete returns the configuration for controller-runtime
+func (c *ControllerManagerConfigurationSpec) Complete() (ControllerManagerConfigurationSpec, error) {
 	return *c, nil
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -416,7 +416,7 @@ func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options,
 		}
 	}
 
-	newObj, err := loader.GetControllerManagerConfiguration()
+	newObj, err := loader.Complete()
 	if err != nil {
 		return o, err
 	}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1610,7 +1610,7 @@ type fakeDeferredLoader struct {
 	*v1alpha1.ControllerManagerConfiguration
 }
 
-func (f *fakeDeferredLoader) GetControllerManagerConfiguration() (v1alpha1.ControllerManagerConfigurationSpec, error) {
+func (f *fakeDeferredLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) {
 	return f.ControllerManagerConfiguration.ControllerManagerConfigurationSpec, nil
 }
 


### PR DESCRIPTION
This is a breaking change for an unreleased feature that will be rolled out in `0.7.0`. This renames `loader.GetControllerManagerConfiguration()` to `loader.Complete()`.

Fixes #1252

Signed-off-by: Chris Hein <me@chrishein.com>
