### PR TITLE
:sparkles: Add Selector option to Builder

### DIFF
--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -18,6 +18,7 @@ package builder
 
 import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 // {{{ "Functional" Option Interfaces
@@ -113,5 +114,40 @@ var (
 	_ OwnsOption    = OnlyMetadata
 	_ WatchesOption = OnlyMetadata
 )
+
+// }}}
+
+// {{{ Selector Options
+
+// WithSelector the given predicates list.
+func WithSelector(selector selector.Selector) Selector {
+	return Selector{
+		selector: selector,
+	}
+}
+
+// Selector filters events before enqueuing the keys.
+type Selector struct {
+	selector selector.Selector
+}
+
+// ApplyToFor applies this configuration to the given ForInput options.
+func (w Selector) ApplyToFor(opts *ForInput) {
+	opts.selector = w.selector
+}
+
+// ApplyToOwns applies this configuration to the given OwnsInput options.
+func (w Selector) ApplyToOwns(opts *OwnsInput) {
+	opts.selector = w.selector
+}
+
+// ApplyToWatches applies this configuration to the given WatchesInput options.
+func (w Selector) ApplyToWatches(opts *WatchesInput) {
+	opts.selector = w.selector
+}
+
+var _ ForOption = &Selector{}
+var _ OwnsOption = &Selector{}
+var _ WatchesOption = &Selector{}
 
 // }}}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 var log = logf.RuntimeLog.WithName("object-cache")
@@ -57,6 +58,10 @@ type Informers interface {
 	// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
 	// of the underlying object.
 	GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error)
+
+	// SetSelector apply a selector at informer ListWatch to fillter in the
+	// the cache
+	SetSelector(obj client.Object, selector selector.Selector) error
 
 	// Start runs all the informers known to this cache until the context is closed.
 	// It blocks.

--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/internal"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 var (
@@ -157,6 +158,15 @@ func (ip *informerCache) GetInformer(ctx context.Context, obj client.Object) (In
 		return nil, err
 	}
 	return i.Informer, err
+}
+
+func (ip *informerCache) SetSelector(obj client.Object, selector selector.Selector) error {
+	gvk, err := apiutil.GVKForObject(obj, ip.Scheme)
+	if err != nil {
+		return err
+	}
+	ip.InformersMap.SetSelectorForKind(gvk, obj, selector)
+	return nil
 }
 
 // NeedLeaderElection implements the LeaderElectionRunnable interface

--- a/pkg/cache/informertest/fake_cache.go
+++ b/pkg/cache/informertest/fake_cache.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllertest"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 var _ cache.Cache = &FakeInformers{}
@@ -77,6 +78,13 @@ func (c *FakeInformers) GetInformer(ctx context.Context, obj client.Object) (cac
 	}
 	gvk := gvks[0]
 	return c.informerFor(gvk, obj)
+}
+
+// SetSelector specify the field/label selector to apply to obj ListWatch at
+// cache
+func (c *FakeInformers) SetSelector(obj client.Object, selector selector.Selector) error {
+	// TODO
+	return nil
 }
 
 // WaitForCacheSync implements Informers

--- a/pkg/cache/internal/deleg_map.go
+++ b/pkg/cache/internal/deleg_map.go
@@ -27,6 +27,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 // InformersMap create and caches Informers for (runtime.Object, schema.GroupVersionKind) pairs.
@@ -57,6 +59,22 @@ func NewInformersMap(config *rest.Config,
 		metadata:     newMetadataInformersMap(config, scheme, mapper, resync, namespace),
 
 		Scheme: scheme,
+	}
+}
+
+// SetSelectorForKind set the field/label selector for the Informer ListWatch
+func (m *InformersMap) SetSelectorForKind(gvk schema.GroupVersionKind, obj runtime.Object, selector selector.Selector) {
+	switch obj.(type) {
+	case *unstructured.Unstructured:
+		m.unstructured.setSelectorForKind(gvk, selector)
+	case *unstructured.UnstructuredList:
+		m.unstructured.setSelectorForKind(gvk, selector)
+	case *metav1.PartialObjectMetadata:
+		m.metadata.setSelectorForKind(gvk, selector)
+	case *metav1.PartialObjectMetadataList:
+		m.metadata.setSelectorForKind(gvk, selector)
+	default:
+		m.structured.setSelectorForKind(gvk, selector)
 	}
 }
 

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 	toolscache "k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 // NewCacheFunc - Function for creating a new cache from the options and a rest config
@@ -92,6 +93,16 @@ func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema
 		informers[ns] = informer
 	}
 	return &multiNamespaceInformer{namespaceToInformer: informers}, nil
+}
+
+func (c *multiNamespaceCache) SetSelector(obj client.Object, selector selector.Selector) error {
+	for _, cache := range c.namespaceToCache {
+		err := cache.SetSelector(obj, selector)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *multiNamespaceCache) Start(ctx context.Context) error {

--- a/pkg/selector/doc.go
+++ b/pkg/selector/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package selector defines Selectors used by Controllers to filter Cache
+*/
+package selector

--- a/pkg/selector/selectors.go
+++ b/pkg/selector/selectors.go
@@ -1,0 +1,23 @@
+package selector
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+// Selector specify the label/field selector to fill in ListOptions
+type Selector struct {
+	Label labels.Selector
+	Field fields.Selector
+}
+
+// FillInListOpts fill in ListOptions LabelSelector and FieldSelector if needed
+func (s Selector) FillInListOpts(listOpts *metav1.ListOptions) {
+	if s.Label != nil {
+		listOpts.LabelSelector = s.Label.String()
+	}
+	if s.Field != nil {
+		listOpts.FieldSelector = s.Field.String()
+	}
+}

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -33,6 +33,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/selector"
 )
 
 var log = logf.RuntimeLog.WithName("source")
@@ -89,6 +90,9 @@ type Kind struct {
 	// Type is the type of object to watch.  e.g. &v1.Pod{}
 	Type client.Object
 
+	// Selector add labels and fields selector to the cache
+	Selector selector.Selector
+
 	// cache used to watch APIs
 	cache cache.Cache
 }
@@ -108,6 +112,11 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 	// cache should have been injected before Start was called
 	if ks.cache == nil {
 		return fmt.Errorf("must call CacheInto on Kind before calling Start")
+	}
+
+	err := ks.cache.SetSelector(ks.Type, ks.Selector)
+	if err != nil {
+		return err
 	}
 
 	// Lookup the Informer from the Cache and add an EventHandler which populates the Queue


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
As a follow up of [1] this change instruct the ListWatcher from the
informers to select by label/field but instead of using a manager/cache
Options it pass the select using the builder.

[1] #1404