### PR TITLE
⚠ Handle finalizers in the fake client

### DIFF
--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -443,6 +443,46 @@ var _ = Describe("Fake client", func() {
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
+		It("should handle finalizers on Update", func() {
+			namespacedName := types.NamespacedName{
+				Name:      "test-cm",
+				Namespace: "delete-with-finalizers",
+			}
+			By("Updating a new object")
+			newObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       namespacedName.Name,
+					Namespace:  namespacedName.Namespace,
+					Finalizers: []string{"finalizers.sigs.k8s.io/test"},
+				},
+				Data: map[string]string{
+					"test-key": "new-value",
+				},
+			}
+			err := cl.Create(context.Background(), newObj)
+			Expect(err).To(BeNil())
+
+			By("Deleting the object")
+			err = cl.Delete(context.Background(), newObj)
+			Expect(err).To(BeNil())
+
+			By("Getting the object")
+			obj := &corev1.ConfigMap{}
+			err = cl.Get(context.Background(), namespacedName, obj)
+			Expect(err).To(BeNil())
+			Expect(obj.DeletionTimestamp).NotTo(BeNil())
+
+			By("Removing the finalizer")
+			obj.Finalizers = []string{}
+			err = cl.Update(context.Background(), obj)
+			Expect(err).To(BeNil())
+
+			By("Getting the object")
+			obj = &corev1.ConfigMap{}
+			err = cl.Get(context.Background(), namespacedName, obj)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
 		It("should be able to Delete a Collection", func() {
 			By("Deleting a deploymentList")
 			err := cl.DeleteAllOf(context.Background(), &appsv1.Deployment{}, client.InNamespace("ns1"))
@@ -530,6 +570,46 @@ var _ = Describe("Fake client", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(obj.Annotations["foo"]).To(Equal("bar"))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1000"))
+		})
+
+		It("should handle finalizers on Patch", func() {
+			namespacedName := types.NamespacedName{
+				Name:      "test-cm",
+				Namespace: "delete-with-finalizers",
+			}
+			By("Updating a new object")
+			now := metav1.Now()
+			newObj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              namespacedName.Name,
+					Namespace:         namespacedName.Namespace,
+					Finalizers:        []string{"finalizers.sigs.k8s.io/test"},
+					DeletionTimestamp: &now,
+				},
+				Data: map[string]string{
+					"test-key": "new-value",
+				},
+			}
+			err := cl.Create(context.Background(), newObj)
+			Expect(err).To(BeNil())
+
+			By("Removing the finalizer")
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              namespacedName.Name,
+					Namespace:         namespacedName.Namespace,
+					Finalizers:        []string{},
+					DeletionTimestamp: &now,
+				},
+			}
+			obj.Finalizers = []string{}
+			err = cl.Patch(context.Background(), obj, client.MergeFrom(newObj))
+			Expect(err).To(BeNil())
+
+			By("Getting the object")
+			obj = &corev1.ConfigMap{}
+			err = cl.Get(context.Background(), namespacedName, obj)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 	}
 


### PR DESCRIPTION
The fake client differs significantly from the real implementation.
With the real client implementation, upon the deletion of a resource,
when finalizers are set the DeletionTimestamp is filled with a non-null
value.
This triggers a number of reconciling loops for all controllers that then
can take the opportunity to inspect the resource being deleted, perform
the required cleaning actions and then update the resource by removing
their finalizers as the cleaning job have been done.

In the current implementation, the Delete function implements a straight
delete and hence triggers a false positive or negative test when trying
to run tests at the client level, without interacting with the objects.

For example:

```
client.CreateObject()
controller.Reconcile()
Expect(Something).To(BeDone())
client.DeleteObject()
controller.Reconcile()
Expect(SomethingElse).To(BeDone())
```

In the real life, SomethingElse would actually be done as the controller
would still have access to the resource. In the current fake implementation,
this is not the case as the controller does not have access to the
resource any longer.

