### PR TITLE
✨ Fix minor listwatch comment typo

### DIFF
--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -320,7 +320,7 @@ func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersM
 	//  pass in their own contexts instead of relying on this fixed one here.
 	ctx := context.TODO()
 
-	// create the relevant listwaatch
+	// create the relevant listwatch
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {


### PR DESCRIPTION
Updates comment in metatdata listwatch creation to read listwatch
instead of listwaatch.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
