### PR TITLE
:sparkles: Allow panic as an option to -zap-stacktrace-level"

### DIFF
--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -34,11 +34,10 @@ var levelStrings = map[string]zapcore.Level{
 	"error": zap.ErrorLevel,
 }
 
-// TODO Add level to disable stacktraces.
-// https://github.com/kubernetes-sigs/controller-runtime/issues/1035
 var stackLevelStrings = map[string]zapcore.Level{
 	"info":  zap.InfoLevel,
 	"error": zap.ErrorLevel,
+	"panic": zap.PanicLevel,
 }
 
 type encoderFlag struct {

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -230,7 +230,7 @@ func NewRaw(opts ...Opts) *zap.Logger {
 //  zap-encoder: Zap log encoding (one of 'json' or 'console')
 //  zap-log-level:  Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
 //			       or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
-//  zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info' or 'error')
+//  zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
 func (o *Options) BindFlags(fs *flag.FlagSet) {
 
 	// Set Development mode value
@@ -260,7 +260,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 		o.StacktraceLevel = fromFlag
 	}
 	fs.Var(&stackVal, "zap-stacktrace-level",
-		"Zap Level at and above which stacktraces are captured (one of 'info', 'error').")
+		"Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').")
 }
 
 // UseFlagOptions configures the logger to use the Options set by parsing zap option flags from the CLI.

--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -423,6 +423,19 @@ var _ = Describe("Zap log level flag options setup", func() {
 			Expect(out.StacktraceLevel.Enabled(zapcore.ErrorLevel)).To(BeTrue())
 		})
 
+		It("Should output stacktrace at panic level, with development mode set to true.", func() {
+			args := []string{"--zap-stacktrace-level=panic", "--zap-devel=true"}
+			fromFlags.BindFlags(&fs)
+			err := fs.Parse(args)
+			Expect(err).ToNot(HaveOccurred())
+			out := Options{}
+			UseFlagOptions(&fromFlags)(&out)
+
+			Expect(out.StacktraceLevel.Enabled(zapcore.PanicLevel)).To(BeTrue())
+			Expect(out.StacktraceLevel.Enabled(zapcore.ErrorLevel)).To(BeFalse())
+			Expect(out.StacktraceLevel.Enabled(zapcore.InfoLevel)).To(BeFalse())
+		})
+
 	})
 
 	Context("with only -zap-devel flag provided", func() {


### PR DESCRIPTION
This allows stack trace logging to be disabled for all but panic log entries.

The Zap `DisableStackTrace` config parameter (https://github.com/uber-go/zap/blob/master/config.go#L72) isn't available via the `Option` interface, so it's not possible (or at least I couldn't find a way) to disable it completely via a user-added flag.

Closes https://github.com/kubernetes-sigs/controller-runtime/issues/1035

