### PR TITLE
:seedling: Fix typo namespace/Name to Namespace/Name

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -293,7 +293,7 @@ func (c *Controller) reconcileHandler(ctx context.Context, obj interface{}) {
 	log := c.Log.WithValues("name", req.Name, "namespace", req.Namespace)
 	ctx = logf.IntoContext(ctx, log)
 
-	// RunInformersAndControllers the syncHandler, passing it the namespace/Name string of the
+	// RunInformersAndControllers the syncHandler, passing it the Namespace/Name string of the
 	// resource to be synced.
 	if result, err := c.Do.Reconcile(ctx, req); err != nil {
 		c.Queue.AddRateLimited(req)


### PR DESCRIPTION
This is my first time to submit a patch via PR. I found a spelling error (at line 296) in the process of reading the code,

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
