### PR TITLE
:bug: Deflake should update CRDs if already present in the cluster

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Test", func() {
 			Eventually(func() bool {
 				err := c.Get(context.TODO(), crdObjectKey, &placeholder)
 				return apierrors.IsNotFound(err)
-			}, 1*time.Second).Should(BeTrue())
+			}, 5*time.Second).Should(BeTrue())
 		}
 		close(done)
 	}, teardownTimeoutSeconds)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Reproduces easily under load, e.G. by running `for s in $(seq 1 10); do go test ./pkg/envtest & done`. Doesn't reproduce for me with this patch.

/assign @vincepri 