### PR TITLE
🐛 pkg/client: optionally allow caching of unstructured objects

### DIFF
--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -24,14 +24,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // NewDelegatingClientInput encapsulates the input parameters to create a new delegating client.
 type NewDelegatingClientInput struct {
-	CacheReader     Reader
-	Client          Client
-	UncachedObjects []Object
+	CacheReader       Reader
+	Client            Client
+	UncachedObjects   []Object
+	CacheUnstructured bool
 }
 
 // NewDelegatingClient creates a new delegating client.
@@ -53,10 +55,11 @@ func NewDelegatingClient(in NewDelegatingClientInput) (Client, error) {
 		scheme: in.Client.Scheme(),
 		mapper: in.Client.RESTMapper(),
 		Reader: &delegatingReader{
-			CacheReader:  in.CacheReader,
-			ClientReader: in.Client,
-			scheme:       in.Client.Scheme(),
-			uncachedGVKs: uncachedGVKs,
+			CacheReader:       in.CacheReader,
+			ClientReader:      in.Client,
+			scheme:            in.Client.Scheme(),
+			uncachedGVKs:      uncachedGVKs,
+			cacheUnstructured: in.CacheUnstructured,
 		},
 		Writer:       in.Client,
 		StatusClient: in.Client,
@@ -91,8 +94,9 @@ type delegatingReader struct {
 	CacheReader  Reader
 	ClientReader Reader
 
-	uncachedGVKs map[schema.GroupVersionKind]struct{}
-	scheme       *runtime.Scheme
+	uncachedGVKs      map[schema.GroupVersionKind]struct{}
+	scheme            *runtime.Scheme
+	cacheUnstructured bool
 }
 
 func (d *delegatingReader) shouldBypassCache(obj runtime.Object) (bool, error) {
@@ -105,10 +109,15 @@ func (d *delegatingReader) shouldBypassCache(obj runtime.Object) (bool, error) {
 	if meta.IsListType(obj) {
 		gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 	}
-	_, isUncached := d.uncachedGVKs[gvk]
-	_, isUnstructured := obj.(*unstructured.Unstructured)
-	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
-	return isUncached || isUnstructured || isUnstructuredList, nil
+	if _, isUncached := d.uncachedGVKs[gvk]; isUncached {
+		return true, nil
+	}
+	if !d.cacheUnstructured {
+		_, isUnstructured := obj.(*unstructured.Unstructured)
+		_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+		return isUnstructured || isUnstructuredList, nil
+	}
+	return false, nil
 }
 
 // Get retrieves an obj for a given object key from the Kubernetes Cluster.


### PR DESCRIPTION
Cherry-pick of #1332 to release-0.7.

>Based on #615, it seems like there is intent to allow the DelegatingClient to cache unstructured objects. This is behavior that was possible to use before v0.7.0 by using the NewClientFunc manager option and creating a custom DelegatingClient.
>
>IMO, this could be considered a regression, but since a large chunk of this code was restructured in v0.7.0, I'm not sure if dropping support for unstructured caching was intentional.
>
>This PR adds a new boolean field to the NewDelegatingClientInput struct that allows users to opt-in to caching unstructured objects.

