### PR TITLE
:running: AddToProtobufScheme: Take AddToScheme, not Schemebulilder

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -50,10 +50,10 @@ func init() {
 
 // AddToProtobufScheme add the given SchemeBuilder into protobufScheme, which should
 // be additional types that do support protobuf.
-func AddToProtobufScheme(builder runtime.SchemeBuilder) error {
+func AddToProtobufScheme(addToScheme func(*runtime.Scheme) error) error {
 	protobufSchemeLock.Lock()
 	defer protobufSchemeLock.Unlock()
-	return builder.AddToScheme(protobufScheme)
+	return addToScheme(protobufScheme)
 }
 
 // NewDiscoveryRESTMapper constructs a new RESTMapper based on discovery


### PR DESCRIPTION
Depending on the API, the SchemeBuilder might not be exported. Since we
only care about its AddToScheme, take that as argument instead.

/assign @vincepri 
/cc @FillZpp 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
