### PR TITLE
:bug: Print webhook config options from scratch-env example

### DIFF
--- a/examples/scratch-env/main.go
+++ b/examples/scratch-env/main.go
@@ -103,6 +103,10 @@ func runMain() int {
 		log.Info("Wrote kubeconfig")
 	}
 
+	if opts := env.WebhookInstallOptions; opts.LocalServingPort != 0 {
+		log.Info("webhooks configured for", "host", opts.LocalServingHost, "port", opts.LocalServingPort, "dir", opts.LocalServingCertDir)
+	}
+
 	ctx := ctrl.SetupSignalHandler()
 	<-ctx.Done()
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Print out config options for webhooks (host, port, cert dir) that are needed in order to run a webhook server that communicates with the scratch env API server
