### PR TITLE
[WIP] :sparkles: Add support for implicit paging in un/structured clients

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -55,6 +55,13 @@ type Reader interface {
 	// successful call, Items field in the list will be populated with the
 	// result returned from the server.
 	List(ctx context.Context, list ObjectList, opts ...ListOption) error
+
+	// Retrieves a list of objects in "chunks" (of size one hundred by default)
+	// for a given namespace and list options.
+	// One can pass a callback function to process each chunk recieved from the server.
+	// On a successful call, Items field in the list will be populated with the
+	// result returned from the server.
+	ListPages(ctx context.Context, obj ObjectList, callback func(obj ObjectList) error, opts ...ListOption) error
 }
 
 // Writer knows how to create, delete, and update Kubernetes objects.

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -23,6 +23,12 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 )
 
+const (
+	// DefaultPageLimit represents the default limit used for ListPaging when no "Limit"
+	// is specified as ListOption.
+	DefaultPageLimit = 100
+)
+
 // {{{ "Functional" Option Interfaces
 
 // CreateOption is some configuration that modifies options for a create request.


### PR DESCRIPTION
## What this does?
Following #341  this patch adds implicit paging to the un/structured clients. Fixes #532.

## Thoughts about the API:
This patch opts for adding a new Method called `ListPages`: This method lists large data in "chunks" using the `Continue` curser token with a callback to be used by the user.

## Open Questions:

- Should `ListPages` be part of the `Reader` [interface](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/client/interfaces.go#L47-L58)?

@ncdc @DirectXMan12 @vincepri @cben PTAL.