### PR TITLE
🐛 Inject manager's logger instead of internal one

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -38,7 +38,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -58,7 +57,6 @@ const (
 )
 
 var _ Runnable = &controllerManager{}
-var log = logf.RuntimeLog.WithName("manager")
 
 type controllerManager struct {
 	// config is the rest.config used to talk to the apiserver.  Required.
@@ -251,7 +249,7 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 	if _, err := inject.MapperInto(cm.mapper, i); err != nil {
 		return err
 	}
-	if _, err := inject.LoggerInto(log, i); err != nil {
+	if _, err := inject.LoggerInto(cm.logger, i); err != nil {
 		return err
 	}
 	return nil
@@ -272,7 +270,7 @@ func (cm *controllerManager) AddMetricsExtraHandler(path string, handler http.Ha
 	}
 
 	cm.metricsExtraHandlers[path] = handler
-	log.V(2).Info("Registering metrics http server extra handler", "path", path)
+	cm.logger.V(2).Info("Registering metrics http server extra handler", "path", path)
 	return nil
 }
 
@@ -405,7 +403,7 @@ func (cm *controllerManager) serveMetrics() {
 	}
 	// Run the server
 	cm.startRunnable(RunnableFunc(func(_ context.Context) error {
-		log.Info("starting metrics server", "path", defaultMetricsEndpoint)
+		cm.logger.Info("starting metrics server", "path", defaultMetricsEndpoint)
 		if err := server.Serve(cm.metricsListener); err != nil && err != http.ErrServerClosed {
 			return err
 		}
@@ -546,7 +544,7 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 			select {
 			case err, ok := <-cm.errChan:
 				if ok {
-					log.Error(err, "error received after stop sequence was engaged")
+					cm.logger.Error(err, "error received after stop sequence was engaged")
 				}
 			case <-stopComplete:
 				return

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -38,9 +38,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -314,7 +314,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	// Create the mapper provider
 	mapper, err := options.MapperProvider(config)
 	if err != nil {
-		log.Error(err, "Failed to get API Group-Resources")
+		options.Logger.Error(err, "Failed to get API Group-Resources")
 		return nil, err
 	}
 
@@ -345,7 +345,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	// Create the recorder provider to inject event recorders for the components.
 	// TODO(directxman12): the log for the event provider should have a context (name, tags, etc) specific
 	// to the particular controller that it's being injected into, rather than a generic one like is here.
-	recorderProvider, err := options.newRecorderProvider(config, options.Scheme, log.WithName("events"), options.makeBroadcaster)
+	recorderProvider, err := options.newRecorderProvider(config, options.Scheme, options.Logger.WithName("events"), options.makeBroadcaster)
 	if err != nil {
 		return nil, err
 	}
@@ -599,7 +599,7 @@ func setOptionsDefaults(options Options) Options {
 	}
 
 	if options.Logger == nil {
-		options.Logger = logf.Log
+		options.Logger = logf.RuntimeLog.WithName("manager")
 	}
 
 	return options

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -40,11 +40,11 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	configv1alpha1 "k8s.io/component-base/config/v1alpha1"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
-
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 	fakeleaderelection "sigs.k8s.io/controller-runtime/pkg/leaderelection/fake"
@@ -1359,7 +1359,7 @@ var _ = Describe("manger.Manager", func() {
 				},
 				log: func(logger logr.Logger) error {
 					defer GinkgoRecover()
-					Expect(logger).To(Equal(log))
+					Expect(logger).To(Equal(logf.RuntimeLog.WithName("manager")))
 					return nil
 				},
 			})


### PR DESCRIPTION
Before this PR, the manager injected the controller-runtime-internal logger into controllers, predicates and so on, that implemented the `inject.Logger` interface. This means, controllers and so on were provided with a logger which name is set to `controller-runtime.manager`.

I found this behaviour to be confusing, especially if you provided the manager with a custom logger via `manager.Options.Logger` (e.g. with a different top-level name).

With this PR, the manager injects its own logger or the default one, if none is specified.