### PR TITLE
:bug: Fix a race in the delegating logger

### DIFF
--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -72,8 +72,10 @@ func (p *loggerPromise) Fulfill(parentLogger logr.Logger) {
 		logger = logger.WithValues(p.tags...)
 	}
 
+	p.logger.lock.Lock()
 	p.logger.Logger = logger
 	p.logger.promise = nil
+	p.logger.lock.Unlock()
 
 	for _, childPromise := range p.childPromises {
 		childPromise.Fulfill(logger)
@@ -86,12 +88,16 @@ func (p *loggerPromise) Fulfill(parentLogger logr.Logger) {
 // logger.  It expects to have *some* logr.Logger set at all times (generally
 // a no-op logger before the promises are fulfilled).
 type DelegatingLogger struct {
+	lock sync.Mutex
 	logr.Logger
 	promise *loggerPromise
 }
 
 // WithName provides a new Logger with the name appended
 func (l *DelegatingLogger) WithName(name string) logr.Logger {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	if l.promise == nil {
 		return l.Logger.WithName(name)
 	}
@@ -105,6 +111,9 @@ func (l *DelegatingLogger) WithName(name string) logr.Logger {
 
 // WithValues provides a new Logger with the tags appended
 func (l *DelegatingLogger) WithValues(tags ...interface{}) logr.Logger {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+
 	if l.promise == nil {
 		return l.Logger.WithValues(tags...)
 	}


### PR DESCRIPTION
For as long as the delegating loggers Fullfill wasn't called, it holds a
loggerPromise and that loggerPromise holds the same delegating logger.

Calls to With{Name,Field} and FullFill of such a loggerPromise and
delegatingLogger pair have to be serialized, because the former accesses
the actual logger and promise, while the latter sets and unsets them.

Furthermore, a call to With{Name,Field} of such a pair returns a new
pair that is attached to the parent pair by making the original promise
keep a reference to the new promise. Because of that, the aforementioned
serialization has to happen recursively for each pair.

https://github.com/kubernetes-sigs/controller-runtime/pull/1309 made this race more visible, because the defaulting of the logger controller-runtime does in the background might race with users code getting a logger (Potentially indirectly by constructing a controller).

Surprisingly, I only managed to reproduce this on tests that import controller-runtime when they take 30 seconds or more. I didn't expect the race detector to take `Sleep` into account, but apparently it does.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1337

/assign @vincepri @joelanford 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
