### PR TITLE
✨ Simple helper for unmanaged webhook server

### DIFF
--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -113,6 +113,9 @@ func (f HandlerFunc) Handle(ctx context.Context, req Request) Response {
 }
 
 // Webhook represents each individual webhook.
+//
+// It must be registered with a webhook.Server or
+// populated by StandaloneWebhook to be ran on an arbitrary HTTP server.
 type Webhook struct {
 	// Handler actually processes an admission request returning whether it was allowed or denied,
 	// and potentially patches to apply to the handler.
@@ -221,8 +224,11 @@ type StandaloneOptions struct {
 	Path string
 }
 
-// StandaloneWebhook transforms a Webhook that needs to be registered
-// on a webhook.Server into one that can be ran on any arbitrary mux.
+// StandaloneWebhook prepares a webhook for use without a webhook.Server,
+// passing in the information normally populated by webhook.Server
+// and instrumenting the webhook with metrics.
+//
+// Use this to attach your webhook to an arbitrary HTTP server or mux.
 func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, error) {
 	if opts.Scheme == nil {
 		opts.Scheme = scheme.Scheme

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -219,9 +219,10 @@ type StandaloneOptions struct {
 	// Logger to be used by the webhook.
 	// If none is set, it defaults to log.Log global logger.
 	Logger logr.Logger
-	// Path the webhook will be served at.
-	// Used for labelling prometheus metrics.
-	Path string
+	// MetricsPath is used for labelling prometheus metrics
+	// by the path is served on.
+	// If none is set, prometheus metrics will not be generated.
+	MetricsPath string
 }
 
 // StandaloneWebhook prepares a webhook for use without a webhook.Server,
@@ -245,8 +246,8 @@ func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, err
 	}
 	hook.log = opts.Logger
 
-	if opts.Path == "" {
+	if opts.MetricsPath == "" {
 		return hook, nil
 	}
-	return metrics.InstrumentedHook(opts.Path, hook), nil
+	return metrics.InstrumentedHook(opts.MetricsPath, hook), nil
 }

--- a/pkg/webhook/example_test.go
+++ b/pkg/webhook/example_test.go
@@ -83,7 +83,7 @@ func Example() {
 
 // This example creates a webhook server that can be
 // ran without a controller manager.
-func ExampleStandaloneServer() {
+func ExampleServer_StartStandalone() {
 	// Create a webhook server
 	hookServer := &Server{
 		Port: 8443,
@@ -105,7 +105,7 @@ func ExampleStandaloneServer() {
 // and runs it on a vanilla go HTTP server to demonstrate
 // how you could run a webhook on an existing server
 // without a controller manager.
-func ExampleArbitraryHTTPServer() {
+func ExampleStandaloneWebhook() {
 	// Assume you have an existing HTTP server at your disposal
 	// configured as desired (e.g. with TLS).
 	// For this example just create a basic http.ServeMux
@@ -144,6 +144,8 @@ func ExampleArbitraryHTTPServer() {
 	mux.Handle("/validating", validatingHookHandler)
 
 	// Run your handler
-	http.ListenAndServe(port, mux)
+	if err := http.ListenAndServe(port, mux); err != nil {
+		panic(err)
+	}
 
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -68,12 +69,12 @@ var _ = Describe("Webhook Server", func() {
 		Expect(servingOpts.Cleanup()).To(Succeed())
 	})
 
-	startServer := func() (done <-chan struct{}) {
+	genericStartServer := func(f func(ctx context.Context)) (done <-chan struct{}) {
 		doneCh := make(chan struct{})
 		go func() {
 			defer GinkgoRecover()
 			defer close(doneCh)
-			Expect(server.Start(ctx)).To(Succeed())
+			f(ctx)
 		}()
 		// wait till we can ping the server to start the test
 		Eventually(func() error {
@@ -91,6 +92,12 @@ var _ = Describe("Webhook Server", func() {
 		})).To(Succeed())
 
 		return doneCh
+	}
+
+	startServer := func() (done <-chan struct{}) {
+		return genericStartServer(func(ctx context.Context) {
+			Expect(server.Start(ctx)).To(Succeed())
+		})
 	}
 
 	// TODO(directxman12): figure out a good way to test all the serving setup
@@ -175,32 +182,26 @@ var _ = Describe("Webhook Server", func() {
 		})
 	})
 
-	Context("when using an unmanaged webhook server", func() {
-		It("should serve a webhook on the requested path", func() {
-			opts := webhook.Options{
-				Host:    servingOpts.LocalServingHost,
-				Port:    servingOpts.LocalServingPort,
-				CertDir: servingOpts.LocalServingCertDir,
-			}
-			var err error
-			// overwrite the server so that startServer() starts it
-			server, err = webhook.NewUnmanaged(opts)
-
-			Expect(err).NotTo(HaveOccurred())
-			server.Register("/somepath", &testHandler{})
-			doneCh := startServer()
-
-			Eventually(func() ([]byte, error) {
-				resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
-				Expect(err).NotTo(HaveOccurred())
-				defer resp.Body.Close()
-				return ioutil.ReadAll(resp.Body)
-			}).Should(Equal([]byte("gadzooks!")))
-
-			ctxCancel()
-			Eventually(doneCh, "4s").Should(BeClosed())
+	It("should serve be able to serve in unmanaged mode", func() {
+		server = &webhook.Server{
+			Host:    servingOpts.LocalServingHost,
+			Port:    servingOpts.LocalServingPort,
+			CertDir: servingOpts.LocalServingCertDir,
+		}
+		server.Register("/somepath", &testHandler{})
+		doneCh := genericStartServer(func(ctx context.Context) {
+			Expect(server.StartStandalone(ctx, scheme.Scheme))
 		})
 
+		Eventually(func() ([]byte, error) {
+			resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			return ioutil.ReadAll(resp.Body)
+		}).Should(Equal([]byte("gadzooks!")))
+
+		ctxCancel()
+		Eventually(doneCh, "4s").Should(BeClosed())
 	})
 })
 

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -127,7 +127,9 @@ var _ = Describe("Webhook", func() {
 			}
 
 			// generate listener
-			listener, err := tls.Listen("tcp", net.JoinHostPort(testenv.WebhookInstallOptions.LocalServingHost, strconv.Itoa(int(testenv.WebhookInstallOptions.LocalServingPort))), cfg)
+			listener, err := tls.Listen("tcp",
+				net.JoinHostPort(testenv.WebhookInstallOptions.LocalServingHost,
+					strconv.Itoa(int(testenv.WebhookInstallOptions.LocalServingPort))), cfg)
 			Expect(err).NotTo(HaveOccurred())
 
 			// create and register the standalone webhook
@@ -144,7 +146,7 @@ var _ = Describe("Webhook", func() {
 					Expect(srv.Shutdown(context.Background())).NotTo(HaveOccurred())
 					close(idleConnsClosed)
 				}()
-				srv.Serve(listener)
+				_ = srv.Serve(listener)
 				<-idleConnsClosed
 			}()
 

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -1,0 +1,113 @@
+package webhook_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("Webhook", func() {
+	var c client.Client
+	var obj *appsv1.Deployment
+	BeforeEach(func() {
+		Expect(cfg).NotTo(BeNil())
+		var err error
+		c, err = client.New(cfg, client.Options{})
+		Expect(err).NotTo(HaveOccurred())
+
+		obj = &appsv1.Deployment{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-deployment",
+				Namespace: "default",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"foo": "bar"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "nginx",
+								Image: "nginx",
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Context("when running a webhook server with a manager", func() {
+		It("should reject create request for webhook that rejects all requests", func(done Done) {
+			m, err := manager.New(cfg, manager.Options{
+				Port:    testenv.WebhookInstallOptions.LocalServingPort,
+				Host:    testenv.WebhookInstallOptions.LocalServingHost,
+				CertDir: testenv.WebhookInstallOptions.LocalServingCertDir,
+			}) // we need manager here just to leverage manager.SetFields
+			Expect(err).NotTo(HaveOccurred())
+			server := m.GetWebhookServer()
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				_ = server.Start(ctx)
+			}()
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				return errors.ReasonForError(err) == metav1.StatusReason("Always denied")
+			}, 1*time.Second).Should(BeTrue())
+
+			cancel()
+			close(done)
+		})
+	})
+	Context("when running a webhook server without a manager ", func() {
+		It("should reject create request for webhook that rejects all requests", func(done Done) {
+			opts := webhook.Options{
+				Port:    testenv.WebhookInstallOptions.LocalServingPort,
+				Host:    testenv.WebhookInstallOptions.LocalServingHost,
+				CertDir: testenv.WebhookInstallOptions.LocalServingCertDir,
+			}
+			server, err := webhook.NewUnmanaged(opts)
+			Expect(err).NotTo(HaveOccurred())
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				_ = server.Start(ctx)
+			}()
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				return errors.ReasonForError(err) == metav1.StatusReason("Always denied")
+			}, 1*time.Second).Should(BeTrue())
+
+			cancel()
+			close(done)
+		})
+	})
+})
+
+type rejectingValidator struct {
+}
+
+func (v *rejectingValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	return admission.Denied(fmt.Sprint("Always denied"))
+}


### PR DESCRIPTION
This adds helper functions to setup webhooks server without a manager. It adds 
1. `webhook.Unmanaged` that creates a `webhook.Server` without a manager / cluster connection information
2. `admission.StandalonWebhook` that creates an `http.Handler` that can be run on any arbitrary Go HTTP server (`http.SeverMux`) rather than a `webhook.Server`)

Fixes #1255 
