### PR TITLE
🌱 Prepare envtest certs for aggregation layer

### DIFF
--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -150,6 +150,9 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
+	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver-ca.crt"), ca.CA.CertBytes(), 0640); err != nil {
+		return err
+	}
 	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil {
 		return err
 	}

--- a/pkg/internal/testing/integration/internal/tinyca.go
+++ b/pkg/internal/testing/integration/internal/tinyca.go
@@ -154,7 +154,7 @@ func (c *TinyCA) NewServingCert(names ...string) (CertPair, error) {
 			DNSNames: dnsNames,
 			IPs:      ips,
 		},
-		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	})
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Prepare API server certs in envtest for usage with the [aggregation layer](https://kubernetes.io/docs/tasks/extend-kubernetes/configure-aggregation-layer/):
- write CA cert of API server to a file for usage as `--requestheader-client-ca-file` and `--client-ca-file`
- add `ClientAuth` key usage to API server cert, so it can be used by the API server to authenticate against an extension API server

With this change, tests are able to setup the API server's aggregation layer for registering `APIService`s in their test environment.

For example:
```go
testEnv.ControlPlane.APIServer.Args = append(envtest.DefaultKubeAPIServerFlags,
	"--client-ca-file={{ .CertDir }}/apiserver-ca.crt",
	"--proxy-client-key-file={{ .CertDir }}/apiserver.key",
	"--proxy-client-cert-file={{ .CertDir }}/apiserver.crt",
	"--requestheader-client-ca-file={{ .CertDir }}/apiserver-ca.crt",
	"--requestheader-extra-headers-prefix=X-Remote-Extra-",
	"--requestheader-group-headers=X-Remote-Group",
	"--requestheader-username-headers=X-Remote-User",
)
```

These are the minimum required changes to make this scenario work.

Ref #1448