### PR TITLE
🐛 client.List should check on UnstructuredList, not Unstructured

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -198,7 +198,7 @@ func (c *client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) err
 // List implements client.Client
 func (c *client) List(ctx context.Context, obj runtime.Object, opts ...ListOption) error {
 	switch obj.(type) {
-	case *unstructured.Unstructured:
+	case *unstructured.UnstructuredList:
 		return c.unstructuredClient.List(ctx, obj, opts...)
 	case *metav1.PartialObjectMetadataList:
 		return c.metadataClient.List(ctx, obj, opts...)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

After adding the metadata only watch and client support, the List object
was type checking on `Unstructured` instead of `UnstructuredList`.

Now! "Why were the tests passing??" one might ask, it seems that even
though our tests had some using UnstructuredLists and querying against
List, the objects we were asking (appsv1/Deployments) are core objects
that are usually included in the default client-go scheme.Scheme.

For the above reason, the internal `typedClient` was able to make the
request to the API server and convert the list of object back to
UnstructuredList.

/milestone v0.5.x
