### PR TITLE
:bug: Wait for metadata cache to sync

### DIFF
--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -73,6 +73,7 @@ func (m *InformersMap) Start(ctx context.Context) error {
 func (m *InformersMap) WaitForCacheSync(ctx context.Context) bool {
 	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
 	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)
+	syncedFuncs = append(syncedFuncs, m.metadata.HasSyncedFuncs()...)
 
 	if !m.structured.waitForStarted(ctx) {
 		return false


### PR DESCRIPTION
It seems we are missing a wait for cache sync function for the metadata cache. I think we should do to this cache whatever we do to the unstructured one

Descriptiveness check, begone!