### PR TITLE
📖 Update godoc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ see how it can be used.
 
 Documentation:
 
-- [Package overview](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg)
-- [Basic controller using builder](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/builder#example-Builder)
-- [Creating a manager](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager#example-New)
-- [Creating a controller](https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/controller#example-New)
+- [Package overview](https://pkg.go.dev/sigs.k8s.io/controller-runtime/)
+- [Basic controller using builder](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder#example-Builder)
+- [Creating a manager](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#example-New)
+- [Creating a controller](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#example-New)
 - [Examples](https://github.com/kubernetes-sigs/controller-runtime/blob/master/examples)
 - [Designs](https://github.com/kubernetes-sigs/controller-runtime/blob/master/designs)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ see how it can be used.
 
 Documentation:
 
-- [Package overview](https://pkg.go.dev/sigs.k8s.io/controller-runtime/)
+- [Package overview](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg)
 - [Basic controller using builder](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder#example-Builder)
 - [Creating a manager](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#example-New)
 - [Creating a controller](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#example-New)
@@ -63,4 +63,3 @@ Before starting any work, please either comment on an existing issue, or file a 
 ## Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
-


### PR DESCRIPTION
The links in the README point to v0.1.12. The new links point to v0.8.x and forward.