### PR TITLE
📖  Typo: fix typo in validatingwebhook example

### DIFF
--- a/examples/builtins/validatingwebhook.go
+++ b/examples/builtins/validatingwebhook.go
@@ -34,7 +34,7 @@ type podValidator struct {
 	decoder *admission.Decoder
 }
 
-// podValidator admits a pod iff a specific annotation exists.
+// podValidator admits a pod if a specific annotation exists.
 func (v *podValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	pod := &corev1.Pod{}
 


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
fix typo in validatingwebhook example