### PR TITLE
:bug: Manager leader election: Don't reset restcfg UserAgent

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -308,9 +308,9 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}
 
 	// Create the resource lock to enable leader election)
-	leaderConfig := config
-	if options.LeaderElectionConfig != nil {
-		leaderConfig = options.LeaderElectionConfig
+	leaderConfig := options.LeaderElectionConfig
+	if leaderConfig == nil {
+		leaderConfig = rest.CopyConfig(config)
 	}
 	resourceLock, err := options.newResourceLock(leaderConfig, recorderProvider, leaderelection.Options{
 		LeaderElection:             options.LeaderElection,

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -592,6 +592,20 @@ var _ = Describe("manger.Manager", func() {
 				close(done)
 			})
 
+			It("should not manipulate the provided config", func() {
+				originalCfg := rest.CopyConfig(cfg)
+				// The options object is shared by multiple tests, copy it
+				// into our scope so we manipulate it for this testcase only
+				options := options
+				options.newResourceLock = nil
+				m, err := New(cfg, options)
+				Expect(err).NotTo(HaveOccurred())
+				for _, cb := range callbacks {
+					cb(m)
+				}
+				Expect(m.GetConfig()).To(Equal(originalCfg))
+			})
+
 			It("should stop when context is cancelled", func(done Done) {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
In pkg.LeaderElection.NewResourceLock we call rest.AddUserAgent
which resets the restcfgs useragent and sets it to the default one plus
a suffix. This resets whatever was originally set as UserAgent and since
we do not copy our restcfg before passing it in there, this leads to the
UserAgent being set to the leader-election one globally.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
