### PR TITLE
🐛 Fix client.Apply and client.Merge to satisfy Patch

### DIFF
--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -20,18 +20,17 @@ import (
 	"fmt"
 
 	jsonpatch "github.com/evanphx/json-patch"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 )
 
 var (
 	// Apply uses server-side apply to patch the given object.
-	Apply = applyPatch{}
+	Apply Patch = applyPatch{}
 
 	// Merge uses the raw object as a merge patch, without modifications.
 	// Use MergeFrom if you wish to compute a diff instead.
-	Merge = mergePatch{}
+	Merge Patch = mergePatch{}
 )
 
 type patch struct {
@@ -89,7 +88,7 @@ type mergeFromPatch struct {
 	opts MergeFromOptions
 }
 
-// Type implements patch.
+// Type implements Patch.
 func (s *mergeFromPatch) Type() types.PatchType {
 	return types.MergePatchType
 }
@@ -153,7 +152,7 @@ func (p mergePatch) Type() types.PatchType {
 }
 
 // Data implements Patch.
-func (p mergePatch) Data(obj runtime.Object) ([]byte, error) {
+func (p mergePatch) Data(obj Object) ([]byte, error) {
 	// NB(directxman12): we might technically want to be using an actual encoder
 	// here (in case some more performant encoder is introduced) but this is
 	// correct and sufficient for our uses (it's what the JSON serializer in
@@ -170,7 +169,7 @@ func (p applyPatch) Type() types.PatchType {
 }
 
 // Data implements Patch.
-func (p applyPatch) Data(obj runtime.Object) ([]byte, error) {
+func (p applyPatch) Data(obj Object) ([]byte, error) {
 	// NB(directxman12): we might technically want to be using an actual encoder
 	// here (in case some more performant encoder is introduced) but this is
 	// correct and sufficient for our uses (it's what the JSON serializer in


### PR DESCRIPTION
I missed this in #1395 and so did the tests. 😬 This changes the variable declarations of `client.Apply` and `client.Merge` to ensure they satisfy `client.Patch`. The compiler caught the other types because their constructors return `Patch`.