### PR TITLE
:seedling: Specify buckets for "controller_runtime_reconcile_time_seconds" histogram metrics

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -43,6 +43,8 @@ var (
 	ReconcileTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name: "controller_runtime_reconcile_time_seconds",
 		Help: "Length of time per reconciliation per controller",
+		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
+			1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
 	}, []string{"controller"})
 
 	// WorkerCount is a prometheus metric which holds the number of


### PR DESCRIPTION
The current metric uses Prometheus [default bucket](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#pkg-variables) for reconcile time histogram. This bucket is
not sufficient to reason about the percentile of requests which take less than x seconds when x falls outside
the bucket of 10 secs(current last bucket). It's also hard to infer when the reconcile loops are fairly fast, as mentioned in
this issue: kubernetes-sigs#258.

This PR attempts to define explicit buckets for the metrics, values are chosen based on the API-server
request latency defined here: https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go#L103.
The default Prometheus histogram buckets have also been added(wherever missing) to ensure backward compatibility.