### PR TITLE
✨ Checking configfile examples on check_everything.sh

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -37,6 +37,8 @@ ${hack_dir}/test-all.sh
 header_text "confirming examples compile (via go install)"
 go install ${MOD_OPT} ./examples/builtins
 go install ${MOD_OPT} ./examples/crd
+go install ${MOD_OPT} ./examples/configfile/builtin
+go install ${MOD_OPT} ./examples/configfile/custom
 
 echo "passed"
 exit 0


### PR DESCRIPTION
This adds both configfiles examples to the automated testing with `check-everything.sh`.

Signed-off-by: Chris Hein <me@chrishein.com>