### PR TITLE
:bug: Cache bypass should take into account List types

### DIFF
--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -98,6 +99,11 @@ func (d *delegatingReader) shouldBypassCache(obj runtime.Object) (bool, error) {
 	gvk, err := apiutil.GVKForObject(obj, d.scheme)
 	if err != nil {
 		return false, err
+	}
+	// TODO: this is producing unsafe guesses that don't actually work,
+	// but it matches ~99% of the cases out there.
+	if meta.IsListType(obj) {
+		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 	}
 	_, isUncached := d.uncachedGVKs[gvk]
 	_, isUnstructured := obj.(*unstructured.Unstructured)


### PR DESCRIPTION
Currently, when we create a new delegating client and we force some
types to be uncached, we can only specify client.Object(s).

When these objects are passed to the delegating client, and their GVK is
matched against the internal map, the check doesn't take into account
that the client might be issuing a List call with a ObjectList instead
of a metav1.Object.

The proposed solution is taken from the discovery rest mapper, which
does the same ~hack. While it's not perfect, probably close to all
generated objects are going to have a list that has the "List" suffix,
that when removed gives back the original GVK.

If there are other solutions, happy to change this hack.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

/assign @alvaroaleman 
/milestone v0.7.x
