### PR TITLE
:sparkles: Deprecate Inject interface

### DIFF
--- a/pkg/runtime/inject/inject.go
+++ b/pkg/runtime/inject/inject.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package inject is used by a Manager to inject types into Sources, EventHandlers, Predicates, and Reconciles.
+// Deprecated: Use manager.Options fields directly. This package will be removed in v0.10.
 package inject
 
 import (
@@ -24,7 +26,16 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 )
+
+// log is specifically to add a warning message for injectors.
+var log = logf.RuntimeLog.WithName("injectors-warning")
+
+// logWarningMsg logs a warning message if inject is used
+func logWarningMsg() {
+	log.Info("Injectors are deprecated, and will be removed in v0.10.x")
+}
 
 // Cache is used by the ControllerManager to inject Cache into Sources, EventHandlers, Predicates, and
 // Reconciles
@@ -36,6 +47,7 @@ type Cache interface {
 // false if i does not implement Cache.
 func CacheInto(c cache.Cache, i interface{}) (bool, error) {
 	if s, ok := i.(Cache); ok {
+		logWarningMsg()
 		return true, s.InjectCache(c)
 	}
 	return false, nil
@@ -50,6 +62,7 @@ type APIReader interface {
 // Returns false if i does not implement APIReader
 func APIReaderInto(reader client.Reader, i interface{}) (bool, error) {
 	if s, ok := i.(APIReader); ok {
+		logWarningMsg()
 		return true, s.InjectAPIReader(reader)
 	}
 	return false, nil
@@ -65,6 +78,7 @@ type Config interface {
 // false if i does not implement Config.
 func ConfigInto(config *rest.Config, i interface{}) (bool, error) {
 	if s, ok := i.(Config); ok {
+		logWarningMsg()
 		return true, s.InjectConfig(config)
 	}
 	return false, nil
@@ -80,6 +94,7 @@ type Client interface {
 // false if i does not implement Client.
 func ClientInto(client client.Client, i interface{}) (bool, error) {
 	if s, ok := i.(Client); ok {
+		logWarningMsg()
 		return true, s.InjectClient(client)
 	}
 	return false, nil
@@ -95,6 +110,7 @@ type Scheme interface {
 // false if i does not implement Scheme.
 func SchemeInto(scheme *runtime.Scheme, i interface{}) (bool, error) {
 	if is, ok := i.(Scheme); ok {
+		logWarningMsg()
 		return true, is.InjectScheme(scheme)
 	}
 	return false, nil
@@ -110,6 +126,7 @@ type Stoppable interface {
 // Returns false if i does not implement Stoppable.
 func StopChannelInto(stop <-chan struct{}, i interface{}) (bool, error) {
 	if s, ok := i.(Stoppable); ok {
+		logWarningMsg()
 		return true, s.InjectStopChannel(stop)
 	}
 	return false, nil
@@ -124,6 +141,7 @@ type Mapper interface {
 // Returns false if i does not implement Mapper.
 func MapperInto(mapper meta.RESTMapper, i interface{}) (bool, error) {
 	if m, ok := i.(Mapper); ok {
+		logWarningMsg()
 		return true, m.InjectMapper(mapper)
 	}
 	return false, nil
@@ -141,6 +159,7 @@ type Injector interface {
 // false if i does not implement Injector.
 func InjectorInto(f Func, i interface{}) (bool, error) {
 	if ii, ok := i.(Injector); ok {
+		logWarningMsg()
 		return true, ii.InjectFunc(f)
 	}
 	return false, nil
@@ -156,6 +175,7 @@ type Logger interface {
 // returning true if a InjectLogger was called, and false otherwise.
 func LoggerInto(l logr.Logger, i interface{}) (bool, error) {
 	if injectable, wantsLogger := i.(Logger); wantsLogger {
+		logWarningMsg()
 		return true, injectable.InjectLogger(l)
 	}
 	return false, nil


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Deprecate `inject` interface

cc: @estroz 