### PR TITLE
:bug: Run verify workflow after pushes

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,6 +1,6 @@
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 jobs:
   verify:


### PR DESCRIPTION
Currently, we do not run the PR title verification after pushes to a PR.
This means that if a PR with an invalid title is opened, then pushed to,
the check won't run and nothing will keep the PR from merging.

GitHub doesn't seem to be very explicit about the meaning of
synchronize, the only source I could quickly find is https://github.blog/2011-10-19-all-of-the-hooks/

Source for `synchronize` being a valid value: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

/assign @vincepri 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
