### PR TITLE
:sparkles: hack/setup-envtest.sh: install binaries and print export variable command

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -20,16 +20,12 @@ set -o pipefail
 
 hack_dir=$(dirname ${BASH_SOURCE})
 source ${hack_dir}/common.sh
-source ${hack_dir}/setup-envtest.sh
 
-tmp_root=/tmp
-kb_root_dir=$tmp_root/kubebuilder
+kb_root_dir=/tmp/kubebuilder/bin
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.16.4"}
-
-fetch_envtest_tools "$kb_root_dir"
-fetch_envtest_tools "${hack_dir}/../pkg/internal/testing/integration/assets"
-setup_envtest_env "$kb_root_dir"
+${hack_dir}/setup-envtest.sh "$kb_root_dir" >/dev/null
+${hack_dir}/setup-envtest.sh "${hack_dir}/../pkg/internal/testing/integration/assets/bin" >/dev/null
+export KUBEBUILDER_ASSETS="${kb_root_dir}"
 
 ${hack_dir}/verify.sh
 ${hack_dir}/test-all.sh

--- a/hack/setup-envtest.sh
+++ b/hack/setup-envtest.sh
@@ -14,83 +14,51 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-set -o errexit
-set -o pipefail
-
-# Turn colors in this script off by setting the NO_COLOR variable in your
-# environment to any value:
-#
-# $ NO_COLOR=1 test.sh
-NO_COLOR=${NO_COLOR:-""}
-if [ -z "$NO_COLOR" ]; then
-  header=$'\e[1;33m'
-  reset=$'\e[0m'
-else
-  header=''
-  reset=''
-fi
-
-function header_text {
-  echo "$header$*$reset"
+function get_dest_dir() {
+  echo "$(realpath -m ${1:-"bin"})"
 }
 
-function setup_envtest_env {
-  header_text "setting up env vars"
-
-  # Setup env vars
-  KUBEBUILDER_ASSETS=${KUBEBUILDER_ASSETS:-""}
-  if [[ -z "${KUBEBUILDER_ASSETS}" ]]; then
-    export KUBEBUILDER_ASSETS=$1/bin
-  fi
-}
-
-# fetch k8s API gen tools and make it available under envtest_root_dir/bin.
-#
-# Skip fetching and untaring the tools by setting the SKIP_FETCH_TOOLS variable
-# in your environment to any value:
-#
-# $ SKIP_FETCH_TOOLS=1 ./check-everything.sh
-#
-# If you skip fetching tools, this script will use the tools already on your
-# machine.
+# fetch k8s API gen tools and make it available under $1.
 function fetch_envtest_tools {
-  SKIP_FETCH_TOOLS=${SKIP_FETCH_TOOLS:-""}
-  if [ -n "$SKIP_FETCH_TOOLS" ]; then
-    return 0
-  fi
-
-  tmp_root=/tmp
-  envtest_root_dir=$tmp_root/envtest
-
-  k8s_version="${ENVTEST_K8S_VERSION:-1.16.4}"
-  goarch="$(go env GOARCH)"
-  goos="$(go env GOOS)"
+  local dest_dir="$(get_dest_dir $1)"
+  local archive_cache_dir=/tmp/envtest
+  local k8s_version="${ENVTEST_K8S_VERSION:-1.16.4}"
+  local goarch="$(go env GOARCH)"
+  local goos="$(go env GOOS)"
 
   if [[ "$goos" != "linux" && "$goos" != "darwin" ]]; then
     echo "OS '$goos' not supported. Aborting." >&2
     return 1
   fi
 
-  local dest_dir="${1}"
-
   # use the pre-existing version in the temporary folder if it matches our k8s version
-  if [[ -x "${dest_dir}/bin/kube-apiserver" ]]; then
-    version=$("${dest_dir}"/bin/kube-apiserver --version)
+  if [[ -x "${dest_dir}/kube-apiserver" ]]; then
+    local version=$("${dest_dir}"/kube-apiserver --version)
     if [[ $version == *"${k8s_version}"* ]]; then
-      header_text "Using cached envtest tools from ${dest_dir}"
+      echo "# Using cached envtest tools from '${dest_dir}'"
       return 0
     fi
   fi
 
-  header_text "fetching envtest tools@${k8s_version} (into '${dest_dir}')"
-  envtest_tools_archive_name="kubebuilder-tools-$k8s_version-$goos-$goarch.tar.gz"
-  envtest_tools_download_url="https://storage.googleapis.com/kubebuilder-tools/$envtest_tools_archive_name"
+  echo "# Fetching envtest@${k8s_version} into '${dest_dir}'"
+  local archive_name="kubebuilder-tools-${k8s_version}-${goos}-${goarch}.tar.gz"
+  local url="https://storage.googleapis.com/kubebuilder-tools/${archive_name}"
 
-  envtest_tools_archive_path="$tmp_root/$envtest_tools_archive_name"
-  if [ ! -f $envtest_tools_archive_path ]; then
-    curl -sL ${envtest_tools_download_url} -o "$envtest_tools_archive_path"
+  local archive_path="$archive_cache_dir/$archive_name"
+  mkdir -p "$archive_cache_dir"
+  if [ ! -f $archive_path ]; then
+    curl -sSL ${url} -o "$archive_path"
   fi
 
   mkdir -p "${dest_dir}"
-  tar -C "${dest_dir}" --strip-components=1 -zvxf "$envtest_tools_archive_path"
+  tar -C "${dest_dir}" --strip-components=2 -zvxf "$archive_path" >/dev/null
 }
+
+set -o errexit
+set -o pipefail
+
+fetch_envtest_tools $@
+
+echo "# Run the following command to finish setting up your environment:"
+echo
+echo "export KUBEBUILDER_ASSETS=$(get_dest_dir $1)"


### PR DESCRIPTION
The current setup-envtest.sh script is a little clunky, since it contains a combination of global settings and functions, and your calling shell is expected to be bash. Instead, the script should only download the envtest binaries, then print what to do next (`export KUBEBUILDER_ASSETS=bin`). You can automatically do the next thing with

```sh
eval $(./setup-envtest.sh | tail -1)
```

Binaries are now installed into the argument directory directly instead of under `$1/bin`, which is more intuitive; the default is `$PWD/bin`.