### PR TITLE
⚠ Add manager option to enable caching of unstructured objects

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -117,6 +117,10 @@ type Options struct {
 	// for the given objects.
 	ClientDisableCacheFor []client.Object
 
+	// ClientCacheUnstructured tells the client that, if any cache is used, to use it
+	// for unstructured and unstructured list objects.
+	ClientCacheUnstructured bool
+
 	// DryRunClient specifies whether the client should be configured to enforce
 	// dryRun mode.
 	DryRunClient bool
@@ -175,6 +179,7 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 
 	writeObj, err := options.ClientBuilder.
 		WithUncached(options.ClientDisableCacheFor...).
+		CacheUnstructured(options.ClientCacheUnstructured).
 		Build(cache, config, clientOptions)
 	if err != nil {
 		return nil, err

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -43,6 +43,10 @@ func (e *fakeClientBuilder) WithUncached(objs ...client.Object) ClientBuilder {
 	return e
 }
 
+func (e *fakeClientBuilder) CacheUnstructured(_ bool) ClientBuilder {
+	return e
+}
+
 func (e *fakeClientBuilder) Build(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
 	return nil, e.err
 }

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -213,6 +213,10 @@ type Options struct {
 	// for the given objects.
 	ClientDisableCacheFor []client.Object
 
+	// ClientCacheUnstructured tells the client that, if any cache is used, to use it
+	// for unstructured and unstructured list objects.
+	ClientCacheUnstructured bool
+
 	// DryRunClient specifies whether the client should be configured to enforce
 	// dryRun mode.
 	DryRunClient bool
@@ -284,6 +288,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		clusterOptions.NewCache = options.NewCache
 		clusterOptions.ClientBuilder = options.ClientBuilder
 		clusterOptions.ClientDisableCacheFor = options.ClientDisableCacheFor
+		clusterOptions.ClientCacheUnstructured = options.ClientCacheUnstructured
 		clusterOptions.DryRunClient = options.DryRunClient
 		clusterOptions.EventBroadcaster = options.EventBroadcaster
 	})

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -62,6 +62,10 @@ func (e *fakeClientBuilder) WithUncached(objs ...client.Object) ClientBuilder {
 	return e
 }
 
+func (e *fakeClientBuilder) CacheUnstructured(_ bool) ClientBuilder {
+	return e
+}
+
 func (e *fakeClientBuilder) Build(cache cache.Cache, config *rest.Config, options client.Options) (client.Client, error) {
 	return nil, e.err
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

This PR adds a new manager/cluster option, called `ClientCacheUnstructured` that configures the ClientBuilder to build a client that caches unstructured objects.

It is a breaking change because it requires a new method on the `cluster.ClientBuilder` interface.

This is a follow-up based on https://github.com/kubernetes-sigs/controller-runtime/pull/1332#issuecomment-760313271
