### PR TITLE
✨ Support for using both an external control plane and automatic webhooks together

### DIFF
--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -61,7 +61,7 @@ var _ = BeforeSuite(func(done Done) {
 	// Prevent the metrics listener being created
 	metrics.DefaultBindAddress = "0"
 
-	webhook.DefaultPort, _, err = addr.Suggest()
+	webhook.DefaultPort, _, err = addr.Suggest("")
 	Expect(err).NotTo(HaveOccurred())
 
 	close(done)

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -67,6 +67,9 @@ type WebhookInstallOptions struct {
 	// CAData is the CA that can be used to trust the serving certificates in LocalServingCertDir.
 	LocalServingCAData []byte
 
+	// LocalServingHostExternalName is the hostname to use to reach the webhook server.
+	LocalServingHostExternalName string
+
 	// MaxTime is the max time to wait
 	MaxTime time.Duration
 
@@ -137,13 +140,19 @@ func modifyWebhook(webhook map[string]interface{}, caData []byte, hostPort strin
 }
 
 func (o *WebhookInstallOptions) generateHostPort() (string, error) {
-	port, host, err := addr.Suggest()
-	if err != nil {
-		return "", fmt.Errorf("unable to grab random port for serving webhooks on: %v", err)
+	if o.LocalServingPort == 0 {
+		port, host, err := addr.Suggest(o.LocalServingHost)
+		if err != nil {
+			return "", fmt.Errorf("unable to grab random port for serving webhooks on: %v", err)
+		}
+		o.LocalServingPort = port
+		o.LocalServingHost = host
 	}
-	o.LocalServingPort = port
-	o.LocalServingHost = host
-	return net.JoinHostPort(host, fmt.Sprintf("%d", port)), nil
+	host := o.LocalServingHostExternalName
+	if host == "" {
+		host = o.LocalServingHost
+	}
+	return net.JoinHostPort(host, fmt.Sprintf("%d", o.LocalServingPort)), nil
 }
 
 // PrepWithoutInstalling does the setup parts of Install (populating host-port,
@@ -266,7 +275,8 @@ func (o *WebhookInstallOptions) setupCA() ([]byte, error) {
 		return nil, fmt.Errorf("unable to set up webhook CA: %v", err)
 	}
 
-	hookCert, err := hookCA.NewServingCert()
+	names := []string{"localhost", o.LocalServingHost, o.LocalServingHostExternalName}
+	hookCert, err := hookCA.NewServingCert(names...)
 	if err != nil {
 		return nil, fmt.Errorf("unable to set up webhook serving certs: %v", err)
 	}

--- a/pkg/internal/testing/integration/addr/manager.go
+++ b/pkg/internal/testing/integration/addr/manager.go
@@ -38,8 +38,11 @@ var cache = &portCache{
 	ports: make(map[int]time.Time),
 }
 
-func suggest() (port int, resolvedHost string, err error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+func suggest(listenHost string) (port int, resolvedHost string, err error) {
+	if listenHost == "" {
+		listenHost = "localhost"
+	}
+	addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(listenHost, "0"))
 	if err != nil {
 		return
 	}
@@ -59,9 +62,9 @@ func suggest() (port int, resolvedHost string, err error) {
 // a tuple consisting of a free port and the hostname resolved to its IP.
 // It makes sure that new port allocated does not conflict with old ports
 // allocated within 1 minute.
-func Suggest() (port int, resolvedHost string, err error) {
+func Suggest(listenHost string) (port int, resolvedHost string, err error) {
 	for i := 0; i < portConflictRetry; i++ {
-		port, resolvedHost, err = suggest()
+		port, resolvedHost, err = suggest(listenHost)
 		if err != nil {
 			return
 		}

--- a/pkg/internal/testing/integration/addr/manager_test.go
+++ b/pkg/internal/testing/integration/addr/manager_test.go
@@ -12,10 +12,42 @@ import (
 
 var _ = Describe("SuggestAddress", func() {
 	It("returns a free port and an address to bind to", func() {
-		port, host, err := addr.Suggest()
+		port, host, err := addr.Suggest("")
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(host).To(Or(Equal("127.0.0.1"), Equal("::1")))
+		Expect(port).NotTo(Equal(0))
+
+		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		Expect(err).NotTo(HaveOccurred())
+		l, err := net.ListenTCP("tcp", addr)
+		defer func() {
+			Expect(l.Close()).To(Succeed())
+		}()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("supports an explicit listenHost", func() {
+		port, host, err := addr.Suggest("localhost")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(host).To(Or(Equal("127.0.0.1"), Equal("::1")))
+		Expect(port).NotTo(Equal(0))
+
+		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+		Expect(err).NotTo(HaveOccurred())
+		l, err := net.ListenTCP("tcp", addr)
+		defer func() {
+			Expect(l.Close()).To(Succeed())
+		}()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("supports a 0.0.0.0 listenHost", func() {
+		port, host, err := addr.Suggest("0.0.0.0")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(host).To(Equal("0.0.0.0"))
 		Expect(port).NotTo(Equal(0))
 
 		addr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort(host, strconv.Itoa(port)))

--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -105,7 +105,7 @@ func (s *APIServer) setProcessState() error {
 
 	// Defaulting the secure port
 	if s.SecurePort == 0 {
-		s.SecurePort, _, err = addr.Suggest()
+		s.SecurePort, _, err = addr.Suggest("")
 		if err != nil {
 			return err
 		}

--- a/pkg/internal/testing/integration/internal/process.go
+++ b/pkg/internal/testing/integration/internal/process.go
@@ -75,7 +75,7 @@ func DoDefaulting(
 	}
 
 	if listenURL == nil {
-		port, host, err := addr.Suggest()
+		port, host, err := addr.Suggest("")
 		if err != nil {
 			return DefaultedProcessInput{}, err
 		}

--- a/pkg/internal/testing/integration/internal/process_test.go
+++ b/pkg/internal/testing/integration/internal/process_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Start method", func() {
 				processState.HealthCheckEndpoint = healthURLPath
 				processState.StartTimeout = 500 * time.Millisecond
 
-				port, host, err := addr.Suggest()
+				port, host, err := addr.Suggest("")
 				Expect(err).NotTo(HaveOccurred())
 
 				processState.URL = url.URL{


### PR DESCRIPTION
This requires pre-filling LocalServingHost and possibly LocalServingExternalName with the right listen interface and external name so that the external control plane can reach the webhook server launched by envtest.

Using this successfully for local integration tests against kind and k3s. It does change some APIs but the only compat change is on addr.Suggest and that's explicitly an internal API so I think that's okay?