### PR TITLE
✨ Deduplicate events before sending them into the workqueue.

### DIFF
--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -26,6 +26,8 @@ import (
 
 var enqueueLog = logf.RuntimeLog.WithName("eventhandler").WithName("EnqueueRequestForObject")
 
+type empty struct{}
+
 var _ EventHandler = &EnqueueRequestForObject{}
 
 // EnqueueRequestForObject enqueues a Request containing the Name and Namespace of the object that is the source of the Event.

--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -47,22 +47,18 @@ func (e *EnqueueRequestForObject) Create(evt event.CreateEvent, q workqueue.Rate
 
 // Update implements EventHandler
 func (e *EnqueueRequestForObject) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	if evt.ObjectOld != nil {
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-			Name:      evt.ObjectOld.GetName(),
-			Namespace: evt.ObjectOld.GetNamespace(),
-		}})
-	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no old metadata", "event", evt)
-	}
-
 	if evt.ObjectNew != nil {
 		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      evt.ObjectNew.GetName(),
 			Namespace: evt.ObjectNew.GetNamespace(),
 		}})
+	} else if evt.ObjectOld != nil {
+		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+			Name:      evt.ObjectOld.GetName(),
+			Namespace: evt.ObjectOld.GetNamespace(),
+		}})
 	} else {
-		enqueueLog.Error(nil, "UpdateEvent received with no new metadata", "event", evt)
+		enqueueLog.Error(nil, "UpdateEvent received with no metadata", "event", evt)
 	}
 }
 

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -73,7 +73,11 @@ func (e *enqueueRequestsFromMapFunc) Generic(evt event.GenericEvent, q workqueue
 }
 
 func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object client.Object) {
+	reqs := map[reconcile.Request]bool{}
 	for _, req := range e.toRequests(object) {
+		reqs[req] = true
+	}
+	for req := range reqs {
 		q.Add(req)
 	}
 }

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -73,12 +73,13 @@ func (e *enqueueRequestsFromMapFunc) Generic(evt event.GenericEvent, q workqueue
 }
 
 func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object client.Object) {
-	reqs := map[reconcile.Request]bool{}
+	reqs := map[reconcile.Request]empty{}
 	for _, req := range e.toRequests(object) {
-		reqs[req] = true
-	}
-	for req := range reqs {
-		q.Add(req)
+		_, ok := reqs[req]
+		if !ok {
+			q.Add(req)
+			reqs[req] = empty{}
+		}
 	}
 }
 

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -53,27 +53,30 @@ type enqueueRequestsFromMapFunc struct {
 
 // Create implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, evt.Object)
+	reqs := map[reconcile.Request]empty{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
 }
 
 // Update implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, evt.ObjectOld)
-	e.mapAndEnqueue(q, evt.ObjectNew)
+	reqs := map[reconcile.Request]empty{}
+	e.mapAndEnqueue(q, evt.ObjectOld, reqs)
+	e.mapAndEnqueue(q, evt.ObjectNew, reqs)
 }
 
 // Delete implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, evt.Object)
+	reqs := map[reconcile.Request]empty{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
 }
 
 // Generic implements EventHandler
 func (e *enqueueRequestsFromMapFunc) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	e.mapAndEnqueue(q, evt.Object)
+	reqs := map[reconcile.Request]empty{}
+	e.mapAndEnqueue(q, evt.Object, reqs)
 }
 
-func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object client.Object) {
-	reqs := map[reconcile.Request]empty{}
+func (e *enqueueRequestsFromMapFunc) mapAndEnqueue(q workqueue.RateLimitingInterface, object client.Object, reqs map[reconcile.Request]empty) {
 	for _, req := range e.toRequests(object) {
 		_, ok := reqs[req]
 		if !ok {

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -59,31 +59,37 @@ type EnqueueRequestForOwner struct {
 
 // Create implements EventHandler
 func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
+	reqs := map[reconcile.Request]bool{}
+	e.getOwnerReconcileRequest(evt.Object, reqs)
+	for req := range reqs {
 		q.Add(req)
 	}
 }
 
 // Update implements EventHandler
 func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	for _, req := range e.getOwnerReconcileRequest(evt.ObjectOld) {
-		q.Add(req)
-	}
-	for _, req := range e.getOwnerReconcileRequest(evt.ObjectNew) {
+	reqs := map[reconcile.Request]bool{}
+	e.getOwnerReconcileRequest(evt.ObjectOld, reqs)
+	e.getOwnerReconcileRequest(evt.ObjectNew, reqs)
+	for req := range reqs {
 		q.Add(req)
 	}
 }
 
 // Delete implements EventHandler
 func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
+	reqs := map[reconcile.Request]bool{}
+	e.getOwnerReconcileRequest(evt.Object, reqs)
+	for req := range reqs {
 		q.Add(req)
 	}
 }
 
 // Generic implements EventHandler
 func (e *EnqueueRequestForOwner) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	for _, req := range e.getOwnerReconcileRequest(evt.Object) {
+	reqs := map[reconcile.Request]bool{}
+	e.getOwnerReconcileRequest(evt.Object, reqs)
+	for req := range reqs {
 		q.Add(req)
 	}
 }
@@ -111,17 +117,16 @@ func (e *EnqueueRequestForOwner) parseOwnerTypeGroupKind(scheme *runtime.Scheme)
 
 // getOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
 // owners of object that match e.OwnerType.
-func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object) []reconcile.Request {
+func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, result map[reconcile.Request]bool) {
 	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
 	// by the user
-	var result []reconcile.Request
 	for _, ref := range e.getOwnersReferences(object) {
 		// Parse the Group out of the OwnerReference to compare it to what was parsed out of the requested OwnerType
 		refGV, err := schema.ParseGroupVersion(ref.APIVersion)
 		if err != nil {
 			log.Error(err, "Could not parse OwnerReference APIVersion",
 				"api version", ref.APIVersion)
-			return nil
+			return
 		}
 
 		// Compare the OwnerReference Group and Kind against the OwnerType Group and Kind specified by the user.
@@ -138,18 +143,15 @@ func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object) 
 			mapping, err := e.mapper.RESTMapping(e.groupKind, refGV.Version)
 			if err != nil {
 				log.Error(err, "Could not retrieve rest mapping", "kind", e.groupKind)
-				return nil
+				return
 			}
 			if mapping.Scope.Name() != meta.RESTScopeNameRoot {
 				request.Namespace = object.GetNamespace()
 			}
 
-			result = append(result, request)
+			result[request] = true
 		}
 	}
-
-	// Return the matches
-	return result
 }
 
 // getOwnersReferences returns the OwnerReferences for an object as specified by the EnqueueRequestForOwner

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -59,7 +59,7 @@ type EnqueueRequestForOwner struct {
 
 // Create implements EventHandler
 func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
-	reqs := map[reconcile.Request]bool{}
+	reqs := map[reconcile.Request]empty{}
 	e.getOwnerReconcileRequest(evt.Object, reqs)
 	for req := range reqs {
 		q.Add(req)
@@ -68,7 +68,7 @@ func (e *EnqueueRequestForOwner) Create(evt event.CreateEvent, q workqueue.RateL
 
 // Update implements EventHandler
 func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
-	reqs := map[reconcile.Request]bool{}
+	reqs := map[reconcile.Request]empty{}
 	e.getOwnerReconcileRequest(evt.ObjectOld, reqs)
 	e.getOwnerReconcileRequest(evt.ObjectNew, reqs)
 	for req := range reqs {
@@ -78,7 +78,7 @@ func (e *EnqueueRequestForOwner) Update(evt event.UpdateEvent, q workqueue.RateL
 
 // Delete implements EventHandler
 func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
-	reqs := map[reconcile.Request]bool{}
+	reqs := map[reconcile.Request]empty{}
 	e.getOwnerReconcileRequest(evt.Object, reqs)
 	for req := range reqs {
 		q.Add(req)
@@ -87,7 +87,7 @@ func (e *EnqueueRequestForOwner) Delete(evt event.DeleteEvent, q workqueue.RateL
 
 // Generic implements EventHandler
 func (e *EnqueueRequestForOwner) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
-	reqs := map[reconcile.Request]bool{}
+	reqs := map[reconcile.Request]empty{}
 	e.getOwnerReconcileRequest(evt.Object, reqs)
 	for req := range reqs {
 		q.Add(req)
@@ -117,7 +117,7 @@ func (e *EnqueueRequestForOwner) parseOwnerTypeGroupKind(scheme *runtime.Scheme)
 
 // getOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
 // owners of object that match e.OwnerType.
-func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, result map[reconcile.Request]bool) {
+func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, result map[reconcile.Request]empty) {
 	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested
 	// by the user
 	for _, ref := range e.getOwnersReferences(object) {
@@ -149,7 +149,7 @@ func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, 
 				request.Namespace = object.GetNamespace()
 			}
 
-			result[request] = true
+			result[request] = empty{}
 		}
 	}
 }

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -115,7 +115,7 @@ func (e *EnqueueRequestForOwner) parseOwnerTypeGroupKind(scheme *runtime.Scheme)
 	return nil
 }
 
-// getOwnerReconcileRequest looks at object and returns a slice of reconcile.Request to reconcile
+// getOwnerReconcileRequest looks at object and builds a map of reconcile.Request to reconcile
 // owners of object that match e.OwnerType.
 func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, result map[reconcile.Request]empty) {
 	// Iterate through the OwnerReferences looking for a match on Group and Kind against what was requested

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Eventhandler", func() {
 			close(done)
 		})
 
-		It("should enqueue a Request with the Name / Namespace of both objects in the UpdateEvent.",
+		It("should enqueue a Request with the Name / Namespace of one object in the UpdateEvent.",
 			func(done Done) {
 				newPod := pod.DeepCopy()
 				newPod.Name = "baz2"
@@ -97,17 +97,11 @@ var _ = Describe("Eventhandler", func() {
 					ObjectNew: newPod,
 				}
 				instance.Update(evt, q)
-				Expect(q.Len()).To(Equal(2))
+				Expect(q.Len()).To(Equal(1))
 
 				i, _ := q.Get()
 				Expect(i).NotTo(BeNil())
 				req, ok := i.(reconcile.Request)
-				Expect(ok).To(BeTrue())
-				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
-
-				i, _ = q.Get()
-				Expect(i).NotTo(BeNil())
-				req, ok = i.(reconcile.Request)
 				Expect(ok).To(BeTrue())
 				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz2", Name: "baz2"}))
 
@@ -212,13 +206,14 @@ var _ = Describe("Eventhandler", func() {
 			instance.Create(evt, q)
 			Expect(q.Len()).To(Equal(2))
 
-			i, _ := q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}))
-
-			i, _ = q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}}))
+			i1, _ := q.Get()
+			i2, _ := q.Get()
+			Expect([]interface{}{i1, i2}).To(ConsistOf(
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}},
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}},
+			))
 		})
 
 		It("should enqueue a Request with the function applied to the DeleteEvent.", func() {
@@ -243,13 +238,14 @@ var _ = Describe("Eventhandler", func() {
 			instance.Delete(evt, q)
 			Expect(q.Len()).To(Equal(2))
 
-			i, _ := q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}))
-
-			i, _ = q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}}))
+			i1, _ := q.Get()
+			i2, _ := q.Get()
+			Expect([]interface{}{i1, i2}).To(ConsistOf(
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}},
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}},
+			))
 		})
 
 		It("should enqueue a Request with the function applied to both objects in the UpdateEvent.",
@@ -280,21 +276,20 @@ var _ = Describe("Eventhandler", func() {
 				instance.Update(evt, q)
 				Expect(q.Len()).To(Equal(4))
 
-				i, _ := q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz-bar"}}))
-
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}}))
-
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz2-bar"}}))
-
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz2-baz"}}))
+				i1, _ := q.Get()
+				i2, _ := q.Get()
+				i3, _ := q.Get()
+				i4, _ := q.Get()
+				Expect([]interface{}{i1, i2, i3, i4}).To(ConsistOf(
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz-bar"}},
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}},
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz2-bar"}},
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz2-baz"}},
+				))
 			})
 
 		It("should enqueue a Request with the function applied to the GenericEvent.", func() {
@@ -319,13 +314,14 @@ var _ = Describe("Eventhandler", func() {
 			instance.Generic(evt, q)
 			Expect(q.Len()).To(Equal(2))
 
-			i, _ := q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}}))
-
-			i, _ = q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}}))
+			i1, _ := q.Get()
+			i2, _ := q.Get()
+			Expect([]interface{}{i1, i2}).To(ConsistOf(
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "foo", Name: "bar"}},
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz"}},
+			))
 		})
 	})
 
@@ -412,13 +408,50 @@ var _ = Describe("Eventhandler", func() {
 			instance.Update(evt, q)
 			Expect(q.Len()).To(Equal(2))
 
+			i1, _ := q.Get()
+			i2, _ := q.Get()
+			Expect([]interface{}{i1, i2}).To(ConsistOf(
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo1-parent"}},
+				reconcile.Request{
+					NamespacedName: types.NamespacedName{Namespace: newPod.GetNamespace(), Name: "foo2-parent"}},
+			))
+		})
+
+		It("should enqueue a Request with the one duplicate Owner of both objects in the UpdateEvent.", func() {
+			newPod := pod.DeepCopy()
+			newPod.Name = pod.Name + "2"
+
+			instance := handler.EnqueueRequestForOwner{
+				OwnerType: &appsv1.ReplicaSet{},
+			}
+			Expect(instance.InjectScheme(scheme.Scheme)).To(Succeed())
+			Expect(instance.InjectMapper(mapper)).To(Succeed())
+
+			pod.OwnerReferences = []metav1.OwnerReference{
+				{
+					Name:       "foo-parent",
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+			}
+			newPod.OwnerReferences = []metav1.OwnerReference{
+				{
+					Name:       "foo-parent",
+					Kind:       "ReplicaSet",
+					APIVersion: "apps/v1",
+				},
+			}
+			evt := event.UpdateEvent{
+				ObjectOld: pod,
+				ObjectNew: newPod,
+			}
+			instance.Update(evt, q)
+			Expect(q.Len()).To(Equal(1))
+
 			i, _ := q.Get()
 			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo1-parent"}}))
-
-			i, _ = q.Get()
-			Expect(i).To(Equal(reconcile.Request{
-				NamespacedName: types.NamespacedName{Namespace: newPod.GetNamespace(), Name: "foo2-parent"}}))
+				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
 		It("should enqueue a Request with the Owner of the object in the GenericEvent.", func() {
@@ -659,15 +692,17 @@ var _ = Describe("Eventhandler", func() {
 				instance.Create(evt, q)
 				Expect(q.Len()).To(Equal(3))
 
-				i, _ := q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo1-parent"}}))
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo2-parent"}}))
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{
-					NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo3-parent"}}))
+				i1, _ := q.Get()
+				i2, _ := q.Get()
+				i3, _ := q.Get()
+				Expect([]interface{}{i1, i2, i3}).To(ConsistOf(
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo1-parent"}},
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo2-parent"}},
+					reconcile.Request{
+						NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo3-parent"}},
+				))
 			})
 		})
 

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -251,8 +251,6 @@ var _ = Describe("Eventhandler", func() {
 		It("should enqueue a Request with the function applied to both objects in the UpdateEvent.",
 			func() {
 				newPod := pod.DeepCopy()
-				newPod.Name = pod.Name + "2"
-				newPod.Namespace = pod.Namespace + "2"
 
 				req := []reconcile.Request{}
 
@@ -274,19 +272,13 @@ var _ = Describe("Eventhandler", func() {
 					ObjectNew: newPod,
 				}
 				instance.Update(evt, q)
-				Expect(q.Len()).To(Equal(4))
+				Expect(q.Len()).To(Equal(2))
 
 				i, _ := q.Get()
 				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz-bar"}}))
 
 				i, _ = q.Get()
 				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}}))
-
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz2-bar"}}))
-
-				i, _ = q.Get()
-				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz2-baz"}}))
 			})
 
 		It("should enqueue a Request with the function applied to the GenericEvent.", func() {

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -276,20 +276,17 @@ var _ = Describe("Eventhandler", func() {
 				instance.Update(evt, q)
 				Expect(q.Len()).To(Equal(4))
 
-				i1, _ := q.Get()
-				i2, _ := q.Get()
-				i3, _ := q.Get()
-				i4, _ := q.Get()
-				Expect([]interface{}{i1, i2, i3, i4}).To(ConsistOf(
-					reconcile.Request{
-						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz-bar"}},
-					reconcile.Request{
-						NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}},
-					reconcile.Request{
-						NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz2-bar"}},
-					reconcile.Request{
-						NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz2-baz"}},
-				))
+				i, _ := q.Get()
+				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz-bar"}}))
+
+				i, _ = q.Get()
+				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}}))
+
+				i, _ = q.Get()
+				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "foo", Name: "baz2-bar"}}))
+
+				i, _ = q.Get()
+				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz2-baz"}}))
 			})
 
 		It("should enqueue a Request with the function applied to the GenericEvent.", func() {


### PR DESCRIPTION
This avoids race conditions where extra reconciles can happen rarely.

I still think https://github.com/kubernetes/kubernetes/pull/99185 is a better solution but failing that, here is a "userspace" solution.