### PR TITLE
:bug: client.List should check on UnstructuredList, not Unstructured

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -198,7 +198,7 @@ func (c *client) Get(ctx context.Context, key ObjectKey, obj runtime.Object) err
 // List implements client.Client
 func (c *client) List(ctx context.Context, obj runtime.Object, opts ...ListOption) error {
 	switch obj.(type) {
-	case *unstructured.Unstructured:
+	case *unstructured.UnstructuredList:
 		return c.unstructuredClient.List(ctx, obj, opts...)
 	case *metav1.PartialObjectMetadataList:
 		return c.metadataClient.List(ctx, obj, opts...)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1681,6 +1681,36 @@ var _ = Describe("Client", func() {
 				close(done)
 			}, serverSideTimeoutSeconds)
 
+			It("should fetch unstructured collection of objects, even if scheme is empty", func(done Done) {
+				By("create an initial object")
+				_, err := clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("listing all objects of that type in the cluster")
+				deps := &unstructured.UnstructuredList{}
+				deps.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "apps",
+					Kind:    "DeploymentList",
+					Version: "v1",
+				})
+				err = cl.List(context.Background(), deps)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(deps.Items).NotTo(BeEmpty())
+				hasDep := false
+				for _, item := range deps.Items {
+					if item.GetName() == dep.Name && item.GetNamespace() == dep.Namespace {
+						hasDep = true
+						break
+					}
+				}
+				Expect(hasDep).To(BeTrue())
+				close(done)
+			}, serverSideTimeoutSeconds)
+
 			It("should return an empty list if there are no matching objects", func(done Done) {
 				cl, err := client.New(cfg, client.Options{})
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
After adding the metadata only watch and client support, the List object
was type checking on `Unstructured` instead of `UnstructuredList`.

Now! "Why were the tests passing??" one might ask, it seems that even
though our tests had some using UnstructuredLists and querying against
List, the objects we were asking (appsv1/Deployments) are core objects
that are usually included in the default client-go scheme.Scheme.

For the above reason, the internal `typedClient` was able to make the
request to the API server and convert the list of object back to
UnstructuredList.

/milestone v0.6.x
/assign @alvaroaleman @DirectXMan12 