### PR TITLE
:bug: Don't hotloop on channel source closure

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -274,7 +274,13 @@ func (cs *Channel) syncLoop(ctx context.Context) {
 			// Close destination channels
 			cs.doStop()
 			return
-		case evt := <-cs.Source:
+		case evt, stillOpen := <-cs.Source:
+			if !stillOpen {
+				// if the source channel is closed, we're never gonna get
+				// anything more on it, so stop & bail
+				cs.doStop()
+				return
+			}
 			cs.distribute(evt)
 		}
 	}


### PR DESCRIPTION
Previously, when we received from the channel in a channel source, we
didn't check if it was still open.  This lead to hotlooping and spamming
the source's handler/queue when the input channel is closed.

Now, we stop the source when the channel is closed, similarly to what
happens if the context is closed.