### PR TITLE
:warning: pkg/webhook/admission: upgrade v1beta1 admission types to v1

### DIFF
--- a/pkg/webhook/admission/decode_test.go
+++ b/pkg/webhook/admission/decode_test.go
@@ -20,7 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -39,7 +39,7 @@ var _ = Describe("Admission Webhook Decoder", func() {
 	})
 
 	req := Request{
-		AdmissionRequest: admissionv1beta1.AdmissionRequest{
+		AdmissionRequest: admissionv1.AdmissionRequest{
 			Object: runtime.RawExtension{
 				Raw: []byte(`{
     "apiVersion": "v1",

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -27,10 +27,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	admissionv1 "k8s.io/api/admission/v1"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 var _ = Describe("Admission Webhooks", func() {
@@ -155,7 +155,7 @@ func (h *fakeHandler) Handle(ctx context.Context, req Request) Response {
 	if h.fn != nil {
 		return h.fn(ctx, req)
 	}
-	return Response{AdmissionResponse: admissionv1beta1.AdmissionResponse{
+	return Response{AdmissionResponse: admissionv1.AdmissionResponse{
 		Allowed: true,
 	}}
 }

--- a/pkg/webhook/admission/multi.go
+++ b/pkg/webhook/admission/multi.go
@@ -22,9 +22,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"gomodules.xyz/jsonpatch/v2"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
@@ -37,10 +38,10 @@ func (hs multiMutating) Handle(ctx context.Context, req Request) Response {
 		if !resp.Allowed {
 			return resp
 		}
-		if resp.PatchType != nil && *resp.PatchType != admissionv1beta1.PatchTypeJSONPatch {
+		if resp.PatchType != nil && *resp.PatchType != admissionv1.PatchTypeJSONPatch {
 			return Errored(http.StatusInternalServerError,
 				fmt.Errorf("unexpected patch type returned by the handler: %v, only allow: %v",
-					resp.PatchType, admissionv1beta1.PatchTypeJSONPatch))
+					resp.PatchType, admissionv1.PatchTypeJSONPatch))
 		}
 		patches = append(patches, resp.Patches...)
 	}
@@ -50,13 +51,13 @@ func (hs multiMutating) Handle(ctx context.Context, req Request) Response {
 		return Errored(http.StatusBadRequest, fmt.Errorf("error when marshaling the patch: %w", err))
 	}
 	return Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: true,
 			Result: &metav1.Status{
 				Code: http.StatusOK,
 			},
 			Patch:     marshaledPatch,
-			PatchType: func() *admissionv1beta1.PatchType { pt := admissionv1beta1.PatchTypeJSONPatch; return &pt }(),
+			PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
 		},
 	}
 }
@@ -94,7 +95,7 @@ func (hs multiValidating) Handle(ctx context.Context, req Request) Response {
 		}
 	}
 	return Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: true,
 			Result: &metav1.Status{
 				Code: http.StatusOK,

--- a/pkg/webhook/admission/multi_test.go
+++ b/pkg/webhook/admission/multi_test.go
@@ -22,15 +22,15 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gomodules.xyz/jsonpatch/v2"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 )
 
 var _ = Describe("Multi-Handler Admission Webhooks", func() {
 	alwaysAllow := &fakeHandler{
 		fn: func(ctx context.Context, req Request) Response {
 			return Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 				},
 			}
@@ -39,7 +39,7 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 	alwaysDeny := &fakeHandler{
 		fn: func(ctx context.Context, req Request) Response {
 			return Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: false,
 				},
 			}
@@ -82,9 +82,9 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 							Value:     "2",
 						},
 					},
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed:   true,
-						PatchType: func() *admissionv1beta1.PatchType { pt := admissionv1beta1.PatchTypeJSONPatch; return &pt }(),
+						PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
 					},
 				}
 			},
@@ -99,9 +99,9 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 							Value:     "world",
 						},
 					},
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed:   true,
-						PatchType: func() *admissionv1beta1.PatchType { pt := admissionv1beta1.PatchTypeJSONPatch; return &pt }(),
+						PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
 					},
 				}
 			},

--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -19,9 +19,8 @@ package admission
 import (
 	"net/http"
 
-	"gomodules.xyz/jsonpatch/v2"
-
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -50,7 +49,7 @@ func Patched(reason string, patches ...jsonpatch.JsonPatchOperation) Response {
 // Errored creates a new Response for error-handling a request.
 func Errored(code int32, err error) Response {
 	return Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: false,
 			Result: &metav1.Status{
 				Code:    code,
@@ -67,7 +66,7 @@ func ValidationResponse(allowed bool, reason string) Response {
 		code = http.StatusOK
 	}
 	resp := Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: allowed,
 			Result: &metav1.Status{
 				Code: int32(code),
@@ -90,9 +89,9 @@ func PatchResponseFromRaw(original, current []byte) Response {
 	}
 	return Response{
 		Patches: patches,
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed:   true,
-			PatchType: func() *admissionv1beta1.PatchType { pt := admissionv1beta1.PatchTypeJSONPatch; return &pt }(),
+			PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
 		},
 	}
 }
@@ -100,7 +99,7 @@ func PatchResponseFromRaw(original, current []byte) Response {
 // validationResponseFromStatus returns a response for admitting a request with provided Status object.
 func validationResponseFromStatus(allowed bool, status metav1.Status) Response {
 	resp := Response{
-		AdmissionResponse: admissionv1beta1.AdmissionResponse{
+		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: allowed,
 			Result:  &status,
 		},

--- a/pkg/webhook/admission/response_test.go
+++ b/pkg/webhook/admission/response_test.go
@@ -22,9 +22,9 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gomodules.xyz/jsonpatch/v2"
 
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -33,7 +33,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should return an 'allowed' response", func() {
 			Expect(Allowed("")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code: http.StatusOK,
@@ -46,7 +46,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should populate a status with a reason when a reason is given", func() {
 			Expect(Allowed("acceptable")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code:   http.StatusOK,
@@ -62,7 +62,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should return a 'not allowed' response", func() {
 			Expect(Denied("")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: false,
 						Result: &metav1.Status{
 							Code: http.StatusForbidden,
@@ -75,7 +75,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should populate a status with a reason when a reason is given", func() {
 			Expect(Denied("UNACCEPTABLE!")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: false,
 						Result: &metav1.Status{
 							Code:   http.StatusForbidden,
@@ -102,7 +102,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should return an 'allowed' response with the given patches", func() {
 			Expect(Patched("", ops...)).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code: http.StatusOK,
@@ -115,7 +115,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should populate a status with a reason when a reason is given", func() {
 			Expect(Patched("some changes", ops...)).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code:   http.StatusOK,
@@ -132,7 +132,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 		It("should return a denied response with an error", func() {
 			err := errors.New("this is an error")
 			expected := Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: false,
 					Result: &metav1.Status{
 						Code:    http.StatusBadRequest,
@@ -150,7 +150,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			By("checking that a message is populated for 'allowed' responses")
 			Expect(ValidationResponse(true, "acceptable")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code:   http.StatusOK,
@@ -163,7 +163,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			By("checking that a message is populated for 'denied' responses")
 			Expect(ValidationResponse(false, "UNACCEPTABLE!")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: false,
 						Result: &metav1.Status{
 							Code:   http.StatusForbidden,
@@ -178,7 +178,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			By("checking that it returns an 'allowed' response when allowed is true")
 			Expect(ValidationResponse(true, "")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result: &metav1.Status{
 							Code: http.StatusOK,
@@ -190,7 +190,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			By("checking that it returns an 'denied' response when allowed is false")
 			Expect(ValidationResponse(false, "")).To(Equal(
 				Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: false,
 						Result: &metav1.Status{
 							Code: http.StatusForbidden,
@@ -207,9 +207,9 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 				Patches: []jsonpatch.JsonPatchOperation{
 					{Operation: "replace", Path: "/a", Value: "bar"},
 				},
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed:   true,
-					PatchType: func() *admissionv1beta1.PatchType { pt := admissionv1beta1.PatchTypeJSONPatch; return &pt }(),
+					PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
 				},
 			}
 			resp := PatchResponseFromRaw([]byte(`{"a": "foo"}`), []byte(`{"a": "bar"}`))
@@ -220,7 +220,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 	Describe("WithWarnings", func() {
 		It("should add the warnings to the existing response without removing any existing warnings", func() {
 			initialResponse := Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result: &metav1.Status{
 						Code: http.StatusOK,
@@ -230,7 +230,7 @@ var _ = Describe("Admission Webhook Response Helpers", func() {
 			}
 			warnings := []string{"additional-warning-1", "additional-warning-2"}
 			expectedResponse := Response{
-				AdmissionResponse: admissionv1beta1.AdmissionResponse{
+				AdmissionResponse: admissionv1.AdmissionResponse{
 					Allowed: true,
 					Result: &metav1.Status{
 						Code: http.StatusOK,

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -18,11 +18,10 @@ package admission
 
 import (
 	"context"
+	goerrors "errors"
 	"net/http"
 
-	goerrors "errors"
-
-	"k8s.io/api/admission/v1beta1"
+	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -63,7 +62,7 @@ func (h *validatingHandler) Handle(ctx context.Context, req Request) Response {
 
 	// Get the object in the request
 	obj := h.validator.DeepCopyObject().(Validator)
-	if req.Operation == v1beta1.Create {
+	if req.Operation == v1.Create {
 		err := h.decoder.Decode(req, obj)
 		if err != nil {
 			return Errored(http.StatusBadRequest, err)
@@ -79,7 +78,7 @@ func (h *validatingHandler) Handle(ctx context.Context, req Request) Response {
 		}
 	}
 
-	if req.Operation == v1beta1.Update {
+	if req.Operation == v1.Update {
 		oldObj := obj.DeepCopyObject()
 
 		err := h.decoder.DecodeRaw(req.Object, obj)
@@ -101,7 +100,7 @@ func (h *validatingHandler) Handle(ctx context.Context, req Request) Response {
 		}
 	}
 
-	if req.Operation == v1beta1.Delete {
+	if req.Operation == v1.Delete {
 		// In reference to PR: https://github.com/kubernetes/kubernetes/pull/76346
 		// OldObject contains the object being deleted
 		err := h.decoder.DecodeRaw(req.OldObject, obj)

--- a/pkg/webhook/admission/validator_test.go
+++ b/pkg/webhook/admission/validator_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"k8s.io/api/admission/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -28,8 +28,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 200 in response when create succeeds", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Create,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -44,8 +44,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 200 in response when update succeeds", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Update,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -63,8 +63,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 200 in response when delete succeeds", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Delete,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -80,7 +80,7 @@ var _ = Describe("validatingHandler", func() {
 	Context("when dealing with Status errors", func() {
 
 		expectedError := &apierrs.StatusError{
-			ErrStatus: v1.Status{
+			ErrStatus: metav1.Status{
 				Message: "some message",
 				Code:    http.StatusUnprocessableEntity,
 			},
@@ -91,8 +91,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should propagate the Status from ValidateCreate's return value to the HTTP response", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Create,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -109,8 +109,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should propagate the Status from ValidateUpdate's return value to the HTTP response", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Update,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -131,8 +131,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should propagate the Status from ValidateDelete's return value to the HTTP response", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Delete,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -156,8 +156,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 403 response when ValidateCreate with error message embedded", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Create,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -173,8 +173,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Update,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,
@@ -194,8 +194,8 @@ var _ = Describe("validatingHandler", func() {
 		It("should return 403 response when ValidateDelete returns non-APIStatus error", func() {
 
 			response := handler.Handle(context.TODO(), Request{
-				AdmissionRequest: v1beta1.AdmissionRequest{
-					Operation: v1beta1.Delete,
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
 						Raw:    []byte("{}"),
 						Object: handler.validator,

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -22,8 +22,8 @@ import (
 	"net/http"
 
 	"github.com/go-logr/logr"
-	"gomodules.xyz/jsonpatch/v2"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
@@ -41,7 +41,7 @@ var (
 // name, namespace), as well as the operation in question
 // (e.g. Get, Create, etc), and the object itself.
 type Request struct {
-	admissionv1beta1.AdmissionRequest
+	admissionv1.AdmissionRequest
 }
 
 // Response is the output of an admission handler.
@@ -57,7 +57,7 @@ type Response struct {
 	Patches []jsonpatch.JsonPatchOperation
 	// AdmissionResponse is the raw admission response.
 	// The Patch field in it will be overwritten by the listed patches.
-	admissionv1beta1.AdmissionResponse
+	admissionv1.AdmissionResponse
 }
 
 // Complete populates any fields that are yet to be set in
@@ -84,7 +84,7 @@ func (r *Response) Complete(req Request) error {
 	if err != nil {
 		return err
 	}
-	patchType := admissionv1beta1.PatchTypeJSONPatch
+	patchType := admissionv1.PatchTypeJSONPatch
 	r.PatchType = &patchType
 
 	return nil

--- a/pkg/webhook/admission/webhook_test.go
+++ b/pkg/webhook/admission/webhook_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"gomodules.xyz/jsonpatch/v2"
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	machinerytypes "k8s.io/apimachinery/pkg/types"
@@ -38,7 +38,7 @@ var _ = Describe("Admission Webhooks", func() {
 		handler := &fakeHandler{
 			fn: func(ctx context.Context, req Request) Response {
 				return Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 					},
 				}
@@ -68,7 +68,7 @@ var _ = Describe("Admission Webhooks", func() {
 		webhook := allowHandler()
 
 		By("invoking the webhook")
-		resp := webhook.Handle(context.Background(), Request{AdmissionRequest: admissionv1beta1.AdmissionRequest{UID: "foobar"}})
+		resp := webhook.Handle(context.Background(), Request{AdmissionRequest: admissionv1.AdmissionRequest{UID: "foobar"}})
 
 		By("checking that the response share's the request's UID")
 		Expect(resp.UID).To(Equal(machinerytypes.UID("foobar")))
@@ -90,7 +90,7 @@ var _ = Describe("Admission Webhooks", func() {
 		webhook := &Webhook{
 			Handler: HandlerFunc(func(ctx context.Context, req Request) Response {
 				return Response{
-					AdmissionResponse: admissionv1beta1.AdmissionResponse{
+					AdmissionResponse: admissionv1.AdmissionResponse{
 						Allowed: true,
 						Result:  &metav1.Status{Message: "Ground Control to Major Tom"},
 					},
@@ -120,7 +120,7 @@ var _ = Describe("Admission Webhooks", func() {
 		resp := webhook.Handle(context.Background(), Request{})
 
 		By("checking that a JSON patch is populated on the response")
-		patchType := admissionv1beta1.PatchTypeJSONPatch
+		patchType := admissionv1.PatchTypeJSONPatch
 		Expect(resp.PatchType).To(Equal(&patchType))
 		Expect(resp.Patch).To(Equal([]byte(`[{"op":"add","path":"/a","value":2},{"op":"replace","path":"/b","value":4}]`)))
 	})


### PR DESCRIPTION
As per [this review](https://github.com/kubernetes-sigs/controller-runtime/pull/1233#pullrequestreview-534898408) on #1233:

>currently, v1 and v1beta1 are identical [...], which means that we can safely just deserialize v1beta1 into a v1 struct and call it a day, without the duplication

This PR captures the essence of that comment.