### PR TITLE
✨ introduce LabelChangedPredicate to trigger event on label change

### DIFF
--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -610,6 +610,202 @@ var _ = Describe("Predicate", func() {
 		})
 	})
 
+	Describe("When checking a LabelChangedPredicate", func() {
+		instance := predicate.LabelChangedPredicate{}
+		Context("Where the old object is missing", func() {
+			It("should return false", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeFalse())
+			})
+		})
+
+		Context("Where the new object is missing", func() {
+			It("should return false", func() {
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeFalse())
+			})
+		})
+
+		Context("Where the labels are empty", func() {
+			It("should return false", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+					}}
+
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeFalse())
+			})
+		})
+
+		Context("Where the labels haven't changed", func() {
+			It("should return false", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeFalse())
+			})
+		})
+
+		Context("Where a label value has changed", func() {
+			It("should return true", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bee",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeTrue())
+			})
+		})
+
+		Context("Where a label has been added", func() {
+			It("should return true", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+							"faa": "bor",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeTrue())
+			})
+		})
+
+		Context("Where a label has been removed", func() {
+			It("should return true", func() {
+				new := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+							"faa": "bor",
+						},
+					}}
+
+				old := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "baz",
+						Namespace: "biz",
+						Labels: map[string]string{
+							"foo": "bar",
+						},
+					}}
+
+				evt := event.UpdateEvent{
+					ObjectOld: old,
+					ObjectNew: new,
+				}
+				Expect(instance.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(instance.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(instance.Generic(event.GenericEvent{})).To(BeTrue())
+				Expect(instance.Update(evt)).To(BeTrue())
+			})
+		})
+	})
+
 	Context("With a boolean predicate", func() {
 		funcs := func(pass bool) predicate.Funcs {
 			return predicate.Funcs{

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -414,6 +414,9 @@ var _ = Describe("Predicate", func() {
 
 	})
 
+	// AnnotationChangedPredicate has almost identical test cases as LabelChangedPredicates,
+	// so the duplication linter should be muted on both two test suites.
+	// nolint:dupl
 	Describe("When checking an AnnotationChangedPredicate", func() {
 		instance := predicate.AnnotationChangedPredicate{}
 		Context("Where the old object is missing", func() {
@@ -610,6 +613,9 @@ var _ = Describe("Predicate", func() {
 		})
 	})
 
+	// LabelChangedPredicates has almost identical test cases as AnnotationChangedPredicates,
+	// so the duplication linter should be muted on both two test suites.
+	// nolint:dupl
 	Describe("When checking a LabelChangedPredicate", func() {
 		instance := predicate.LabelChangedPredicate{}
 		Context("Where the old object is missing", func() {


### PR DESCRIPTION
Signed-off-by: Bruce Ma <brucema19901024@gmail.com>

This is a non-breaking feature :sparkles: .
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Just as the title, a `LabelChangedPredicate` is introduced to trigger event on label change, if some extra specification information is carried through object's label, this predicate function will be useful.

