### PR TITLE
✨  deduplicate repeated requests in a single update event

### DIFF
--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -48,30 +48,18 @@ func (e *EnqueueRequestForObject) Create(evt event.CreateEvent, q workqueue.Rate
 
 // Update implements EventHandler
 func (e *EnqueueRequestForObject) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	// requestSet will help to deduplicate requests in a single event
-	requestSet := reconcile.NewRequestSet()
-
-	if evt.ObjectOld != nil {
-		requestSet.Insert(reconcile.Request{NamespacedName: types.NamespacedName{
+	if evt.ObjectNew != nil {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      evt.ObjectNew.GetName(),
+			Namespace: evt.ObjectNew.GetNamespace(),
+		}})
+	} else if evt.ObjectOld != nil {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      evt.ObjectOld.GetName(),
 			Namespace: evt.ObjectOld.GetNamespace(),
 		}})
 	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no old metadata", "event", evt)
-	}
-
-	if evt.ObjectNew != nil {
-		requestSet.Insert(reconcile.Request{NamespacedName: types.NamespacedName{
-			Name:      evt.ObjectNew.GetName(),
-			Namespace: evt.ObjectNew.GetNamespace(),
-		}})
-	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no new metadata", "event", evt)
-	}
-
-	requests := requestSet.List()
-	for i := range requests {
-		q.Add(requests[i])
+		enqueueLog.Error(nil, "UpdateEvent received with no metadata", "event", evt)
 	}
 }
 

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -114,6 +114,26 @@ var _ = Describe("Eventhandler", func() {
 				close(done)
 			})
 
+		It("should enqueue a single Request if both objects have same Name and Namespace in the UpdateEvent.",
+			func(done Done) {
+				newPod := pod.DeepCopy()
+
+				evt := event.UpdateEvent{
+					ObjectOld: pod,
+					ObjectNew: newPod,
+				}
+				instance.Update(evt, q)
+				Expect(q.Len()).To(Equal(1))
+
+				i, _ := q.Get()
+				Expect(i).NotTo(BeNil())
+				req, ok := i.(reconcile.Request)
+				Expect(ok).To(BeTrue())
+				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
+
+				close(done)
+			})
+
 		It("should enqueue a Request with the Name / Namespace of the object in the GenericEvent.", func(done Done) {
 			evt := event.GenericEvent{
 				Object: pod,

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -100,7 +100,7 @@ func (s *RequestSet) Delete(request Request) {
 }
 
 // List returns an ordered slice with all requests in set.
-func (s RequestSet) List() []Request {
+func (s *RequestSet) List() []Request {
 	s.Lock()
 	defer s.Unlock()
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Now the `Update` handler of `EnqueueRequestForObject` will handle the old and new objects respectively, which will enqueue two requests, even the old and new objects have same name and namespace, just like [https://github.com/kubernetes-sigs/controller-runtime/blob/0247574810d7c7a7dfc234f8064e85a50cc814f2/pkg/handler/enqueue.go#L49-L67](https://github.com/kubernetes-sigs/controller-runtime/blob/0247574810d7c7a7dfc234f8064e85a50cc814f2/pkg/handler/enqueue.go#L49-L67)
IMO, the update event is a level trigger in kubernetes, so the same requests will lead to duplicated reconciliations, which are useless.
So I introduce a `RequestSet` to help collect and deduplicate requests in a single event to solve the issue above.
