### PR TITLE
✨ thread context through to some library functions

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -135,7 +135,7 @@ func (a *ReplicaSetReconciler) Reconcile(ctx context.Context, req controllers.Re
 
 	// Update the ReplicaSet
 	rs.Labels["pod-count"] = fmt.Sprintf("%v", len(pods.Items))
-	err = a.Update(context.TODO(), rs)
+	err = a.Update(ctx, rs)
 	if err != nil {
 		return controllers.Result{}, err
 	}

--- a/examples/configfile/builtin/controller.go
+++ b/examples/configfile/builtin/controller.go
@@ -42,7 +42,7 @@ func (r *reconcileReplicaSet) Reconcile(ctx context.Context, request reconcile.R
 
 	// Fetch the ReplicaSet from the cache
 	rs := &appsv1.ReplicaSet{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, rs)
+	err := r.client.Get(ctx, request.NamespacedName, rs)
 	if errors.IsNotFound(err) {
 		log.Error(nil, "Could not find ReplicaSet")
 		return reconcile.Result{}, nil

--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -44,8 +45,10 @@ func TestBuilder(t *testing.T) {
 
 var testenv *envtest.Environment
 var cfg *rest.Config
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -55,7 +58,7 @@ var _ = BeforeSuite(func(done Done) {
 		testDefaultValidatorGVK)
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	// Prevent the metrics listener being created
@@ -68,7 +71,7 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 
 	// Put the DefaultBindAddress back
 	metrics.DefaultBindAddress = ":8080"

--- a/pkg/cache/cache_suite_test.go
+++ b/pkg/cache/cache_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cache_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,14 +39,16 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(cfg)
@@ -55,5 +58,5 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -39,7 +39,7 @@ import (
 )
 
 // clientListWatcherFunc knows how to create a ListWatcher
-type createListWatcherFunc func(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error)
+type createListWatcherFunc func(ctx context.Context, gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error)
 
 // newSpecificInformersMap returns a new specificInformersMap (like
 // the generical InformersMap, except that it doesn't implement WaitForCacheSync).
@@ -177,7 +177,7 @@ func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersion
 
 	if !ok {
 		var err error
-		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {
+		if i, started, err = ip.addInformerToMap(ctx, gvk, obj); err != nil {
 			return started, nil, err
 		}
 	}
@@ -192,7 +192,7 @@ func (ip *specificInformersMap) Get(ctx context.Context, gvk schema.GroupVersion
 	return started, i, nil
 }
 
-func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.Object) (*MapEntry, bool, error) {
+func (ip *specificInformersMap) addInformerToMap(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (*MapEntry, bool, error) {
 	ip.mu.Lock()
 	defer ip.mu.Unlock()
 
@@ -205,7 +205,7 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 
 	// Create a NewSharedIndexInformer and add it to the map.
 	var lw *cache.ListWatch
-	lw, err := ip.createListWatcher(gvk, ip)
+	lw, err := ip.createListWatcher(ctx, gvk, ip)
 	if err != nil {
 		return nil, false, err
 	}
@@ -232,7 +232,7 @@ func (ip *specificInformersMap) addInformerToMap(gvk schema.GroupVersionKind, ob
 }
 
 // newListWatch returns a new ListWatch object that can be used to create a SharedIndexInformer.
-func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+func createStructuredListWatch(ctx context.Context, gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
 	// groupVersionKind to the Resource API we will use.
 	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -250,9 +250,6 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		return nil, err
 	}
 
-	// TODO: the functions that make use of this ListWatch should be adapted to
-	//  pass in their own contexts instead of relying on this fixed one here.
-	ctx := context.TODO()
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -271,7 +268,7 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 	}, nil
 }
 
-func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+func createUnstructuredListWatch(ctx context.Context, gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
 	// groupVersionKind to the Resource API we will use.
 	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -283,9 +280,6 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 		return nil, err
 	}
 
-	// TODO: the functions that make use of this ListWatch should be adapted to
-	//  pass in their own contexts instead of relying on this fixed one here.
-	ctx := context.TODO()
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
@@ -306,7 +300,7 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 	}, nil
 }
 
-func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
+func createMetadataListWatch(ctx context.Context, gvk schema.GroupVersionKind, ip *specificInformersMap) (*cache.ListWatch, error) {
 	// Kubernetes APIs work against Resources, not GroupVersionKinds.  Map the
 	// groupVersionKind to the Resource API we will use.
 	mapping, err := ip.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
@@ -319,10 +313,6 @@ func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersM
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO: the functions that make use of this ListWatch should be adapted to
-	//  pass in their own contexts instead of relying on this fixed one here.
-	ctx := context.TODO()
 
 	// create the relevant listwatch
 	return &cache.ListWatch{

--- a/pkg/client/client_suite_test.go
+++ b/pkg/client/client_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -39,14 +40,16 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(cfg)
@@ -56,5 +59,5 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/cluster/cluster_suite_test.go
+++ b/pkg/cluster/cluster_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cluster
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -39,17 +40,19 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 // clientTransport is used to force-close keep-alives in tests that check for leaks
 var clientTransport *http.Transport
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientTransport = &http.Transport{}
@@ -62,5 +65,5 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller_test
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -45,11 +46,13 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 // clientTransport is used to force-close keep-alives in tests that check for leaks
 var clientTransport *http.Transport
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	err := (&crscheme.Builder{
@@ -65,7 +68,7 @@ var _ = BeforeSuite(func(done Done) {
 		CRDDirectoryPaths: []string{"testdata/crds"},
 	}
 
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientTransport = &http.Transport{}
@@ -81,7 +84,7 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 
 	// Put the DefaultBindAddress back
 	metrics.DefaultBindAddress = ":8080"

--- a/pkg/controller/controllerutil/controllerutil_suite_test.go
+++ b/pkg/controller/controllerutil/controllerutil_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controllerutil_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -37,13 +38,15 @@ func TestControllerutil(t *testing.T) {
 var t *envtest.Environment
 var cfg *rest.Config
 var c client.Client
+var ctx context.Context
 
 var _ = BeforeSuite(func() {
 	var err error
 
+	ctx = context.Background()
 	t = &envtest.Environment{}
 
-	cfg, err = t.Start()
+	cfg, err = t.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	c, err = client.New(cfg, client.Options{})
@@ -51,5 +54,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	Expect(t.Stop()).To(Succeed())
+	Expect(t.Stop(ctx)).To(Succeed())
 })

--- a/pkg/envtest/envtest_suite_test.go
+++ b/pkg/envtest/envtest_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package envtest
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -37,13 +38,15 @@ func TestSource(t *testing.T) {
 }
 
 var env *Environment
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	env = &Environment{}
 	// we're initializing webhook here and not in webhook.go to also test the envtest install code via WebhookOptions
 	initializeWebhookInEnvironment()
-	_, err := env.Start()
+	_, err := env.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	close(done)
@@ -137,7 +140,7 @@ func initializeWebhookInEnvironment() {
 }
 
 var _ = AfterSuite(func(done Done) {
-	Expect(env.Stop()).NotTo(HaveOccurred())
+	Expect(env.Stop(ctx)).NotTo(HaveOccurred())
 
 	close(done)
 }, StopTimeout)

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -59,21 +59,23 @@ var _ = Describe("Test", func() {
 
 	// Cleanup CRDs
 	AfterEach(func(done Done) {
+		ctx := context.Background()
+
 		for _, crd := range runtimeCRDListToUnstructured(crds) {
 			// Delete only if CRD exists.
 			crdObjectKey := client.ObjectKey{
 				Name: crd.GetName(),
 			}
 			var placeholder v1beta1.CustomResourceDefinition
-			err := c.Get(context.TODO(), crdObjectKey, &placeholder)
+			err := c.Get(ctx, crdObjectKey, &placeholder)
 			if err != nil && apierrors.IsNotFound(err) {
 				// CRD doesn't need to be deleted.
 				continue
 			}
 			Expect(err).NotTo(HaveOccurred())
-			Expect(c.Delete(context.TODO(), crd)).To(Succeed())
+			Expect(c.Delete(ctx, crd)).To(Succeed())
 			Eventually(func() bool {
-				err := c.Get(context.TODO(), crdObjectKey, &placeholder)
+				err := c.Get(ctx, crdObjectKey, &placeholder)
 				return apierrors.IsNotFound(err)
 			}, 1*time.Second).Should(BeTrue())
 		}
@@ -82,7 +84,9 @@ var _ = Describe("Test", func() {
 
 	Describe("InstallCRDs", func() {
 		It("should install the unserved CRDs into the cluster", func() {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "examplecrd_unserved.yaml")},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -90,11 +94,11 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crdv1 := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "frigates.ship.example.com"}, crdv1)
+			err = c.Get(ctx, types.NamespacedName{Name: "frigates.ship.example.com"}, crdv1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crdv1.Spec.Names.Kind).To(Equal("Frigate"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&v1beta1.CustomResourceDefinition{
 					Spec: v1beta1.CustomResourceDefinitionSpec{
 						Group: "ship.example.com",
@@ -120,7 +124,9 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("should install the CRDs into the cluster using directory", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -128,31 +134,31 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crdv1 := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crdv1)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crdv1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crdv1.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd := &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -224,17 +230,19 @@ var _ = Describe("Test", func() {
 		}, 5)
 
 		It("should install the CRDs into the cluster using file", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "examplecrd3.yaml")},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			crd := &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "configs.foo.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "configs.foo.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Config"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&v1beta1.CustomResourceDefinition{
 					Spec: v1beta1.CustomResourceDefinitionSpec{
 						Group:   "foo.example.com",
@@ -252,7 +260,8 @@ var _ = Describe("Test", func() {
 		}, 10)
 
 		It("should be able to install CRDs using multiple files", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{
 					filepath.Join(".", "testdata", "examplecrd.yaml"),
 					filepath.Join(".", "testdata", "examplecrd_v1.yaml"),
@@ -265,7 +274,8 @@ var _ = Describe("Test", func() {
 		}, 10)
 
 		It("should filter out already existent CRD", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{
 					filepath.Join(".", "testdata"),
 					filepath.Join(".", "testdata", "examplecrd1.yaml"),
@@ -274,11 +284,11 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -307,14 +317,14 @@ var _ = Describe("Test", func() {
 		}, 10)
 
 		It("should not return an not error if the directory doesn't exist", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{Paths: []string{invalidDirectory}})
+			crds, err = InstallCRDs(context.Background(), env.Config, CRDInstallOptions{Paths: []string{invalidDirectory}})
 			Expect(err).NotTo(HaveOccurred())
 
 			close(done)
 		}, 5)
 
 		It("should return an error if the directory doesn't exist", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			crds, err = InstallCRDs(context.Background(), env.Config, CRDInstallOptions{
 				Paths: []string{invalidDirectory}, ErrorIfPathMissing: true,
 			})
 			Expect(err).To(HaveOccurred())
@@ -323,7 +333,7 @@ var _ = Describe("Test", func() {
 		}, 5)
 
 		It("should return an error if the file doesn't exist", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{Paths: []string{
+			crds, err = InstallCRDs(context.Background(), env.Config, CRDInstallOptions{Paths: []string{
 				filepath.Join(".", "testdata", "fake.yaml")}, ErrorIfPathMissing: true,
 			})
 			Expect(err).To(HaveOccurred())
@@ -333,7 +343,7 @@ var _ = Describe("Test", func() {
 
 		It("should return an error if the resource group version isn't found", func(done Done) {
 			// Wait for a CRD where the Group and Version don't exist
-			err := WaitForCRDs(env.Config,
+			err := WaitForCRDs(context.Background(), env.Config,
 				[]client.Object{
 					&v1beta1.CustomResourceDefinition{
 						Spec: v1beta1.CustomResourceDefinitionSpec{
@@ -351,13 +361,15 @@ var _ = Describe("Test", func() {
 		}, 5)
 
 		It("should return an error if the resource isn't found in the group version", func(done Done) {
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			ctx := context.Background()
+
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{"."},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			// Wait for a CRD that doesn't exist, but the Group and Version do
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&v1beta1.CustomResourceDefinition{
 					Spec: v1beta1.CustomResourceDefinitionSpec{
 						Group:   "qux.example.com",
@@ -382,8 +394,9 @@ var _ = Describe("Test", func() {
 		}, 5)
 
 		It("should reinstall the CRDs if already present in the cluster", func(done Done) {
+			ctx := context.Background()
 
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata")},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -391,31 +404,31 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd := &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -485,7 +498,7 @@ var _ = Describe("Test", func() {
 
 			// Try to re-install the CRDs
 
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata")},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -493,31 +506,31 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -590,9 +603,10 @@ var _ = Describe("Test", func() {
 	})
 
 	It("should update CRDs if already present in the cluster", func(done Done) {
+		ctx := context.Background()
 
 		// Install only the CRDv1 multi-version example
-		crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+		crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 			Paths: []string{filepath.Join(".", "testdata")},
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -600,7 +614,7 @@ var _ = Describe("Test", func() {
 		// Expect to find the CRDs
 
 		crd := &v1beta1.CustomResourceDefinition{}
-		err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+		err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 		Expect(len(crd.Spec.Versions)).To(BeEquivalentTo(2))
@@ -608,7 +622,7 @@ var _ = Describe("Test", func() {
 		// Store resource version for comparison later on
 		firstRV := crd.ResourceVersion
 
-		err = WaitForCRDs(env.Config, []client.Object{
+		err = WaitForCRDs(ctx, env.Config, []client.Object{
 			&v1beta1.CustomResourceDefinition{
 				Spec: v1beta1.CustomResourceDefinitionSpec{
 					Group: "crew.example.com",
@@ -634,7 +648,7 @@ var _ = Describe("Test", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Add one more version and update
-		_, err = InstallCRDs(env.Config, CRDInstallOptions{
+		_, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 			Paths: []string{filepath.Join(".", "testdata", "crdv1_updated")},
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -642,13 +656,13 @@ var _ = Describe("Test", func() {
 		// Expect to find updated CRD
 
 		crd = &v1beta1.CustomResourceDefinition{}
-		err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+		err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 		Expect(len(crd.Spec.Versions)).To(BeEquivalentTo(3))
 		Expect(crd.ResourceVersion).NotTo(BeEquivalentTo(firstRV))
 
-		err = WaitForCRDs(env.Config, []client.Object{
+		err = WaitForCRDs(ctx, env.Config, []client.Object{
 			&v1beta1.CustomResourceDefinition{
 				Spec: v1beta1.CustomResourceDefinitionSpec{
 					Group: "crew.example.com",
@@ -683,8 +697,9 @@ var _ = Describe("Test", func() {
 
 	Describe("UninstallCRDs", func() {
 		It("should uninstall the CRDs from the cluster", func(done Done) {
+			ctx := context.Background()
 
-			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
+			crds, err = InstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -692,31 +707,31 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crdv1 := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crdv1)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crdv1)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crdv1.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd := &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &v1beta1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
-			err = WaitForCRDs(env.Config, []client.Object{
+			err = WaitForCRDs(ctx, env.Config, []client.Object{
 				&apiextensionsv1.CustomResourceDefinition{
 					Spec: apiextensionsv1.CustomResourceDefinitionSpec{
 						Group: "bar.example.com",
@@ -784,7 +799,7 @@ var _ = Describe("Test", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = UninstallCRDs(env.Config, CRDInstallOptions{
+			err = UninstallCRDs(ctx, env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -797,7 +812,7 @@ var _ = Describe("Test", func() {
 			v1placeholder := &apiextensionsv1.CustomResourceDefinition{}
 			Eventually(func() bool {
 				for _, crd := range v1crds {
-					err = c.Get(context.TODO(), types.NamespacedName{Name: crd}, v1placeholder)
+					err = c.Get(ctx, types.NamespacedName{Name: crd}, v1placeholder)
 					notFound := err != nil && apierrors.IsNotFound(err)
 					if !notFound {
 						return false
@@ -815,7 +830,7 @@ var _ = Describe("Test", func() {
 			v1beta1placeholder := &v1beta1.CustomResourceDefinition{}
 			Eventually(func() bool {
 				for _, crd := range v1beta1crds {
-					err = c.Get(context.TODO(), types.NamespacedName{Name: crd}, v1beta1placeholder)
+					err = c.Get(ctx, types.NamespacedName{Name: crd}, v1beta1placeholder)
 					notFound := err != nil && apierrors.IsNotFound(err)
 					if !notFound {
 						return false
@@ -830,18 +845,20 @@ var _ = Describe("Test", func() {
 
 	Describe("Start", func() {
 		It("should raise an error on invalid dir when flag is enabled", func(done Done) {
+			ctx := context.Background()
 			env := &Environment{ErrorIfCRDPathMissing: true, CRDDirectoryPaths: []string{invalidDirectory}}
-			_, err := env.Start()
+			_, err := env.Start(ctx)
 			Expect(err).To(HaveOccurred())
-			Expect(env.Stop()).To(Succeed())
+			Expect(env.Stop(ctx)).To(Succeed())
 			close(done)
 		}, 30)
 
 		It("should not raise an error on invalid dir when flag is disabled", func(done Done) {
+			ctx := context.Background()
 			env := &Environment{ErrorIfCRDPathMissing: false, CRDDirectoryPaths: []string{invalidDirectory}}
-			_, err := env.Start()
+			_, err := env.Start(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(env.Stop()).To(Succeed())
+			Expect(env.Stop(ctx)).To(Succeed())
 			close(done)
 		}, 30)
 	})

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package envtest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -152,9 +153,9 @@ type Environment struct {
 // Stop stops a running server.
 // Previously installed CRDs, as listed in CRDInstallOptions.CRDs, will be uninstalled
 // if CRDInstallOptions.CleanUpAfterUse are set to true.
-func (te *Environment) Stop() error {
+func (te *Environment) Stop(ctx context.Context) error {
 	if te.CRDInstallOptions.CleanUpAfterUse {
-		if err := UninstallCRDs(te.Config, te.CRDInstallOptions); err != nil {
+		if err := UninstallCRDs(ctx, te.Config, te.CRDInstallOptions); err != nil {
 			return err
 		}
 	}
@@ -190,7 +191,7 @@ func (te Environment) getAPIServerFlags() []string {
 }
 
 // Start starts a local Kubernetes server and updates te.ApiserverPort with the port it is listening on
-func (te *Environment) Start() (*rest.Config, error) {
+func (te *Environment) Start(ctx context.Context) (*rest.Config, error) {
 	if te.useExistingCluster() {
 		log.V(1).Info("using existing cluster")
 		if te.Config == nil {
@@ -267,7 +268,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
 	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
 	te.CRDInstallOptions.ErrorIfPathMissing = te.ErrorIfCRDPathMissing
-	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
+	crds, err := InstallCRDs(ctx, te.Config, te.CRDInstallOptions)
 	if err != nil {
 		return te.Config, err
 	}

--- a/pkg/handler/eventhandler_suite_test.go
+++ b/pkg/handler/eventhandler_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -36,16 +37,18 @@ func TestEventhandler(t *testing.T) {
 
 var testenv *envtest.Environment
 var cfg *rest.Config
+var ctx context.Context
 
 var _ = BeforeSuite(func() {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/internal/controller/controller_suite_test.go
+++ b/pkg/internal/controller/controller_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,14 +39,16 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(cfg)
@@ -55,5 +58,5 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/internal/recorder/recorder_suite_test.go
+++ b/pkg/internal/recorder/recorder_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package recorder_test
 
 import (
+	"context"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -38,14 +39,17 @@ func TestRecorder(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
+
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(cfg)
@@ -55,5 +59,5 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 })

--- a/pkg/manager/manager_suite_test.go
+++ b/pkg/manager/manager_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package manager
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -40,17 +41,20 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
+var ctx context.Context
 
 // clientTransport is used to force-close keep-alives in tests that check for leaks
 var clientTransport *http.Transport
 
 var _ = BeforeSuite(func(done Done) {
+	ctx = context.Background()
+
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 
 	var err error
-	cfg, err = testenv.Start()
+	cfg, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientTransport = &http.Transport{}
@@ -66,7 +70,7 @@ var _ = BeforeSuite(func(done Done) {
 }, 60)
 
 var _ = AfterSuite(func() {
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 
 	// Put the DefaultBindAddress back
 	metrics.DefaultBindAddress = ":8080"

--- a/pkg/source/source_suite_test.go
+++ b/pkg/source/source_suite_test.go
@@ -51,7 +51,7 @@ var _ = BeforeSuite(func(done Done) {
 	testenv = &envtest.Environment{}
 
 	var err error
-	config, err = testenv.Start()
+	config, err = testenv.Start(ctx)
 	Expect(err).NotTo(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(config)
@@ -70,7 +70,7 @@ var _ = BeforeSuite(func(done Done) {
 
 var _ = AfterSuite(func(done Done) {
 	cancel()
-	Expect(testenv.Stop()).To(Succeed())
+	Expect(testenv.Stop(ctx)).To(Succeed())
 
 	close(done)
 }, 5)


### PR DESCRIPTION
Cleans up some context.TODOs() by plumbing contexts through. This is a breaking change to the envtest setup/teardown API, by threading a context parameter through `Stop`, `Start`, `InstallCRDs`, `UninstallCRDs` etc. I think it's reasonable to expect a context in the `envtest` API,  considering that a user is likely instantiating a context already for interacting with the control plane via a Client.

As for why we need it -- this is an API cleanup that improves the overall code quality by removing `context.TODO`s. I noticed it while familiarizing myself with the codebase and thought it'd be a good way to get used to making changes to the project.