### PR TITLE
🐛 controllerutil.CreateOrPatch doesn't update not empty Status fields if Spec fields are specified

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -309,6 +309,20 @@ func CreateOrPatch(ctx context.Context, c client.Client, obj client.Object, f Mu
 	if (hasBeforeStatus || hasAfterStatus) && !reflect.DeepEqual(beforeStatus, afterStatus) {
 		// Only issue a Status Patch if the resource has a status and the beforeStatus
 		// and afterStatus copies differ
+		if result == OperationResultUpdated {
+			// If Status was replaced by Patch before, set it to afterStatus
+			objectAfterPatch, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+			if err != nil {
+				return result, err
+			}
+			if err = unstructured.SetNestedField(objectAfterPatch, afterStatus, "status"); err != nil {
+				return result, err
+			}
+			// If Status was replaced by Patch before, restore patched structure to the obj
+			if err = runtime.DefaultUnstructuredConverter.FromUnstructured(objectAfterPatch, obj); err != nil {
+				return result, err
+			}
+		}
 		if err := c.Status().Patch(ctx, obj, statusPatch); err != nil {
 			return result, err
 		}


### PR DESCRIPTION
If we would like to patch custom resource with some `Spec` fields and `Status` which are not empty, the controllerutil.CreateOrPatch patches `Spec` only fields, but any `Status` keep unchanged,
`result` returns `OperationResultUpdatedStatus` which means that both `Spec` and `Status` where updated
The reason why this happens is that the original `Status` of the object returned when the `Patch` procedure is exited and, as a result, no` Status` fields are updated

Fixes #1392