### PR TITLE
:seedling: Add testingclient package with clients for testing

### DIFF
--- a/pkg/client/testingclient/error.go
+++ b/pkg/client/testingclient/error.go
@@ -11,14 +11,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type Verb string
+
+const (
+	GetVerb    Verb = "get"
+	CreateVerb Verb = "create"
+	DeleteVerb Verb = "delete"
+	UpdateVerb Verb = "update"
+	PatchVerb  Verb = "patch"
+	AnyVerb    Verb = "*"
+)
+
 type resourceActionKey struct {
-	action    string
+	verb      Verb
 	kind      schema.GroupVersionKind
 	objectKey client.ObjectKey
 }
 
 var (
-	AnyAction  = "*"
 	AnyKind    = &unstructured.Unstructured{}
 	AnyObject  = client.ObjectKey{}
 	anyKindGVK = schema.GroupVersionKind{Kind: "*"}
@@ -49,7 +59,7 @@ func (c ErrorInjector) RESTMapper() meta.RESTMapper {
 }
 
 func (c ErrorInjector) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-	err := c.getStubbedError("get", obj, key)
+	err := c.getStubbedError(GetVerb, obj, key)
 	if err != nil {
 		return err
 	}
@@ -62,7 +72,7 @@ func (c ErrorInjector) List(ctx context.Context, list client.ObjectList, opts ..
 }
 
 func (c ErrorInjector) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
-	err := c.getStubbedError("create", obj, client.ObjectKeyFromObject(obj))
+	err := c.getStubbedError(CreateVerb, obj, client.ObjectKeyFromObject(obj))
 	if err != nil {
 		return err
 	}
@@ -71,7 +81,7 @@ func (c ErrorInjector) Create(ctx context.Context, obj client.Object, opts ...cl
 }
 
 func (c ErrorInjector) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
-	err := c.getStubbedError("delete", obj, client.ObjectKeyFromObject(obj))
+	err := c.getStubbedError(DeleteVerb, obj, client.ObjectKeyFromObject(obj))
 	if err != nil {
 		return err
 	}
@@ -80,7 +90,7 @@ func (c ErrorInjector) Delete(ctx context.Context, obj client.Object, opts ...cl
 }
 
 func (c ErrorInjector) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	err := c.getStubbedError("update", obj, client.ObjectKeyFromObject(obj))
+	err := c.getStubbedError(UpdateVerb, obj, client.ObjectKeyFromObject(obj))
 	if err != nil {
 		return err
 	}
@@ -89,7 +99,7 @@ func (c ErrorInjector) Update(ctx context.Context, obj client.Object, opts ...cl
 }
 
 func (c ErrorInjector) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	err := c.getStubbedError("patch", obj, client.ObjectKeyFromObject(obj))
+	err := c.getStubbedError(PatchVerb, obj, client.ObjectKeyFromObject(obj))
 	if err != nil {
 		return err
 	}
@@ -105,18 +115,18 @@ func (c ErrorInjector) Status() client.StatusWriter {
 	return c
 }
 
-func (c ErrorInjector) getStubbedError(action string, kind client.Object, objectKey client.ObjectKey) error {
+func (c ErrorInjector) getStubbedError(action Verb, kind client.Object, objectKey client.ObjectKey) error {
 	gvk := mustGVKForObject(kind, c.Scheme())
 
 	for _, k := range []resourceActionKey{
-		{action, gvk, objectKey},           // (1) 0 wildcards
-		{action, gvk, AnyObject},           // (2) 1 wildcard
-		{AnyAction, gvk, objectKey},        // (3) 1 wildcard
-		{action, anyKindGVK, objectKey},    // (4) 1 wildcard
-		{AnyAction, gvk, AnyObject},        // (5) 2 wildcards
-		{action, anyKindGVK, AnyObject},    // (6) 2 wildcards
-		{AnyAction, anyKindGVK, objectKey}, // (7) 2 wildcards
-		{AnyAction, anyKindGVK, AnyObject}, // (8) 3 wildcards
+		{action, gvk, objectKey},         // (1) 0 wildcards
+		{action, gvk, AnyObject},         // (2) 1 wildcard
+		{AnyVerb, gvk, objectKey},        // (3) 1 wildcard
+		{action, anyKindGVK, objectKey},  // (4) 1 wildcard
+		{AnyVerb, gvk, AnyObject},        // (5) 2 wildcards
+		{action, anyKindGVK, AnyObject},  // (6) 2 wildcards
+		{AnyVerb, anyKindGVK, objectKey}, // (7) 2 wildcards
+		{AnyVerb, anyKindGVK, AnyObject}, // (8) 3 wildcards
 	} {
 		if err, ok := c.errorsToReturn[k]; ok {
 			return err
@@ -125,12 +135,12 @@ func (c ErrorInjector) getStubbedError(action string, kind client.Object, object
 	return nil
 }
 
-// InjectError will cause ErrorInjector to return an error for the given (action, kind, objectKey) tuple.
+// InjectError will cause ErrorInjector to return an error for the given (verb, kind, objectKey) tuple.
 // Wildcards are supported for each part of the tuple:
 // Pass objectKey = AnyObject to match any object identity.
 // Pass kind = AnyKind to match any type of object.
-// Pass action = AnyAction to match any client action.
-func (c *ErrorInjector) InjectError(action string, kind client.Object, objectKey client.ObjectKey, injectedError error) {
+// Pass verb = AnyVerb to match any client verb.
+func (c *ErrorInjector) InjectError(action Verb, kind client.Object, objectKey client.ObjectKey, injectedError error) {
 	gvk := anyKindGVK
 	if kind != AnyKind {
 		gvk = mustGVKForObject(kind, c.Scheme())

--- a/pkg/client/testingclient/error.go
+++ b/pkg/client/testingclient/error.go
@@ -45,7 +45,7 @@ func (c ErrorInjector) Get(ctx context.Context, key client.ObjectKey, obj client
 
 // List will only match against errors injected for AnyObject.
 func (c ErrorInjector) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	gvk, err := listGVK(list, c.Scheme())
+	gvk, _, err := listGVK(list, c.Scheme())
 	if err != nil {
 		return err
 	}

--- a/pkg/client/testingclient/error.go
+++ b/pkg/client/testingclient/error.go
@@ -4,34 +4,9 @@ import (
 	"context"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-type Verb string
-
-const (
-	GetVerb    Verb = "get"
-	CreateVerb Verb = "create"
-	DeleteVerb Verb = "delete"
-	UpdateVerb Verb = "update"
-	PatchVerb  Verb = "patch"
-	AnyVerb    Verb = "*"
-)
-
-type resourceActionKey struct {
-	verb      Verb
-	kind      schema.GroupVersionKind
-	objectKey client.ObjectKey
-}
-
-var (
-	AnyKind    = &unstructured.Unstructured{}
-	AnyObject  = client.ObjectKey{}
-	anyKindGVK = schema.GroupVersionKind{Kind: "*"}
 )
 
 type ErrorInjector struct {

--- a/pkg/client/testingclient/error.go
+++ b/pkg/client/testingclient/error.go
@@ -1,0 +1,131 @@
+package testingclient
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type resourceActionKey struct {
+	action    string
+	kind      schema.GroupVersionKind
+	objectKey client.ObjectKey
+}
+
+var (
+	AnyAction = "*"
+	AnyKind   = schema.GroupVersionKind{Kind: "*"}
+	AnyObject = client.ObjectKey{}
+)
+
+type ErrorInjector struct {
+	delegate       client.Client
+	errorsToReturn map[resourceActionKey]error
+}
+
+var _ client.Client = ErrorInjector{}
+
+func NewErrorInjector(cl client.Client) *ErrorInjector {
+	injectedErrors := make(map[resourceActionKey]error)
+
+	return &ErrorInjector{
+		delegate:       cl,
+		errorsToReturn: injectedErrors,
+	}
+}
+
+func (c ErrorInjector) Scheme() *runtime.Scheme {
+	return c.delegate.Scheme()
+}
+
+func (c ErrorInjector) RESTMapper() meta.RESTMapper {
+	return c.delegate.RESTMapper()
+}
+
+func (c ErrorInjector) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	err := c.getStubbedError("get", obj, key)
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.Get(ctx, key, obj)
+}
+
+func (c ErrorInjector) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	panic("implement me")
+}
+
+func (c ErrorInjector) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	err := c.getStubbedError("create", obj, client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.Create(ctx, obj, opts...)
+}
+
+func (c ErrorInjector) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	err := c.getStubbedError("delete", obj, client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.Delete(ctx, obj, opts...)
+}
+
+func (c ErrorInjector) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	err := c.getStubbedError("update", obj, client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.Update(ctx, obj, opts...)
+}
+
+func (c ErrorInjector) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	err := c.getStubbedError("patch", obj, client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.Patch(ctx, obj, patch, opts...)
+}
+
+func (c ErrorInjector) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	panic("implement me")
+}
+
+func (c ErrorInjector) Status() client.StatusWriter {
+	return c
+}
+
+func (c ErrorInjector) getStubbedError(action string, kind client.Object, objectKey client.ObjectKey) error {
+	gvk := mustGVKForObject(kind, c.Scheme())
+
+	for _, k := range []resourceActionKey{
+		{action, gvk, objectKey},
+		{action, gvk, AnyObject},
+		{AnyAction, gvk, objectKey},
+		{AnyAction, gvk, AnyObject},
+		{action, AnyKind, AnyObject},
+		{AnyAction, AnyKind, AnyObject},
+	} {
+		if err, ok := c.errorsToReturn[k]; ok {
+			return err
+		}
+	}
+	return nil
+}
+
+// InjectError will cause ErrorInjector to return an error for the given (action, kind, objectKey) tuple.
+// To inject an error for all calls with `(action,kind)`, pass objectKey = AnyObject.
+// To inject an error for all calls with `action`, pass kind = "*" and objectKey = AnyObject.
+// To inject an error for any `action`, pass action = "*",  kind = "*" and objectKey = AnyObject.
+func (c *ErrorInjector) InjectError(action string, kind client.Object, objectKey client.ObjectKey, injectedError error) {
+	gvk := mustGVKForObject(kind, c.Scheme())
+	c.errorsToReturn[resourceActionKey{action, gvk, objectKey}] = injectedError
+}

--- a/pkg/client/testingclient/error.go
+++ b/pkg/client/testingclient/error.go
@@ -93,8 +93,14 @@ func (c ErrorInjector) Patch(ctx context.Context, obj client.Object, patch clien
 	return c.delegate.Patch(ctx, obj, patch, opts...)
 }
 
+// DeleteAllOf will only match against errors injected for AnyObject.
 func (c ErrorInjector) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	panic("implement me")
+	err := c.getStubbedError(DeleteAllVerb, mustGVKForObject(obj, c.Scheme()), client.ObjectKeyFromObject(obj))
+	if err != nil {
+		return err
+	}
+
+	return c.delegate.DeleteAllOf(ctx, obj, opts...)
 }
 
 func (c ErrorInjector) Status() client.StatusWriter {

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -1,0 +1,56 @@
+package testingclient_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/testingclient"
+)
+
+var exampleError = errors.New("injected error")
+
+var _ = Describe("ErrorInjector", func() {
+	var (
+		subject    *testingclient.ErrorInjector
+		fakeClient client.Client
+	)
+	BeforeEach(func() {
+		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+
+		examplePod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "ns",
+			},
+		}
+
+		pod1 := examplePod.DeepCopy()
+		pod1.Name = "pod1"
+		pod2 := examplePod.DeepCopy()
+		pod2.Name = "pod2"
+
+		Expect(fakeClient.Create(nil, pod1)).To(Succeed())
+		Expect(fakeClient.Create(nil, pod2)).To(Succeed())
+
+		subject = testingclient.NewErrorInjector(fakeClient)
+	})
+
+	It("can inject errors on calls to Get", func() {
+		subject.InjectError("get", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var obj corev1.Pod
+		Expect(subject.Get(nil, key, &obj)).To(MatchError("injected error"))
+	})
+
+	// TODO: test falling through to the delegate.
+	// TODO: test more functions.
+	// TODO: test prefers specific matches over general matches.
+})

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -50,7 +50,19 @@ var _ = Describe("ErrorInjector", func() {
 		Expect(subject.Get(nil, key, &obj)).To(MatchError("injected error"))
 	})
 
-	// TODO: test falling through to the delegate.
+	It("calls the delegate client if no errors match", func() {
+		subject.InjectError("get", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var obj corev1.Pod
+		Expect(subject.Get(nil, key, &obj)).To(Succeed())
+
+		var objInDelegate corev1.Pod
+		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+		Expect(obj).To(Equal(objInDelegate), "obj should be the retrieved object")
+	})
+
 	// TODO: test more functions.
 	// TODO: test prefers specific matches over general matches.
 })

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -82,6 +82,28 @@ var _ = Describe("ErrorInjector", func() {
 		})
 	})
 
+	Describe("List", func() {
+		It("can inject errors on calls to List", func() {
+			subject.InjectError(testingclient.ListVerb, &corev1.Pod{}, testingclient.AnyObject, exampleError)
+
+			var list corev1.PodList
+			Expect(subject.List(nil, &list)).To(MatchError("injected error"))
+		})
+
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError(testingclient.ListVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			var list corev1.PodList
+			Expect(subject.List(nil, &list)).To(Succeed())
+
+			var listInDelegate corev1.PodList
+			Expect(fakeClient.List(nil, &listInDelegate)).To(Succeed())
+
+			//Expect(list.Items).To(HaveLen(2))
+			Expect(list).To(Equal(listInDelegate), "obj should be the retrieved object")
+		})
+	})
+
 	Describe("Create", func() {
 		pod3 := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -42,27 +43,155 @@ var _ = Describe("ErrorInjector", func() {
 		subject = testingclient.NewErrorInjector(fakeClient)
 	})
 
-	It("can inject errors on calls to Get", func() {
-		subject.InjectError("get", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+	Describe("Get", func() {
+		It("can inject errors on calls to Get", func() {
+			subject.InjectError("get", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
 
-		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
-		var obj corev1.Pod
-		Expect(subject.Get(nil, key, &obj)).To(MatchError("injected error"))
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(subject.Get(nil, key, &obj)).To(MatchError("injected error"))
+		})
+
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError("get", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(subject.Get(nil, key, &obj)).To(Succeed())
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+			Expect(obj).To(Equal(objInDelegate), "obj should be the retrieved object")
+		})
 	})
 
-	It("calls the delegate client if no errors match", func() {
-		subject.InjectError("get", &corev1.Service{}, testingclient.AnyObject, exampleError)
+	Describe("Create", func() {
+		pod3 := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod3",
+				Namespace: "ns",
+			},
+		}
+		It("can inject errors on calls to Create", func() {
+			subject.InjectError("create", &corev1.Pod{}, client.ObjectKey{Name: "pod3", Namespace: "ns"}, exampleError)
 
-		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
-		var obj corev1.Pod
-		Expect(subject.Get(nil, key, &obj)).To(Succeed())
+			Expect(subject.Create(nil, &pod3)).To(MatchError("injected error"))
 
-		var objInDelegate corev1.Pod
-		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			key := types.NamespacedName{Namespace: "ns", Name: "pod3"}
+			var objInDelegate corev1.Pod
+			err := fakeClient.Get(nil, key, &objInDelegate)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "should not create the object if an error was injected")
+		})
 
-		Expect(obj).To(Equal(objInDelegate), "obj should be the retrieved object")
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError("create", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			Expect(subject.Create(nil, &pod3)).To(Succeed())
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod3"}
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+			objInDelegate.TypeMeta = metav1.TypeMeta{} // Clear TypeMeta for comparison. fakeClient.Get() fills this in.
+			Expect(pod3).To(Equal(objInDelegate), "obj should be the retrieved object")
+		})
 	})
 
-	// TODO: test more functions.
+	Describe("Delete", func() {
+		It("can inject errors on calls to Delete", func() {
+			subject.InjectError("delete", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			Expect(subject.Delete(nil, &obj)).To(MatchError("injected error"))
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			Expect(obj).To(Equal(objInDelegate), "pod1 should still exist")
+		})
+
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError("delete", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			obj := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: key.Namespace, Name: key.Name,
+				},
+			}
+			Expect(subject.Delete(nil, &obj)).To(Succeed())
+
+			var objInDelegate corev1.Pod
+			err := fakeClient.Get(nil, key, &objInDelegate)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue(), "should delete the object if no error was injected")
+
+		})
+	})
+
+	Describe("Update", func() {
+		It("can inject errors on calls to Update", func() {
+			subject.InjectError("update", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			origObj := obj.DeepCopy()
+			obj.Spec.NodeName = "lymph"
+			Expect(subject.Update(nil, &obj)).To(MatchError("injected error"))
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			Expect(objInDelegate).To(Equal(*origObj), "pod1 should be unmodified")
+		})
+
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError("update", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			obj.Spec.NodeName = "lymph"
+			Expect(subject.Update(nil, &obj)).To(Succeed())
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			Expect(objInDelegate).To(Equal(obj), "pod1 should be modified")
+		})
+	})
+
+	Describe("Patch", func() {
+		It("can inject errors on calls to Patch", func() {
+			subject.InjectError("patch", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			origObj := obj.DeepCopy()
+			obj.Spec.NodeName = "lymph"
+			Expect(subject.Patch(nil, &obj, client.MergeFrom(origObj))).To(MatchError("injected error"))
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			Expect(objInDelegate).To(Equal(*origObj), "pod1 should be unmodified")
+		})
+
+		It("calls the delegate client if no errors match", func() {
+			subject.InjectError("patch", &corev1.Service{}, testingclient.AnyObject, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			origObj := obj.DeepCopy()
+			obj.Spec.NodeName = "lymph"
+			Expect(subject.Patch(nil, &obj, client.MergeFrom(origObj))).To(Succeed())
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+			Expect(objInDelegate).To(Equal(obj), "pod1 should be modified")
+		})
+	})
+
 	// TODO: test prefers specific matches over general matches.
 })

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -23,7 +23,7 @@ var _ = Describe("ErrorInjector", func() {
 		fakeClient client.Client
 	)
 	BeforeEach(func() {
-		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+		fakeClient = testingclient.NewFakeClientBuilder().WithScheme(scheme.Scheme).Build()
 
 		examplePod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/client/testingclient/error_test.go
+++ b/pkg/client/testingclient/error_test.go
@@ -45,7 +45,7 @@ var _ = Describe("ErrorInjector", func() {
 
 	Describe("Get", func() {
 		It("can inject errors on calls to Get", func() {
-			subject.InjectError("get", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+			subject.InjectError(testingclient.GetVerb, &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -53,7 +53,7 @@ var _ = Describe("ErrorInjector", func() {
 		})
 
 		It("calls the delegate client if no errors match", func() {
-			subject.InjectError("get", &corev1.Service{}, testingclient.AnyObject, exampleError)
+			subject.InjectError(testingclient.GetVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -63,6 +63,22 @@ var _ = Describe("ErrorInjector", func() {
 			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
 
 			Expect(obj).To(Equal(objInDelegate), "obj should be the retrieved object")
+		})
+
+		It("also accepts actions as a string", func() {
+			subject.InjectError("get", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(subject.Get(nil, key, &obj)).To(MatchError("injected error"))
+		})
+
+		It("does not return injected error for invalid actions", func() {
+			subject.InjectError("invalid", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			var obj corev1.Pod
+			Expect(subject.Get(nil, key, &obj)).To(Succeed())
 		})
 	})
 
@@ -74,7 +90,7 @@ var _ = Describe("ErrorInjector", func() {
 			},
 		}
 		It("can inject errors on calls to Create", func() {
-			subject.InjectError("create", &corev1.Pod{}, client.ObjectKey{Name: "pod3", Namespace: "ns"}, exampleError)
+			subject.InjectError(testingclient.CreateVerb, &corev1.Pod{}, client.ObjectKey{Name: "pod3", Namespace: "ns"}, exampleError)
 
 			Expect(subject.Create(nil, &pod3)).To(MatchError("injected error"))
 
@@ -85,7 +101,7 @@ var _ = Describe("ErrorInjector", func() {
 		})
 
 		It("calls the delegate client if no errors match", func() {
-			subject.InjectError("create", &corev1.Service{}, testingclient.AnyObject, exampleError)
+			subject.InjectError(testingclient.CreateVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
 
 			Expect(subject.Create(nil, &pod3)).To(Succeed())
 
@@ -100,7 +116,7 @@ var _ = Describe("ErrorInjector", func() {
 
 	Describe("Delete", func() {
 		It("can inject errors on calls to Delete", func() {
-			subject.InjectError("delete", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+			subject.InjectError(testingclient.DeleteVerb, &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -113,7 +129,7 @@ var _ = Describe("ErrorInjector", func() {
 		})
 
 		It("calls the delegate client if no errors match", func() {
-			subject.InjectError("delete", &corev1.Service{}, testingclient.AnyObject, exampleError)
+			subject.InjectError(testingclient.DeleteVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			obj := corev1.Pod{
@@ -132,7 +148,7 @@ var _ = Describe("ErrorInjector", func() {
 
 	Describe("Update", func() {
 		It("can inject errors on calls to Update", func() {
-			subject.InjectError("update", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+			subject.InjectError(testingclient.UpdateVerb, &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -147,7 +163,7 @@ var _ = Describe("ErrorInjector", func() {
 		})
 
 		It("calls the delegate client if no errors match", func() {
-			subject.InjectError("update", &corev1.Service{}, testingclient.AnyObject, exampleError)
+			subject.InjectError(testingclient.UpdateVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -163,7 +179,7 @@ var _ = Describe("ErrorInjector", func() {
 
 	Describe("Patch", func() {
 		It("can inject errors on calls to Patch", func() {
-			subject.InjectError("patch", &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
+			subject.InjectError(testingclient.PatchVerb, &corev1.Pod{}, client.ObjectKey{Name: "pod1", Namespace: "ns"}, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -178,7 +194,7 @@ var _ = Describe("ErrorInjector", func() {
 		})
 
 		It("calls the delegate client if no errors match", func() {
-			subject.InjectError("patch", &corev1.Service{}, testingclient.AnyObject, exampleError)
+			subject.InjectError(testingclient.PatchVerb, &corev1.Service{}, testingclient.AnyObject, exampleError)
 
 			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 			var obj corev1.Pod
@@ -201,14 +217,14 @@ var _ = Describe("ErrorInjector", func() {
 		var pod2 corev1.Pod
 		Expect(subject.Get(nil, pod2Key, &pod2)).To(Succeed())
 
-		subject.InjectError("get", &corev1.Pod{}, pod1Key, errors.New("error 1"))
-		subject.InjectError("get", &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2"))
-		subject.InjectError(testingclient.AnyAction, &corev1.Pod{}, pod1Key, errors.New("error 3"))
-		subject.InjectError("get", testingclient.AnyKind, pod1Key, errors.New("error 4"))
-		subject.InjectError(testingclient.AnyAction, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5"))
-		subject.InjectError("get", testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6"))
-		subject.InjectError(testingclient.AnyAction, testingclient.AnyKind, pod1Key, errors.New("error 7"))
-		subject.InjectError(testingclient.AnyAction, testingclient.AnyKind, testingclient.AnyObject, errors.New("error 8"))
+		subject.InjectError(testingclient.GetVerb, &corev1.Pod{}, pod1Key, errors.New("error 1"))
+		subject.InjectError(testingclient.GetVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2"))
+		subject.InjectError(testingclient.AnyVerb, &corev1.Pod{}, pod1Key, errors.New("error 3"))
+		subject.InjectError(testingclient.GetVerb, testingclient.AnyKind, pod1Key, errors.New("error 4"))
+		subject.InjectError(testingclient.AnyVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5"))
+		subject.InjectError(testingclient.GetVerb, testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6"))
+		subject.InjectError(testingclient.AnyVerb, testingclient.AnyKind, pod1Key, errors.New("error 7"))
+		subject.InjectError(testingclient.AnyVerb, testingclient.AnyKind, testingclient.AnyObject, errors.New("error 8"))
 
 		var p corev1.Pod
 		var c corev1.ConfigMap
@@ -228,7 +244,7 @@ var _ = Describe("ErrorInjector", func() {
 
 	Describe("preferences between wildcard injections", func() {
 		type injection struct {
-			action        string
+			verb          testingclient.Verb
 			kind          client.Object
 			objectKey     client.ObjectKey
 			injectedError error
@@ -239,12 +255,12 @@ var _ = Describe("ErrorInjector", func() {
 				var pod1 corev1.Pod
 				Expect(subject.Get(nil, pod1Key, &pod1)).To(Succeed())
 
-				subject.InjectError(demoted.action, demoted.kind, demoted.objectKey, demoted.injectedError)
+				subject.InjectError(demoted.verb, demoted.kind, demoted.objectKey, demoted.injectedError)
 
 				var p corev1.Pod
 				Expect(subject.Get(nil, pod1Key, &p)).To(Equal(demoted.injectedError))
 
-				subject.InjectError(preferred.action, preferred.kind, preferred.objectKey, preferred.injectedError)
+				subject.InjectError(preferred.verb, preferred.kind, preferred.objectKey, preferred.injectedError)
 
 				Expect(subject.Get(nil, pod1Key, &p)).To(Equal(preferred.injectedError))
 			})
@@ -252,39 +268,39 @@ var _ = Describe("ErrorInjector", func() {
 
 		pod1Key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
 
-		ItPrefers("AnyObject(2) matches over AnyAction(3) matches",
-			injection{"get", &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2")},
-			injection{testingclient.AnyAction, &corev1.Pod{}, pod1Key, errors.New("error 3")},
+		ItPrefers("AnyObject(2) matches over AnyVerb(3) matches",
+			injection{testingclient.GetVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2")},
+			injection{testingclient.AnyVerb, &corev1.Pod{}, pod1Key, errors.New("error 3")},
 		)
 
 		ItPrefers("AnyObject(2) matches over AnyKind(4) matches",
-			injection{"get", &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2")},
-			injection{"get", testingclient.AnyKind, pod1Key, errors.New("error 4")},
+			injection{testingclient.GetVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 2")},
+			injection{testingclient.GetVerb, testingclient.AnyKind, pod1Key, errors.New("error 4")},
 		)
 
-		ItPrefers("AnyAction(3) matches over AnyKind(4) matches",
-			injection{testingclient.AnyAction, &corev1.Pod{}, pod1Key, errors.New("error 3")},
-			injection{"get", testingclient.AnyKind, pod1Key, errors.New("error 4")},
+		ItPrefers("AnyVerb(3) matches over AnyKind(4) matches",
+			injection{testingclient.AnyVerb, &corev1.Pod{}, pod1Key, errors.New("error 3")},
+			injection{testingclient.GetVerb, testingclient.AnyKind, pod1Key, errors.New("error 4")},
 		)
 
-		ItPrefers("AnyKind(4) matches over AnyAction,AnyObject(5) matches",
-			injection{"get", testingclient.AnyKind, pod1Key, errors.New("error 4")},
-			injection{testingclient.AnyAction, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
+		ItPrefers("AnyKind(4) matches over AnyVerb,AnyObject(5) matches",
+			injection{testingclient.GetVerb, testingclient.AnyKind, pod1Key, errors.New("error 4")},
+			injection{testingclient.AnyVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
 		)
 
-		ItPrefers("AnyAction,AnyObject(5) matches over AnyKind,AnyObject(6)",
-			injection{testingclient.AnyAction, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
-			injection{"get", testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6")},
+		ItPrefers("AnyVerb,AnyObject(5) matches over AnyKind,AnyObject(6)",
+			injection{testingclient.AnyVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
+			injection{testingclient.GetVerb, testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6")},
 		)
 
-		ItPrefers("AnyAction,AnyObject(5) matches over AnyAction,AnyKind(7)",
-			injection{testingclient.AnyAction, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
-			injection{testingclient.AnyAction, testingclient.AnyKind, pod1Key, errors.New("error 7")},
+		ItPrefers("AnyVerb,AnyObject(5) matches over AnyVerb,AnyKind(7)",
+			injection{testingclient.AnyVerb, &corev1.Pod{}, testingclient.AnyObject, errors.New("error 5")},
+			injection{testingclient.AnyVerb, testingclient.AnyKind, pod1Key, errors.New("error 7")},
 		)
 
-		ItPrefers("AnyKind,AnyObject(6) matches over AnyAction,AnyKind(7)",
-			injection{"get", testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6")},
-			injection{testingclient.AnyAction, testingclient.AnyKind, pod1Key, errors.New("error 7")},
+		ItPrefers("AnyKind,AnyObject(6) matches over AnyVerb,AnyKind(7)",
+			injection{testingclient.GetVerb, testingclient.AnyKind, testingclient.AnyObject, errors.New("error 6")},
+			injection{testingclient.AnyVerb, testingclient.AnyKind, pod1Key, errors.New("error 7")},
 		)
 	})
 })

--- a/pkg/client/testingclient/fake.go
+++ b/pkg/client/testingclient/fake.go
@@ -1,0 +1,5 @@
+package testingclient
+
+import "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+var NewFakeClientWithScheme = fake.NewFakeClientWithScheme

--- a/pkg/client/testingclient/fake.go
+++ b/pkg/client/testingclient/fake.go
@@ -2,4 +2,4 @@ package testingclient
 
 import "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-var NewFakeClientWithScheme = fake.NewFakeClientWithScheme
+var NewFakeClientBuilder = fake.NewClientBuilder

--- a/pkg/client/testingclient/keys.go
+++ b/pkg/client/testingclient/keys.go
@@ -1,0 +1,41 @@
+package testingclient
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Verb string
+
+const (
+	// Verb values are chosen to match those returned by client-go testing.Action#GetVerb()
+	GetVerb       Verb = "get"
+	CreateVerb    Verb = "create"
+	DeleteVerb    Verb = "delete"
+	UpdateVerb    Verb = "update"
+	PatchVerb     Verb = "patch"
+	ListVerb      Verb = "list"
+	DeleteAllVerb Verb = "delete-collection"
+	WatchVerb     Verb = "watch"
+
+	// AnyVerb is used to match any of the above API verbs.
+	AnyVerb Verb = "*"
+)
+
+var (
+	// AnyKind is a sentinel value used as a wildcard to match any Kind.
+	AnyKind = &unstructured.Unstructured{}
+	// AnyObject is an empty ObjectKey used to match an object of any identity.
+	AnyObject = client.ObjectKey{}
+
+	// anyKindGVK is used for internal representation of AnyKind.
+	anyKindGVK = schema.GroupVersionKind{Kind: "*"}
+)
+
+type resourceActionKey struct {
+	verb      Verb
+	kind      schema.GroupVersionKind
+	objectKey client.ObjectKey
+}

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Reactive struct {
-	testing.Fake
+	Fake testing.Fake
 	delegate client.Client
 }
 
@@ -42,7 +42,7 @@ func NewReactiveClient(delegate client.Client) *Reactive {
 		delegate: delegate,
 	}
 
-	r.PrependReactor("*", "*", func(action testing.Action) (bool, runtime.Object, error) {
+	r.Fake.PrependReactor("*", "*", func(action testing.Action) (bool, runtime.Object, error) {
 		ctx := context.TODO()
 		switch action.GetVerb() {
 		case "get":
@@ -156,7 +156,7 @@ func (r *Reactive) populateGVK(obj runtime.Object) {
 
 func (r *Reactive) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
 	action := testing.NewGetAction(r.gvrForObject(obj), key.Namespace, key.Name)
-	retrievedObj, err := r.Invokes(action, nil)
+	retrievedObj, err := r.Fake.Invokes(action, nil)
 	if err != nil {
 		return err
 	}
@@ -182,7 +182,7 @@ func (r *Reactive) List(ctx context.Context, list client.ObjectList, opts ...cli
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
 	action := testing.NewListAction(gvr, listGvk, listOpts.Namespace, *listOpts.AsListOptions())
-	retrievedObj, err := r.Invokes(action, nil)
+	retrievedObj, err := r.Fake.Invokes(action, nil)
 	if err != nil {
 		return err
 	}
@@ -201,7 +201,7 @@ func (r *Reactive) Create(ctx context.Context, obj client.Object, opts ...client
 	r.populateGVK(obj)
 
 	action := testing.NewCreateAction(r.gvrForObject(obj), object.GetNamespace(), obj)
-	_, err = r.Invokes(action, nil)
+	_, err = r.Fake.Invokes(action, nil)
 	return err
 }
 
@@ -213,7 +213,7 @@ func (r *Reactive) Delete(ctx context.Context, obj client.Object, opts ...client
 	deleteOpts.ApplyOptions(opts)
 
 	action := testing.NewDeleteAction(r.gvrForObject(obj), obj.GetNamespace(), obj.GetName())
-	_, err := r.Invokes(action, nil)
+	_, err := r.Fake.Invokes(action, nil)
 	return err
 }
 
@@ -229,7 +229,7 @@ func (r *Reactive) Update(ctx context.Context, obj client.Object, opts ...client
 	r.populateGVK(obj)
 
 	action := testing.NewUpdateAction(r.gvrForObject(obj), obj.GetNamespace(), obj)
-	_, err := r.Invokes(action, nil)
+	_, err := r.Fake.Invokes(action, nil)
 	return err
 }
 
@@ -242,7 +242,7 @@ func (r *Reactive) Patch(ctx context.Context, obj client.Object, patch client.Pa
 		return fmt.Errorf("failed patching object: %w", err)
 	}
 	action := testing.NewPatchAction(r.gvrForObject(obj), obj.GetNamespace(), obj.GetName(), patch.Type(), p)
-	_, err = r.Invokes(action, nil)
+	_, err = r.Fake.Invokes(action, nil)
 	return err
 }
 

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -1,0 +1,243 @@
+package testingclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type Reactive struct {
+	testing.Fake
+	delegate client.Client
+}
+
+var _ client.Client = &Reactive{}
+
+func (r *Reactive) Scheme() *runtime.Scheme {
+	return r.delegate.Scheme()
+}
+
+func (r *Reactive) RESTMapper() meta.RESTMapper {
+	return r.delegate.RESTMapper()
+}
+
+// Workaround for testing.ListAction missing GetKind(). It looks like an oversight.
+type workaroundListAction interface {
+	testing.ListAction
+	GetKind() schema.GroupVersionKind
+}
+
+func NewReactiveClient(delegate client.Client) *Reactive {
+	r := &Reactive{
+		delegate: delegate,
+	}
+
+	r.PrependReactor("*", "*", func(action testing.Action) (bool, runtime.Object, error) {
+		ctx := context.TODO()
+		switch action.GetVerb() {
+		case "get":
+			a := action.(testing.GetAction)
+			key := types.NamespacedName{
+				Name:      a.GetName(),
+				Namespace: a.GetNamespace(),
+			}
+			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
+			err := r.delegate.Get(ctx, key, obj)
+			return true, obj, err
+		case "create":
+			a := action.(testing.CreateAction)
+			err := r.delegate.Create(ctx, a.GetObject().(client.Object))
+			return true, nil, err
+		case "delete":
+			a := action.(testing.DeleteAction)
+			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
+			err := r.delegate.Delete(ctx, obj)
+			return true, nil, err
+		case "update":
+			a := action.(testing.UpdateAction)
+			err := r.delegate.Update(ctx, a.GetObject().(client.Object))
+			return true, nil, err
+		case "patch":
+			a := action.(testing.PatchAction)
+			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
+			patch := client.RawPatch(a.GetPatchType(), a.GetPatch())
+			err := r.delegate.Patch(ctx, obj, patch)
+			return true, nil, err
+		case "list":
+			a := action.(workaroundListAction)
+			obj := r.newObjectList(a.GetKind())
+			err := r.delegate.List(ctx, obj,
+				client.MatchingFieldsSelector{Selector: a.GetListRestrictions().Fields},
+				client.MatchingLabelsSelector{Selector: a.GetListRestrictions().Labels},
+				client.InNamespace(a.GetNamespace()),
+			)
+			return true, obj, err
+		default:
+			return true, nil, fmt.Errorf("unsupported action for verb %#v", action.GetVerb())
+		}
+	})
+
+	return r
+}
+
+func (r *Reactive) gvrForObject(obj runtime.Object) schema.GroupVersionResource {
+	defer GinkgoRecover()
+	kinds, _, err := r.Scheme().ObjectKinds(obj)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(kinds).To(HaveLen(1))
+	gvk := kinds[0]
+
+	rm, err := r.RESTMapper().RESTMapping(gvk.GroupKind())
+	Expect(err).NotTo(HaveOccurred())
+	gvr := rm.Resource
+
+	return gvr
+}
+
+func (r *Reactive) kindForResource(resource schema.GroupVersionResource) schema.GroupVersionKind {
+	defer GinkgoRecover()
+	kind, err := r.RESTMapper().KindFor(resource)
+	Expect(err).NotTo(HaveOccurred())
+	return kind
+}
+
+func (r *Reactive) newNamedObject(kind schema.GroupVersionKind, namespace, name string) client.Object {
+	defer GinkgoRecover()
+	rObj := r.newRuntimeObject(kind)
+	cObj, ok := rObj.(client.Object)
+	Expect(ok).To(BeTrue(), "Expected object to implement client.Object. Does it implement metav1.Object?")
+	cObj.SetNamespace(namespace)
+	cObj.SetName(name)
+	return cObj
+}
+
+func (r *Reactive) newObjectList(kind schema.GroupVersionKind) client.ObjectList {
+	defer GinkgoRecover()
+	rObj := r.newRuntimeObject(kind)
+	cObj, ok := rObj.(client.ObjectList)
+	Expect(ok).To(BeTrue(), "Expected object to implement client.ObjectList. Does it implement metav1.ListInterface?")
+	return cObj
+}
+
+func (r *Reactive) newRuntimeObject(kind schema.GroupVersionKind) runtime.Object {
+	defer GinkgoRecover()
+	rObj, err := r.Scheme().New(kind)
+	Expect(err).NotTo(HaveOccurred())
+	return rObj
+}
+
+func (r *Reactive) populateGVK(obj runtime.Object) {
+	defer GinkgoRecover()
+	// Set GVK using reflection. Normally the apiserver would populate this, but we need it earlier.
+	gvk, err := apiutil.GVKForObject(obj, r.Scheme())
+	Expect(err).NotTo(HaveOccurred())
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+}
+
+func (r *Reactive) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	action := testing.NewGetAction(r.gvrForObject(obj), key.Namespace, key.Name)
+	retrievedObj, err := r.Invokes(action, nil)
+	if err != nil {
+		return err
+	}
+	return r.Scheme().Convert(retrievedObj, obj, nil)
+}
+
+func (r *Reactive) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	defer GinkgoRecover()
+
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+
+	listGvk, err := apiutil.GVKForObject(list, r.Scheme())
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(listGvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", list, listGvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk := listGvk
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-len("List")]
+
+	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
+
+	action := testing.NewListAction(gvr, listGvk, listOpts.Namespace, *listOpts.AsListOptions())
+	retrievedObj, err := r.Invokes(action, nil)
+	if err != nil {
+		return err
+	}
+	return r.Scheme().Convert(retrievedObj, list, nil)
+}
+
+func (r *Reactive) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	defer GinkgoRecover()
+	Expect(opts).To(BeEmpty(), "we can't handle opts")
+	object, err := meta.Accessor(obj)
+	if err != nil {
+		return fmt.Errorf("failed creating object: %w", err)
+	}
+
+	r.populateGVK(obj)
+
+	action := testing.NewCreateAction(r.gvrForObject(obj), object.GetNamespace(), obj)
+	_, err = r.Invokes(action, nil)
+	return err
+}
+
+func (r *Reactive) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	defer GinkgoRecover()
+
+	// TODO: We are just dropping these options on the floor... this is the same thing
+	//       that the controller-runtime fake client does, so it doesn't seem too unusual
+	//       but is that really the right thing to do here?
+	deleteOpts := client.DeleteOptions{}
+	deleteOpts.ApplyOptions(opts)
+
+	action := testing.NewDeleteAction(r.gvrForObject(obj), obj.GetNamespace(), obj.GetName())
+	_, err := r.Invokes(action, nil)
+	return err
+}
+
+func (r *Reactive) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	panic("implement me")
+}
+
+func (r *Reactive) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	defer GinkgoRecover()
+	Expect(opts).To(BeEmpty(), "we can't handle opts")
+
+	r.populateGVK(obj)
+
+	action := testing.NewUpdateAction(r.gvrForObject(obj), obj.GetNamespace(), obj)
+	_, err := r.Invokes(action, nil)
+	return err
+}
+
+func (r *Reactive) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	defer GinkgoRecover()
+	Expect(opts).To(BeEmpty(), "we can't handle opts")
+	p, err := patch.Data(obj)
+	if err != nil {
+		return fmt.Errorf("failed patching object: %w", err)
+	}
+	action := testing.NewPatchAction(r.gvrForObject(obj), obj.GetNamespace(), obj.GetName(), patch.Type(), p)
+	_, err = r.Invokes(action, nil)
+	return err
+}
+
+func (r *Reactive) Status() client.StatusWriter {
+	return r
+}

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -44,8 +44,8 @@ func NewReactiveClient(delegate client.Client) *Reactive {
 
 	r.Fake.PrependReactor("*", "*", func(action testing.Action) (bool, runtime.Object, error) {
 		ctx := context.TODO()
-		switch action.GetVerb() {
-		case "get":
+		switch Verb(action.GetVerb()) {
+		case GetVerb:
 			a := action.(testing.GetAction)
 			key := types.NamespacedName{
 				Name:      a.GetName(),
@@ -54,26 +54,26 @@ func NewReactiveClient(delegate client.Client) *Reactive {
 			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
 			err := r.delegate.Get(ctx, key, obj)
 			return true, obj, err
-		case "create":
+		case CreateVerb:
 			a := action.(testing.CreateAction)
 			err := r.delegate.Create(ctx, a.GetObject().(client.Object))
 			return true, nil, err
-		case "delete":
+		case DeleteVerb:
 			a := action.(testing.DeleteAction)
 			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
 			err := r.delegate.Delete(ctx, obj)
 			return true, nil, err
-		case "update":
+		case UpdateVerb:
 			a := action.(testing.UpdateAction)
 			err := r.delegate.Update(ctx, a.GetObject().(client.Object))
 			return true, nil, err
-		case "patch":
+		case PatchVerb:
 			a := action.(testing.PatchAction)
 			obj := r.newNamedObject(r.kindForResource(a.GetResource()), a.GetNamespace(), a.GetName())
 			patch := client.RawPatch(a.GetPatchType(), a.GetPatch())
 			err := r.delegate.Patch(ctx, obj, patch)
 			return true, nil, err
-		case "list":
+		case ListVerb:
 			a := action.(workaroundListAction)
 			obj := r.newObjectList(a.GetKind())
 			err := r.delegate.List(ctx, obj,

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -217,7 +217,7 @@ func (r *Reactive) List(ctx context.Context, list client.ObjectList, opts ...cli
 	if err != nil {
 		return err
 	}
-	return r.Scheme().Convert(retrievedObj, list, nil)
+	return r.convertWithTypeMeta(retrievedObj, list)
 }
 
 func (r *Reactive) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -145,6 +145,16 @@ func (r *Reactive) newRuntimeObject(kind schema.GroupVersionKind) runtime.Object
 	return rObj
 }
 
+// PrependReactor adds a reactor to the beginning of the chain.
+func (r *Reactive) PrependReactor(verb Verb, kind client.Object, reaction testing.ReactionFunc) {
+	resource := "*"
+	if kind != AnyKind {
+		gvr := r.gvrForObject(kind)
+		resource = gvr.Resource
+	}
+	r.Fake.PrependReactor(string(verb), resource, reaction)
+}
+
 func (r *Reactive) populateGVK(obj runtime.Object) {
 	// Set GVK using reflection. Normally the apiserver would populate this, but we need it earlier.
 	gvk, err := apiutil.GVKForObject(obj, r.Scheme())

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -155,6 +155,16 @@ func (r *Reactive) PrependReactor(verb Verb, kind client.Object, reaction testin
 	r.Fake.PrependReactor(string(verb), resource, reaction)
 }
 
+// Actions returns a chronologically ordered slice of actions called on the fake client.
+func (r *Reactive) Actions() []testing.Action {
+	return r.Fake.Actions()
+}
+
+// ClearActions clears the history of actions called on the fake client.
+func (r *Reactive) ClearActions() {
+	r.Fake.ClearActions()
+}
+
 func (r *Reactive) populateGVK(obj runtime.Object) {
 	// Set GVK using reflection. Normally the apiserver would populate this, but we need it earlier.
 	gvk, err := apiutil.GVKForObject(obj, r.Scheme())

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -198,18 +197,7 @@ func (r *Reactive) List(ctx context.Context, list client.ObjectList, opts ...cli
 	listOpts := client.ListOptions{}
 	listOpts.ApplyOptions(opts)
 
-	listGvk, err := apiutil.GVKForObject(list, r.Scheme())
-	if err != nil {
-		return err
-	}
-
-	if !strings.HasSuffix(listGvk.Kind, "List") {
-		return fmt.Errorf("non-list type %T (kind %q) passed as output", list, listGvk)
-	}
-	// we need the non-list GVK, so chop off the "List" from the end of the kind
-	gvk := listGvk
-	gvk.Kind = gvk.Kind[:len(gvk.Kind)-len("List")]
-
+	gvk, listGvk, err := listGVK(list, r.Scheme())
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 
 	action := testing.NewListAction(gvr, listGvk, listOpts.Namespace, *listOpts.AsListOptions())

--- a/pkg/client/testingclient/reactive.go
+++ b/pkg/client/testingclient/reactive.go
@@ -16,6 +16,9 @@ import (
 )
 
 type Reactive struct {
+	// Fake exposes the underlying client-go testing.Fake used for reaction chains. Be cautious accessing this directly.
+	// In particular, emptying Fake.ReactionChain will remove the default reactor, and may result in falling off the
+	// end of the ReactionChain, resulting in returning nil objects rather than calling the delegate client.
 	Fake testing.Fake
 	delegate client.Client
 }
@@ -145,6 +148,7 @@ func (r *Reactive) newRuntimeObject(kind schema.GroupVersionKind) runtime.Object
 }
 
 // PrependReactor adds a reactor to the beginning of the chain.
+// (testing.Fake's AddReactor is not exposed because it is not useful as long as the default Reactor is in place.)
 func (r *Reactive) PrependReactor(verb Verb, kind client.Object, reaction testing.ReactionFunc) {
 	resource := "*"
 	if kind != AnyKind {

--- a/pkg/client/testingclient/reactive_test.go
+++ b/pkg/client/testingclient/reactive_test.go
@@ -1,0 +1,4 @@
+package testingclient
+
+// TODO: test for assertion failure if List isn't passed something that implements client.ObjectList / metav1.ListInterface
+// TODO: test for assertion failure if Get isn't passed something that implements client.Object / metav1.Object

--- a/pkg/client/testingclient/reactive_test.go
+++ b/pkg/client/testingclient/reactive_test.go
@@ -24,7 +24,7 @@ var _ = Describe("Reactive", func() {
 		fakeClient client.Client
 	)
 	BeforeEach(func() {
-		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+		fakeClient = testingclient.NewFakeClientBuilder().WithScheme(scheme.Scheme).Build()
 
 		examplePod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/client/testingclient/reactive_test.go
+++ b/pkg/client/testingclient/reactive_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -150,6 +151,248 @@ var _ = Describe("Reactive", func() {
 				Expect(fakeClient.List(nil, &listInDelegate)).To(Succeed())
 
 				Expect(list).To(gstruct.PointTo(Equal(listInDelegate)), "list should be the retrieved list")
+			})
+		})
+	})
+
+	Describe("Create", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod3"}
+		var (
+			obj    *corev1.Pod
+			apiErr error
+		)
+		JustBeforeEach(func() {
+			obj = &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      key.Name,
+					Namespace: key.Namespace,
+				},
+			}
+			apiErr = subject.Create(nil, obj)
+		})
+
+		When("the reactor 'handles' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.CreateVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return true, nil, errors.New("reactor error")
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+				Expect(apiErr).To(MatchError("reactor error"))
+			})
+
+			It("doesn't call the delegate", func() {
+				var objInDelegate corev1.Pod
+				err := fakeClient.Get(nil, key, &objInDelegate)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "should not create the object")
+			})
+		})
+
+		When("the reactor doesn't 'handle' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.CreateVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return false, nil, nil
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+			})
+
+			It("calls the delegate client", func() {
+				Expect(apiErr).NotTo(HaveOccurred())
+
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+				objInDelegate.ResourceVersion = "" // Clear this for comparison. It is set by fake.Client.Create()
+
+				Expect(obj).To(gstruct.PointTo(Equal(objInDelegate)), "obj should be the retrieved object")
+			})
+		})
+	})
+
+	Describe("Delete", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var (
+			obj    corev1.Pod
+			apiErr error
+		)
+		JustBeforeEach(func() {
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			apiErr = subject.Delete(nil, &obj)
+		})
+
+		When("the reactor 'handles' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.DeleteVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return true, nil, errors.New("reactor error")
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+				Expect(apiErr).To(MatchError("reactor error"))
+			})
+
+			It("doesn't call the delegate", func() {
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+				Expect(obj).To(Equal(objInDelegate), "obj should still exist in the delegate")
+			})
+		})
+
+		When("the reactor doesn't 'handle' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.DeleteVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return false, nil, nil
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+			})
+
+			It("calls the delegate client", func() {
+				Expect(apiErr).NotTo(HaveOccurred())
+
+				var objInDelegate corev1.Pod
+				err := fakeClient.Get(nil, key, &objInDelegate)
+				Expect(apierrors.IsNotFound(err)).To(BeTrue(), "object should have been deleted")
+			})
+		})
+	})
+
+	Describe("Update", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var (
+			obj    corev1.Pod
+			apiErr error
+		)
+		JustBeforeEach(func() {
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			Expect(obj.Spec.Hostname).To(BeEmpty(), "consistency check")
+			updatedObj := obj.DeepCopy()
+			updatedObj.Spec.Hostname = "new-hostname"
+			apiErr = subject.Update(nil, updatedObj)
+		})
+
+		When("the reactor 'handles' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.UpdateVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return true, nil, errors.New("reactor error")
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+				Expect(apiErr).To(MatchError("reactor error"))
+			})
+
+			It("doesn't call the delegate", func() {
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+				Expect(objInDelegate.Spec.Hostname).To(BeEmpty(), "obj should not have been updated")
+			})
+		})
+
+		When("the reactor doesn't 'handle' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.UpdateVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return false, nil, nil
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+			})
+
+			It("calls the delegate client", func() {
+				Expect(apiErr).NotTo(HaveOccurred())
+
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+				Expect(objInDelegate.Spec.Hostname).To(Equal("new-hostname"), "obj should have been updated")
+			})
+		})
+	})
+
+	Describe("Patch", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var (
+			obj    corev1.Pod
+			apiErr error
+		)
+		JustBeforeEach(func() {
+			Expect(fakeClient.Get(nil, key, &obj)).To(Succeed())
+			Expect(obj.Spec.Hostname).To(BeEmpty(), "consistency check")
+			updatedObj := obj.DeepCopy()
+			updatedObj.Spec.Hostname = "new-hostname"
+			apiErr = subject.Patch(nil, updatedObj, client.MergeFrom(&obj))
+		})
+
+		When("the reactor 'handles' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.PatchVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return true, nil, errors.New("reactor error")
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+				Expect(apiErr).To(MatchError("reactor error"))
+			})
+
+			It("doesn't call the delegate", func() {
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+				Expect(objInDelegate.Spec.Hostname).To(BeEmpty(), "obj should not have been updated")
+			})
+		})
+
+		When("the reactor doesn't 'handle' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.PatchVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return false, nil, nil
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+			})
+
+			It("calls the delegate client", func() {
+				Expect(apiErr).NotTo(HaveOccurred())
+
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+				Expect(objInDelegate.Spec.Hostname).To(Equal("new-hostname"), "obj should have been updated")
 			})
 		})
 	})

--- a/pkg/client/testingclient/reactive_test.go
+++ b/pkg/client/testingclient/reactive_test.go
@@ -1,4 +1,104 @@
-package testingclient
+package testingclient_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/testingclient"
+)
+
+var _ = Describe("Reactive", func() {
+	var (
+		subject    *testingclient.Reactive
+		fakeClient client.Client
+	)
+	BeforeEach(func() {
+		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+
+		examplePod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "ns",
+			},
+		}
+
+		pod1 := examplePod.DeepCopy()
+		pod1.Name = "pod1"
+		pod2 := examplePod.DeepCopy()
+		pod2.Name = "pod2"
+
+		Expect(fakeClient.Create(nil, pod1)).To(Succeed())
+		Expect(fakeClient.Create(nil, pod2)).To(Succeed())
+
+		subject = testingclient.NewReactiveClient(fakeClient)
+	})
+
+	Describe("Get", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		var (
+			obj    *corev1.Pod
+			apiErr error
+		)
+		JustBeforeEach(func() {
+			obj = new(corev1.Pod)
+			apiErr = subject.Get(nil, key, obj)
+		})
+
+		When("the reactor 'handles' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.GetVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return true, nil, errors.New("reactor error")
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+				Expect(apiErr).To(MatchError("reactor error"))
+			})
+
+			It("doesn't call the delegate", func() {
+				Expect(obj.GetName()).To(BeEmpty())
+			})
+		})
+
+		When("the reactor doesn't 'handle' the action", func() {
+			var reactorCalled bool
+			BeforeEach(func() {
+				reactorCalled = false
+				subject.PrependReactor(testingclient.GetVerb, &corev1.Pod{}, func(action testing.Action) (handled bool, ret runtime.Object, err error) {
+					reactorCalled = true
+					return false, nil, nil
+				})
+			})
+
+			It("calls the reactor", func() {
+				Expect(reactorCalled).To(BeTrue())
+			})
+
+			It("calls the delegate client", func() {
+				Expect(apiErr).NotTo(HaveOccurred())
+
+				var objInDelegate corev1.Pod
+				Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+				Expect(obj).To(gstruct.PointTo(Equal(objInDelegate)), "obj should be the retrieved object")
+			})
+		})
+	})
+})
 
 // TODO: test for assertion failure if List isn't passed something that implements client.ObjectList / metav1.ListInterface
 // TODO: test for assertion failure if Get isn't passed something that implements client.Object / metav1.Object

--- a/pkg/client/testingclient/spy.go
+++ b/pkg/client/testingclient/spy.go
@@ -45,7 +45,7 @@ func (s Spy) Get(ctx context.Context, key client.ObjectKey, obj client.Object) e
 		GVK:  mustGVKForObject(obj, s.Scheme()),
 		Verb: "get",
 		Key:  key,
-		Obj:  obj,
+		Obj:  obj.DeepCopyObject().(client.Object),
 	}
 	return err
 }
@@ -60,7 +60,7 @@ func (s Spy) List(ctx context.Context, list client.ObjectList, opts ...client.Li
 	s.Calls <- SpyCall{
 		GVK:  gvk,
 		Verb: "list",
-		List: list,
+		List: list.DeepCopyObject().(client.ObjectList),
 	}
 	return listErr
 }
@@ -70,7 +70,7 @@ func (s Spy) Create(ctx context.Context, obj client.Object, opts ...client.Creat
 	s.Calls <- SpyCall{
 		GVK:  mustGVKForObject(obj, s.Scheme()),
 		Verb: "create",
-		Obj:  obj,
+		Obj:  obj.DeepCopyObject().(client.Object),
 	}
 	return err
 }
@@ -80,7 +80,7 @@ func (s Spy) Delete(ctx context.Context, obj client.Object, opts ...client.Delet
 	s.Calls <- SpyCall{
 		GVK:  mustGVKForObject(obj, s.Scheme()),
 		Verb: "delete",
-		Obj:  obj,
+		Obj:  obj.DeepCopyObject().(client.Object),
 	}
 	return err
 }
@@ -91,7 +91,7 @@ func (s Spy) Update(ctx context.Context, obj client.Object, opts ...client.Updat
 		GVK:      mustGVKForObject(obj, s.Scheme()),
 		IsStatus: s.isStatus,
 		Verb:     "update",
-		Obj:      obj,
+		Obj:      obj.DeepCopyObject().(client.Object),
 	}
 	return err
 }
@@ -102,7 +102,7 @@ func (s Spy) Patch(ctx context.Context, obj client.Object, patch client.Patch, o
 		GVK:      mustGVKForObject(obj, s.Scheme()),
 		IsStatus: s.isStatus,
 		Verb:     "patch",
-		Obj:      obj,
+		Obj:      obj.DeepCopyObject().(client.Object),
 		Patch:    patch,
 	}
 	return err

--- a/pkg/client/testingclient/spy.go
+++ b/pkg/client/testingclient/spy.go
@@ -1,0 +1,143 @@
+package testingclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type SpyCall struct {
+	GVK      schema.GroupVersionKind
+	IsStatus bool
+	Verb     string
+	Key      client.ObjectKey
+	Obj      client.Object
+	List     client.ObjectList
+	Patch    client.Patch
+}
+
+type Spy struct {
+	Delegate client.Client
+	Calls    chan<- SpyCall
+	isStatus bool
+}
+
+var _ client.Client = Spy{}
+
+func (s Spy) Scheme() *runtime.Scheme {
+	return s.Delegate.Scheme()
+}
+
+func (s Spy) RESTMapper() meta.RESTMapper {
+	return s.Delegate.RESTMapper()
+}
+
+func (s Spy) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	err := s.Delegate.Get(ctx, key, obj)
+	s.Calls <- SpyCall{
+		GVK:  mustGVKForObject(obj, s.Scheme()),
+		Verb: "get",
+		Key:  key,
+		Obj:  obj,
+	}
+	return err
+}
+
+func (s Spy) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := listGVK(list, s.Scheme())
+	if err != nil {
+		return err
+	}
+
+	listErr := s.Delegate.List(ctx, list, opts...)
+	s.Calls <- SpyCall{
+		GVK:  gvk,
+		Verb: "list",
+		List: list,
+	}
+	return listErr
+}
+
+func (s Spy) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	err := s.Delegate.Create(ctx, obj, opts...)
+	s.Calls <- SpyCall{
+		GVK:  mustGVKForObject(obj, s.Scheme()),
+		Verb: "create",
+		Obj:  obj,
+	}
+	return err
+}
+
+func (s Spy) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	err := s.Delegate.Delete(ctx, obj, opts...)
+	s.Calls <- SpyCall{
+		GVK:  mustGVKForObject(obj, s.Scheme()),
+		Verb: "delete",
+		Obj:  obj,
+	}
+	return err
+}
+
+func (s Spy) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	err := s.Delegate.Update(ctx, obj, opts...)
+	s.Calls <- SpyCall{
+		GVK:      mustGVKForObject(obj, s.Scheme()),
+		IsStatus: s.isStatus,
+		Verb:     "update",
+		Obj:      obj,
+	}
+	return err
+}
+
+func (s Spy) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	err := s.Delegate.Patch(ctx, obj, patch, opts...)
+	s.Calls <- SpyCall{
+		GVK:      mustGVKForObject(obj, s.Scheme()),
+		IsStatus: s.isStatus,
+		Verb:     "patch",
+		Obj:      obj,
+		Patch:    patch,
+	}
+	return err
+}
+
+func (s Spy) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	err := s.Delegate.DeleteAllOf(ctx, obj, opts...)
+	s.Calls <- SpyCall{
+		GVK:  mustGVKForObject(obj, s.Scheme()),
+		Verb: "deleteallof",
+	}
+	return err
+}
+
+func (s Spy) Status() client.StatusWriter {
+	s.isStatus = true
+	return s
+}
+
+func mustGVKForObject(obj runtime.Object, scheme *runtime.Scheme) schema.GroupVersionKind {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		panic(fmt.Errorf("couldn't look up GVK for object (check Scheme): %w", err))
+	}
+	return gvk
+}
+
+func listGVK(list client.ObjectList, scheme *runtime.Scheme) (schema.GroupVersionKind, error) {
+	listGvk := mustGVKForObject(list, scheme)
+
+	if !strings.HasSuffix(listGvk.Kind, "List") {
+		return schema.GroupVersionKind{}, fmt.Errorf("non-list type %T (kind %q) passed as output", list, listGvk)
+	}
+	// we need the non-list GVK, so chop off the "List" from the end of the kind
+	gvk := listGvk
+	gvk.Kind = gvk.Kind[:len(gvk.Kind)-len("List")]
+	return gvk, nil
+}

--- a/pkg/client/testingclient/spy_test.go
+++ b/pkg/client/testingclient/spy_test.go
@@ -1,0 +1,230 @@
+package testingclient_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/testingclient"
+)
+
+var _ = Describe("Spy", func() {
+	var (
+		subject    testingclient.Spy
+		fakeClient client.Client
+		calls      chan testingclient.SpyCall
+	)
+	BeforeEach(func() {
+		calls = make(chan testingclient.SpyCall, 1)
+		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+
+		examplePod := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod",
+				Namespace: "ns",
+			},
+		}
+
+		pod1 := examplePod.DeepCopy()
+		pod1.Name = "pod1"
+		pod2 := examplePod.DeepCopy()
+		pod2.Name = "pod2"
+
+		Expect(fakeClient.Create(nil, pod1)).To(Succeed())
+		Expect(fakeClient.Create(nil, pod2)).To(Succeed())
+
+		subject = testingclient.Spy{
+			Delegate: fakeClient,
+			Calls:    calls,
+		}
+	})
+
+	It("spies on calls to Get", func() {
+		var obj corev1.Pod
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		Expect(subject.Get(nil, key, &obj)).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("get"))
+		Expect(call.Key).To(Equal(key))
+
+		var objInDelegate corev1.Pod
+		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+		Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the retrieved object")
+	})
+
+	It("spies on calls to List", func() {
+		var list corev1.PodList
+		Expect(subject.List(nil, &list)).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("list"))
+
+		var listInDelegate corev1.PodList
+		Expect(fakeClient.List(nil, &listInDelegate)).To(Succeed())
+		Expect(listInDelegate.Items).To(HaveLen(2), "consistency check")
+
+		Expect(call.List).To(Equal(client.ObjectList(&listInDelegate)), "call.Obj should be the retrieved list")
+	})
+
+	It("spies on calls to Create", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "app1"}
+		obj := appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: key.Namespace, Name: key.Name,
+			},
+		}
+		Expect(subject.Create(nil, &obj)).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("apps/v1, Kind=Deployment"))
+		Expect(call.Verb).To(Equal("create"))
+
+		var objInDelegate appsv1.Deployment
+		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+		objInDelegate.TypeMeta = metav1.TypeMeta{} // Clear TypeMeta for comparison. fakeClient.Get() fills this in.
+		Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the created object")
+	})
+
+	It("spies on calls to Delete", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		obj := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: key.Namespace, Name: key.Name,
+			},
+		}
+		Expect(subject.Delete(nil, &obj)).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("delete"))
+		Expect(call.Obj).To(Equal(client.Object(&obj)), "call.Obj should be the deleted object")
+
+		var objInDelegate corev1.Pod
+		err := fakeClient.Get(nil, key, &objInDelegate)
+		Expect(errors.IsNotFound(err)).To(BeTrue(), "The object should have been deleted in the delegate")
+	})
+
+	It("spies on calls to Update", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		obj := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: key.Namespace, Name: key.Name,
+				Annotations: map[string]string{
+					"annotation1": "added-annotation",
+				},
+			},
+		}
+		Expect(subject.Update(nil, &obj)).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("update"))
+
+		var objInDelegate corev1.Pod
+		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+		Expect(call.Obj.GetAnnotations()).To(HaveKeyWithValue("annotation1", "added-annotation"))
+		objInDelegate.TypeMeta = metav1.TypeMeta{} // Clear TypeMeta for comparison. fakeClient.Get() fills this in.
+		Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the updated object")
+	})
+
+	It("spies on calls to Patch", func() {
+		key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+		obj := corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: key.Namespace, Name: key.Name,
+			},
+		}
+		Expect(subject.Patch(nil, &obj, client.RawPatch(types.MergePatchType,
+			[]byte(`{"metadata":{"annotations":{"annotation1":"patched-annotation"}}}`))),
+		).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("patch"))
+
+		var objInDelegate corev1.Pod
+		Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+		Expect(call.Obj.GetAnnotations()).To(HaveKeyWithValue("annotation1", "patched-annotation"))
+		Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the updated object")
+	})
+
+	It("spies on calls to DeleteAllOf", func() {
+		Expect(subject.DeleteAllOf(nil, &corev1.Pod{})).To(Succeed())
+		var call testingclient.SpyCall
+		Expect(calls).To(Receive(&call))
+		Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+		Expect(call.Verb).To(Equal("deleteallof"))
+
+		for _, key := range []types.NamespacedName{
+			{Namespace: "ns", Name: "pod1"},
+			{Namespace: "ns", Name: "pod2"},
+		} {
+			var objInDelegate corev1.Pod
+			err := fakeClient.Get(nil, key, &objInDelegate)
+			Expect(errors.IsNotFound(err)).To(BeTrue(), "The object %s should have been deleted in the delegate", key)
+		}
+	})
+
+	Context("StatusWriter", func() {
+		It("spies on calls to Status().Update()", func() {
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			obj := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: key.Namespace, Name: key.Name,
+				},
+				Status: corev1.PodStatus{
+					Message: "The status is good",
+				},
+			}
+			Expect(subject.Status().Update(nil, &obj)).To(Succeed())
+			var call testingclient.SpyCall
+			Expect(calls).To(Receive(&call))
+			Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+			Expect(call.Verb).To(Equal("update"))
+			Expect(call.IsStatus).To(BeTrue())
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+			Expect(call.Obj.(*corev1.Pod).Status.Message).To(Equal("The status is good"))
+			objInDelegate.TypeMeta = metav1.TypeMeta{} // Clear TypeMeta for comparison. fakeClient.Get() fills this in.
+			Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the updated object")
+		})
+
+		It("spies on calls to Status().Patch()", func() {
+			key := types.NamespacedName{Namespace: "ns", Name: "pod1"}
+			obj := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: key.Namespace, Name: key.Name,
+				},
+			}
+			Expect(subject.Status().Patch(nil, &obj, client.RawPatch(types.MergePatchType,
+				[]byte(`{"status":{"message":"The status has been patched"}}`))),
+			).To(Succeed())
+			var call testingclient.SpyCall
+			Expect(calls).To(Receive(&call))
+			Expect(call.GVK.String()).To(Equal("/v1, Kind=Pod"))
+			Expect(call.Verb).To(Equal("patch"))
+			Expect(call.IsStatus).To(BeTrue())
+
+			var objInDelegate corev1.Pod
+			Expect(fakeClient.Get(nil, key, &objInDelegate)).To(Succeed())
+
+			Expect(call.Obj.(*corev1.Pod).Status.Message).To(Equal("The status has been patched"))
+			Expect(call.Obj).To(Equal(client.Object(&objInDelegate)), "call.Obj should be the updated object")
+		})
+	})
+})

--- a/pkg/client/testingclient/spy_test.go
+++ b/pkg/client/testingclient/spy_test.go
@@ -22,7 +22,7 @@ var _ = Describe("Spy", func() {
 	)
 	BeforeEach(func() {
 		calls = make(chan testingclient.SpyCall, 1)
-		fakeClient = testingclient.NewFakeClientWithScheme(scheme.Scheme)
+		fakeClient = testingclient.NewFakeClientBuilder().WithScheme(scheme.Scheme).Build()
 
 		examplePod := corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/client/testingclient/testingclient_suite_test.go
+++ b/pkg/client/testingclient/testingclient_suite_test.go
@@ -1,0 +1,13 @@
+package testingclient_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestTestingclient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Testingclient Suite")
+}


### PR DESCRIPTION
This PR is a proposal to add a set of testing clients to controller-runtime. This code is in a fairly early state, and I'm requesting feedback on the direction and acceptability. In particular, I know it needs tests backfilled, and documentation added. Also not sure about any file copyright headers that may need to be added (couldn't find guidelines about that).

This is somewhat an alternative proposal to, but mostly an expansion of, #1048.

- testingclient.Spy: Records calls to the API before delegating to the underlying client. It writes the records to a channel. This means that if a synchronous channel is used, it could also be used for synchronizing timing between test code and the code under test.
- testingclient.ErrorInjector: Intercepts calls to the delegate client to force an error to be returned. Errors can be injected for any combination of action ("get", "create", "update", etc), kind, and object key, with wildcards available.
- testingclient.Reactive: Brings the functionality of client-go's Reactors to the controller-runtime Client API.

I understand that `testingclient.Reactive` might not be desired for inclusion because it's high flexibility can turn it into a footgun. However, it is in active use by a few teams at VMware, with multiple copies existing. Most of its uses could be replaced with the other testing clients, which represent the two most common use cases.

One class of usage of `testingclient.Reactive` in our code that cannot currently covered by `testingclient.ErrorInjector` is filtering the contents of a "patch" to decide if an error should be returned. I can work on adding that, but it's not immediately clear to me what the API for it should be. (Perhaps a separate method, `InjectErrorForPatchContaining(kind client.Object, objectKey client.ObjectKey, patchContains string, injectedError error)`, or `InjectErrorForPatchMatching()` where patchContains could be a `regexp.RE`.)

For the sake of numbers, here's a categorization of all uses of PrependReactor in one operator's unit tests and how they could be replaced with these clients:

```
  28 //Reactive -> Error
  12 //Reactive -> Spy
  11 //Reactive -> Error, but with filtering the patch content
```

CC: @jpatel-pivotal @abg @vincepri 