### PR TITLE
✨ Backport release-0.5: Wait for metadata cache to sync

### DIFF
--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -73,6 +73,7 @@ func (m *InformersMap) Start(stop <-chan struct{}) error {
 func (m *InformersMap) WaitForCacheSync(stop <-chan struct{}) bool {
 	syncedFuncs := append([]cache.InformerSynced(nil), m.structured.HasSyncedFuncs()...)
 	syncedFuncs = append(syncedFuncs, m.unstructured.HasSyncedFuncs()...)
+	syncedFuncs = append(syncedFuncs, m.metadata.HasSyncedFuncs()...)
 
 	if !m.structured.waitForStarted(stop) {
 		return false


### PR DESCRIPTION
This PR backports the metadata cache sync fix, https://github.com/kubernetes-sigs/controller-runtime/pull/1276, to the release-0.5 branch in a non breaking change.
