### PR TITLE
:bug: Prevent source.Channel from shutting down immediately

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -215,7 +215,10 @@ func (cs *Channel) Start(
 	}
 
 	dst := make(chan event.GenericEvent, cs.DestBufferSize)
+
+	cs.destLock.Lock()
 	cs.dest = append(cs.dest, dst)
+	cs.destLock.Unlock()
 
 	cs.once.Do(func() {
 		// Distribute GenericEvents to all EventHandler / Queue pairs Watching this source
@@ -237,9 +240,6 @@ func (cs *Channel) Start(
 			}
 		}
 	}()
-
-	cs.destLock.Lock()
-	defer cs.destLock.Unlock()
 
 	return nil
 }


### PR DESCRIPTION
Because of an incorrectly used context, `source.Channel` gets shutdown almost immediately before it gets a chance to process any events. More details can be found in #1343.

Also fixes a minor bug in `source.Channel` where the destination append operation wasn't protected by a lock as it used to.

Fixes #1343 