### PR TITLE
📖 Remove extraneous "s" in pkg/events in GoDoc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -58,7 +58,7 @@ limitations under the License.
 //
 // Controllers
 //
-// Controllers (pkg/controller) use events (pkg/events) to eventually trigger
+// Controllers (pkg/controller) use events (pkg/event) to eventually trigger
 // reconcile requests.  They may be constructed manually, but are often
 // constructed with a Builder (pkg/builder), which eases the wiring of event
 // sources (pkg/source), like Kubernetes API object changes, to event handlers


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
The package name has one more s