### PR TITLE
🐛 pkg/log: Set Log to NullLogger after 30 seconds

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -35,18 +35,50 @@ package log
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 )
 
 // SetLogger sets a concrete logging implementation for all deferred Loggers.
 func SetLogger(l logr.Logger) {
+	loggerWasSetLock.Lock()
+	defer loggerWasSetLock.Unlock()
+
+	loggerWasSet = true
 	Log.Fulfill(l)
 }
 
+// It is safe to assume that if this wasn't set within the first 30 seconds of a binaries
+// lifetime, it will never get set. The DelegatingLogger causes a high number of memory
+// allocations when not given an actual Logger, so we set a NullLogger to avoid that.
+//
+// We need to keep the DelegatingLogger because we have various inits() that get a logger from
+// here. They will always get executed before any code that imports controller-runtime
+// has a chance to run and hence to set an actual logger.
+func init() {
+	// Init is blocking, so start a new goroutine
+	go func() {
+		time.Sleep(30 * time.Second)
+		loggerWasSetLock.Lock()
+		defer loggerWasSetLock.Unlock()
+		if !loggerWasSet {
+			Log.Fulfill(NullLogger{})
+		}
+	}()
+}
+
+var (
+	loggerWasSetLock sync.Mutex
+	loggerWasSet     bool
+)
+
 // Log is the base logger used by kubebuilder.  It delegates
-// to another logr.Logger.  You *must* call SetLogger to
-// get any actual logging.
+// to another logr.Logger. You *must* call SetLogger to
+// get any actual logging. If SetLogger is not called within
+// the first 30 seconds of a binaries lifetime, it will get
+// set to a NullLogger.
 var Log = NewDelegatingLogger(NullLogger{})
 
 // FromContext returns a logger with predefined values from a context.Context.


### PR DESCRIPTION

    The delegating Logger will cause a high number of memory allocations
    when no actual Logger is set. This change makes us set a NullLogger
    after 30 seconds if none was set yet to avoid that.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1122

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @DirectXMan12 @vincepri 
