### PR TITLE
✨ Adding WithContextFunc for webhook server to pass info to the handler

### DIFF
--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -45,6 +45,10 @@ var _ http.Handler = &Webhook{}
 func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body []byte
 	var err error
+	ctx := r.Context()
+	if wh.WithContextFunc != nil {
+		ctx = wh.WithContextFunc(ctx, r)
+	}
 
 	var reviewResponse Response
 	if r.Body != nil {
@@ -93,7 +97,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	wh.log.V(1).Info("received request", "UID", req.UID, "kind", req.Kind, "resource", req.Resource)
 
 	// TODO: add panic-recovery for Handle
-	reviewResponse = wh.Handle(r.Context(), req)
+	reviewResponse = wh.Handle(ctx, req)
 	wh.writeResponseTyped(w, reviewResponse, actualAdmRevGVK)
 }
 

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -115,6 +115,11 @@ type Webhook struct {
 	// and potentially patches to apply to the handler.
 	Handler Handler
 
+	// WithContextFunc will allow you to take the http.Request.Context() and
+	// add any additional information such as passing the request path or
+	// headers thus allowing you to read them from within the handler
+	WithContextFunc func(context.Context, *http.Request) context.Context
+
 	// decoder is constructed on receiving a scheme and passed down to then handler
 	decoder *Decoder
 


### PR DESCRIPTION
This closes #1333 and extends #549.

This non-breaking change introduces a new field on the webhook server registration, this allows you to add additional information to the request context from the `ServeHTTP` func. This is useful if you need to get information from the http.Request like parsing the request path for variables.

### Controller Builder Implementation:

This example will write the request path back to 

```
type pathKeyType int
const pathKey pathKeyType = iota
func setPath(ctx context.Context, r *http.Request) context.Context {
	return context.WithValue(ctx, pathKey, r.URL.Path)
}

// Get will return the new request details from the context
func getPath(ctx context.Context) string {
	return ctx.Value(pathKey).(string)
}

mgr.GetWebhookServer().Register("/webhook", &webhook.Admission{
	Handler: &fakeHandler{
		fn: func(ctx context.Context, req Request) Response {
			return Allowed(getPath(ctx))
		},
	},
	WithContextFunc: setPath,
})
```

Signed-off-by: Chris Hein <me@chrishein.com>