### PR TITLE
🐛  Modify multinamespaced cache to support cluster scoped resources

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -505,39 +505,39 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					err := informerCache.Get(context.Background(), svcKey, svc)
 					Expect(err).To(HaveOccurred())
 				})
-				It("test multinamespaced cache for cluster scoped resources", func() {
-					By("creating a multinamespaced cache to watch specific namespaces")
-					multi := cache.MultiNamespacedCacheBuilder([]string{"default", testNamespaceOne})
-					m, err := multi(cfg, cache.Options{})
-					Expect(err).NotTo(HaveOccurred())
+				// It("test multinamespaced cache for cluster scoped resources", func() {
+				// 	By("creating a multinamespaced cache to watch specific namespaces")
+				// 	multi := cache.MultiNamespacedCacheBuilder([]string{"default", testNamespaceOne})
+				// 	m, err := multi(cfg, cache.Options{})
+				// 	Expect(err).NotTo(HaveOccurred())
 
-					By("running the cache and waiting it for sync")
-					go func() {
-						defer GinkgoRecover()
-						Expect(m.Start(informerCacheCtx)).To(Succeed())
-					}()
-					Expect(m.WaitForCacheSync(informerCacheCtx)).NotTo(BeFalse())
+				// 	By("running the cache and waiting it for sync")
+				// 	go func() {
+				// 		defer GinkgoRecover()
+				// 		Expect(m.Start(informerCacheCtx)).To(Succeed())
+				// 	}()
+				// 	Expect(m.WaitForCacheSync(informerCacheCtx)).NotTo(BeFalse())
 
-					By("should be able to fetch cluster scoped resource")
-					node := &kcorev1.Node{}
+				// 	By("should be able to fetch cluster scoped resource")
+				// 	node := &kcorev1.Node{}
 
-					By("verifying that getting the node works with an empty namespace")
-					key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-					Expect(m.Get(context.Background(), key1, node)).To(Succeed())
+				// 	By("verifying that getting the node works with an empty namespace")
+				// 	key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
+				// 	Expect(m.Get(context.Background(), key1, node)).To(Succeed())
 
-					By("verifying if the cluster scoped resources are not duplicated")
-					nodeList := &unstructured.UnstructuredList{}
-					nodeList.SetGroupVersionKind(schema.GroupVersionKind{
-						Group:   "",
-						Version: "v1",
-						Kind:    "NodeList",
-					})
-					Expect(m.List(context.Background(), nodeList)).To(Succeed())
+				// 	By("verifying if the cluster scoped resources are not duplicated")
+				// 	nodeList := &unstructured.UnstructuredList{}
+				// 	nodeList.SetGroupVersionKind(schema.GroupVersionKind{
+				// 		Group:   "",
+				// 		Version: "v1",
+				// 		Kind:    "NodeList",
+				// 	})
+				// 	Expect(m.List(context.Background(), nodeList)).To(Succeed())
 
-					By("verifying the node list is not empty")
-					Expect(nodeList.Items).NotTo(BeEmpty())
-					Expect(len(nodeList.Items)).To(BeEquivalentTo(1))
-				})
+				// 	By("verifying the node list is not empty")
+				// 	Expect(nodeList.Items).NotTo(BeEmpty())
+				// 	Expect(len(nodeList.Items)).To(BeEquivalentTo(1))
+				// })
 			})
 			Context("with metadata-only objects", func() {
 				It("should be able to list objects that haven't been watched previously", func() {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -505,39 +505,39 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					err := informerCache.Get(context.Background(), svcKey, svc)
 					Expect(err).To(HaveOccurred())
 				})
-				// It("test multinamespaced cache for cluster scoped resources", func() {
-				// 	By("creating a multinamespaced cache to watch specific namespaces")
-				// 	multi := cache.MultiNamespacedCacheBuilder([]string{"default", testNamespaceOne})
-				// 	m, err := multi(cfg, cache.Options{})
-				// 	Expect(err).NotTo(HaveOccurred())
+				It("test multinamespaced cache for cluster scoped resources", func() {
+					By("creating a multinamespaced cache to watch specific namespaces")
+					multi := cache.MultiNamespacedCacheBuilder([]string{"default", testNamespaceOne})
+					m, err := multi(cfg, cache.Options{})
+					Expect(err).NotTo(HaveOccurred())
 
-				// 	By("running the cache and waiting it for sync")
-				// 	go func() {
-				// 		defer GinkgoRecover()
-				// 		Expect(m.Start(informerCacheCtx)).To(Succeed())
-				// 	}()
-				// 	Expect(m.WaitForCacheSync(informerCacheCtx)).NotTo(BeFalse())
+					By("running the cache and waiting it for sync")
+					go func() {
+						defer GinkgoRecover()
+						Expect(m.Start(informerCacheCtx)).To(Succeed())
+					}()
+					Expect(m.WaitForCacheSync(informerCacheCtx)).NotTo(BeFalse())
 
-				// 	By("should be able to fetch cluster scoped resource")
-				// 	node := &kcorev1.Node{}
+					By("should be able to fetch cluster scoped resource")
+					node := &kcorev1.Node{}
 
-				// 	By("verifying that getting the node works with an empty namespace")
-				// 	key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-				// 	Expect(m.Get(context.Background(), key1, node)).To(Succeed())
+					By("verifying that getting the node works with an empty namespace")
+					key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
+					Expect(m.Get(context.Background(), key1, node)).To(Succeed())
 
-				// 	By("verifying if the cluster scoped resources are not duplicated")
-				// 	nodeList := &unstructured.UnstructuredList{}
-				// 	nodeList.SetGroupVersionKind(schema.GroupVersionKind{
-				// 		Group:   "",
-				// 		Version: "v1",
-				// 		Kind:    "NodeList",
-				// 	})
-				// 	Expect(m.List(context.Background(), nodeList)).To(Succeed())
+					By("verifying if the cluster scoped resources are not duplicated")
+					nodeList := &unstructured.UnstructuredList{}
+					nodeList.SetGroupVersionKind(schema.GroupVersionKind{
+						Group:   "",
+						Version: "v1",
+						Kind:    "NodeList",
+					})
+					Expect(m.List(context.Background(), nodeList)).To(Succeed())
 
-				// 	By("verifying the node list is not empty")
-				// 	Expect(nodeList.Items).NotTo(BeEmpty())
-				// 	Expect(len(nodeList.Items)).To(BeEquivalentTo(1))
-				// })
+					By("verifying the node list is not empty")
+					Expect(nodeList.Items).NotTo(BeEmpty())
+					Expect(len(nodeList.Items)).To(BeEquivalentTo(1))
+				})
 			})
 			Context("with metadata-only objects", func() {
 				It("should be able to list objects that haven't been watched previously", func() {

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -36,7 +36,7 @@ import (
 type NewCacheFunc func(config *rest.Config, opts Options) (Cache, error)
 
 // a new global namespaced cache to handle cluster scoped resources
-var globalCache = "cluster-scope"
+const globalCache = "_cluster-scope"
 
 // MultiNamespacedCacheBuilder - Builder function to create a new multi-namespaced cache.
 // This will scope the cache to a list of namespaces. Listing for all namespaces
@@ -135,7 +135,7 @@ func (c *multiNamespaceCache) IndexField(ctx context.Context, obj client.Object,
 }
 
 func (c *multiNamespaceCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-	isNamespaced, err := objectutil.IsNamespacedObject(obj, c.Scheme, c.RESTMapper)
+	isNamespaced, err := objectutil.IsAPINamespaced(obj, c.Scheme, c.RESTMapper)
 	if err != nil {
 		return err
 	}
@@ -158,7 +158,7 @@ func (c *multiNamespaceCache) List(ctx context.Context, list client.ObjectList, 
 	listOpts := client.ListOptions{}
 	listOpts.ApplyOptions(opts)
 
-	isNamespaced, err := objectutil.IsNamespacedObject(list, c.Scheme, c.RESTMapper)
+	isNamespaced, err := objectutil.IsAPINamespaced(list, c.Scheme, c.RESTMapper)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -57,6 +57,7 @@ func (n *namespacedClient) RESTMapper() meta.RESTMapper {
 
 // isNamespaced returns true if the object is namespace scoped.
 // For unstructured objects the gvk is found from the object itself.
+// TODO: this is repetitive code. Remove this and use ojectutil.IsNamespaced.
 func isNamespaced(c Client, obj runtime.Object) (bool, error) {
 	var gvk schema.GroupVersionKind
 	var err error

--- a/pkg/internal/objectutil/filter.go
+++ b/pkg/internal/objectutil/filter.go
@@ -17,9 +17,16 @@ limitations under the License.
 package objectutil
 
 import (
+	"errors"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // FilterWithLabels returns a copy of the items in objs matching labelSel
@@ -39,4 +46,41 @@ func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtim
 		outItems = append(outItems, obj.DeepCopyObject())
 	}
 	return outItems, nil
+}
+
+// IsNamespacedObject returns true if the object is namespace scoped.
+// For unstructured objects the gvk is found from the object itself.
+func IsNamespacedObject(obj runtime.Object, scheme *runtime.Scheme, restmapper apimeta.RESTMapper) (bool, error) {
+	var gvk schema.GroupVersionKind
+	var err error
+
+	_, isUnstructured := obj.(*unstructured.Unstructured)
+	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
+
+	isUnstructured = isUnstructured || isUnstructuredList
+
+	if isUnstructured {
+		gvk = obj.GetObjectKind().GroupVersionKind()
+	} else {
+		gvk, err = apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	restmapping, err := restmapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})
+	if err != nil {
+		return false, fmt.Errorf("failed to get restmapping: %w", err)
+	}
+
+	scope := restmapping.Scope.Name()
+
+	if scope == "" {
+		return false, errors.New("Scope cannot be identified. Empty scope returned")
+	}
+
+	if scope != meta.RESTScopeNameRoot {
+		return true, nil
+	}
+	return false, nil
 }

--- a/pkg/internal/objectutil/objectutil.go
+++ b/pkg/internal/objectutil/objectutil.go
@@ -22,7 +22,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,24 +47,12 @@ func FilterWithLabels(objs []runtime.Object, labelSel labels.Selector) ([]runtim
 	return outItems, nil
 }
 
-// IsNamespacedObject returns true if the object is namespace scoped.
+// IsAPINamespaced returns true if the object is namespace scoped.
 // For unstructured objects the gvk is found from the object itself.
-func IsNamespacedObject(obj runtime.Object, scheme *runtime.Scheme, restmapper apimeta.RESTMapper) (bool, error) {
-	var gvk schema.GroupVersionKind
-	var err error
-
-	_, isUnstructured := obj.(*unstructured.Unstructured)
-	_, isUnstructuredList := obj.(*unstructured.UnstructuredList)
-
-	isUnstructured = isUnstructured || isUnstructuredList
-
-	if isUnstructured {
-		gvk = obj.GetObjectKind().GroupVersionKind()
-	} else {
-		gvk, err = apiutil.GVKForObject(obj, scheme)
-		if err != nil {
-			return false, err
-		}
+func IsAPINamespaced(obj runtime.Object, scheme *runtime.Scheme, restmapper apimeta.RESTMapper) (bool, error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return false, err
 	}
 
 	restmapping, err := restmapper.RESTMapping(schema.GroupKind{Group: gvk.Group, Kind: gvk.Kind})


### PR DESCRIPTION
This PR modifies the multinamespacedcache implementation to:
- create a global cache mapping for an empty namespace, so that when
cluster scoped resources are fetched, namespace is not required.
- deduplicate the objects in the `List` call, based on
unique combination of resource name and namespace.

Closes: #1377
Closes: #1378

Signed-off-by: varshaprasad96 <varshaprasad96@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
