### PR TITLE
🐛 Do not set PatchType if patch is empty

### DIFF
--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -90,8 +90,14 @@ func PatchResponseFromRaw(original, current []byte) Response {
 	return Response{
 		Patches: patches,
 		AdmissionResponse: admissionv1.AdmissionResponse{
-			Allowed:   true,
-			PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
+			Allowed: true,
+			PatchType: func() *admissionv1.PatchType {
+				if len(patches) == 0 {
+					return nil
+				}
+				pt := admissionv1.PatchTypeJSONPatch
+				return &pt
+			}(),
 		},
 	}
 }


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

In admission v1, API server requires that Patch and PatchType are both
provided or none are provided.  Meanwhile, admission v1beta1 does not
have this kind of requirement.

In controller-runtime, PatchResponseFromRaw sets PatchType regardless
of the existence of patch.  If patch is empty, a response contains
only PatchType and API server does not like it.  Webhook call fails.

This change fixes this issue by not setting PatchType if patch is
empty.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1295