### PR TITLE
🌱 fix DestWritter var name typo

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -56,10 +56,10 @@ func UseDevMode(enabled bool) Opts {
 }
 
 // WriteTo configures the logger to write to the given io.Writer, instead of standard error.
-// See Options.DestWritter
+// See Options.DestWriter
 func WriteTo(out io.Writer) Opts {
 	return func(o *Options) {
-		o.DestWritter = out
+		o.DestWriter = out
 	}
 }
 
@@ -143,8 +143,13 @@ type Options struct {
 	// NewEncoder configures Encoder using the provided EncoderConfigOptions.
 	// Note that the NewEncoder function is not used when the Encoder option is already set.
 	NewEncoder NewEncoderFunc
+	// DestWriter controls the destination of the log output.  Defaults to
+	// os.Stderr.
+	DestWriter io.Writer
 	// DestWritter controls the destination of the log output.  Defaults to
 	// os.Stderr.
+	//
+	// Deprecated: Use DestWriter instead
 	DestWritter io.Writer
 	// Level configures the verbosity of the logging.  Defaults to Debug when
 	// Development is true and Info otherwise
@@ -160,8 +165,11 @@ type Options struct {
 
 // addDefaults adds defaults to the Options
 func (o *Options) addDefaults() {
-	if o.DestWritter == nil {
-		o.DestWritter = os.Stderr
+	if o.DestWriter == nil && o.DestWritter == nil {
+		o.DestWriter = os.Stderr
+	} else if o.DestWriter == nil && o.DestWritter != nil {
+		// while misspelled DestWritter is deprecated but still not removed
+		o.DestWriter = o.DestWritter
 	}
 
 	if o.Development {
@@ -216,7 +224,7 @@ func NewRaw(opts ...Opts) *zap.Logger {
 	o.addDefaults()
 
 	// this basically mimics New<type>Config, but with a custom sink
-	sink := zapcore.AddSync(o.DestWritter)
+	sink := zapcore.AddSync(o.DestWriter)
 
 	o.ZapOpts = append(o.ZapOpts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
 	log := zap.New(zapcore.NewCore(&KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level))

--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Zap options setup", func() {
 	It("should set a custom writer", func() {
 		var w fakeSyncWriter
 		WriteTo(&w)(opts)
-		Expect(opts.DestWritter).To(Equal(&w))
+		Expect(opts.DestWriter).To(Equal(&w))
 	})
 })
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
- change name of var from `DestWritter` to `DestWriter`

Fixes: #1294 