### PR TITLE
🌱 Envtest exports secure config, helpers for simplify users adding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-logr/logr v0.4.0
 	github.com/go-logr/zapr v0.4.0
+	github.com/google/uuid v1.1.2
 	github.com/googleapis/gnostic v0.5.4 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/imdario/mergo v0.3.11 // indirect

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -95,10 +95,33 @@ type Environment struct {
 	// ControlPlane is the ControlPlane including the apiserver and etcd
 	ControlPlane integration.ControlPlane
 
-	// Config can be used to talk to the apiserver.  It's automatically
-	// populated if not set using the standard controller-runtime config
+	// Config can be used to talk to the apiserver (insecure endpoint).
+	// It's automatically populated if not set using the standard controller-runtime config
 	// loading.
 	Config *rest.Config
+
+	// SecureConfig can be used to talk to the apiserver (secure endpoint).
+	// It's automatically populated if not set using the standard controller-runtime config
+	// loading.  This just contains secure endpoint and tlsconfig (no authn info).
+	// To use this config, you have to configure kube-apiserver with some authn module(static token, basic auth, etc.)
+	// and set your authentication info to this config.  For example:
+	//
+	// // basic authn plugin case
+	// te := &envtest.Environment{
+	//   KubeAPIServerFlags: append(
+	//     envtest.DefaultKubeAPIServerFlags,
+	//     "--basic-auth-file=my-file", "--authorization-mode=RBAC",
+	//   ),
+	// }
+	// te.Start()
+	//
+	// cfg := rest.CopyConfig(te.SecureConfig)
+	// cfg.Username = "myname"
+	// cfg.Password = "mypassword"
+	//
+	// // This client can send a request as "myname" user.
+	// cli := client.New(cfg)
+	SecureConfig *rest.Config
 
 	// CRDInstallOptions are the options for installing CRDs.
 	CRDInstallOptions CRDInstallOptions
@@ -257,6 +280,13 @@ func (te *Environment) Start() (*rest.Config, error) {
 		// Create the *rest.Config for creating new clients
 		te.Config = &rest.Config{
 			Host: te.ControlPlane.APIURL().Host,
+			// gotta go fast during tests -- we don't really care about overwhelming our test API server
+			QPS:   1000.0,
+			Burst: 2000.0,
+		}
+		te.SecureConfig = &rest.Config{
+			Host:            fmt.Sprintf("%s:%d", te.ControlPlane.APIURL().Hostname(), te.ControlPlane.APIServer.SecurePort),
+			TLSClientConfig: te.ControlPlane.APIServer.TLSClientConfig,
 			// gotta go fast during tests -- we don't really care about overwhelming our test API server
 			QPS:   1000.0,
 			Burst: 2000.0,

--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/rest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"time"
+
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/addr"
 	"sigs.k8s.io/controller-runtime/pkg/internal/testing/integration/internal"
@@ -25,7 +26,7 @@ type APIServer struct {
 	SecurePort int
 
 	// TLSconfig is tls configuration to connect to its secure endpoint.
-	TlsClientConfig rest.TLSClientConfig
+	TLSClientConfig rest.TLSClientConfig
 
 	// Path is the path to the apiserver binary.
 	//
@@ -161,7 +162,7 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	s.TlsClientConfig = rest.TLSClientConfig{
+	s.TLSClientConfig = rest.TLSClientConfig{
 		CAData: ca.CA.CertBytes(),
 	}
 

--- a/pkg/internal/testing/integration/apiserver.go
+++ b/pkg/internal/testing/integration/apiserver.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"k8s.io/client-go/rest"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -22,6 +23,9 @@ type APIServer struct {
 
 	// SecurePort is the additional secure port that the APIServer should listen on.
 	SecurePort int
+
+	// TLSconfig is tls configuration to connect to its secure endpoint.
+	TlsClientConfig rest.TLSClientConfig
 
 	// Path is the path to the apiserver binary.
 	//
@@ -155,6 +159,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 	}
 	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil {
 		return err
+	}
+
+	s.TlsClientConfig = rest.TLSClientConfig{
+		CAData: ca.CA.CertBytes(),
 	}
 
 	return nil

--- a/pkg/internal/testing/integration/internal/apiserver.go
+++ b/pkg/internal/testing/integration/internal/apiserver.go
@@ -5,16 +5,22 @@ package internal
 var APIServerDefaultArgs = []string{
 	"--advertise-address=127.0.0.1",
 	"--etcd-servers={{ if .EtcdURL }}{{ .EtcdURL.String }}{{ end }}",
-	"--cert-dir={{ .CertDir }}",
+	"--tls-cert-file={{ .CertDir }}/apiserver.crt",
+	"--tls-private-key-file={{ .CertDir }}/apiserver.key",
 	"--insecure-port={{ if .URL }}{{ .URL.Port }}{{ end }}",
 	"--insecure-bind-address={{ if .URL }}{{ .URL.Hostname }}{{ end }}",
 	"--secure-port={{ if .SecurePort }}{{ .SecurePort }}{{ end }}",
+	"--token-auth-file={{ .AuthFileDir }}/token-auth-file",
+	"--authorization-mode=RBAC",
 	// we're keeping this disabled because if enabled, default SA is missing which would force all tests to create one
 	// in normal apiserver operation this SA is created by controller, but that is not run in integration environment
 	"--disable-admission-plugins=ServiceAccount",
 	"--service-cluster-ip-range=10.0.0.0/24",
 	"--allow-privileged=true",
 }
+
+// TokenAuthFileTemplate template for populating auth-token-file for API server
+var TokenAuthFileTemplate = "{{ range .Users }}{{.Token}},{{.Name}},{{.UID}},\"{{range .Groups}}{{.}},{{end}}\"\n{{end}}"
 
 // DoAPIServerArgDefaulting will set default values to allow tests to run offline when the args are not informed. Otherwise,
 // it will return the same []string arg passed as param.

--- a/pkg/internal/testing/integration/internal/arguments.go
+++ b/pkg/internal/testing/integration/internal/arguments.go
@@ -5,6 +5,15 @@ import (
 	"html/template"
 )
 
+// RenderTemplate renders single string template
+func RenderTemplate(tmplStr string, data interface{}) (rendered string, err error) {
+	renderedArray, err := RenderTemplates([]string{tmplStr}, data)
+	if err != nil {
+		return "", err
+	}
+	return renderedArray[0], nil
+}
+
 // RenderTemplates returns an []string to render the templates
 func RenderTemplates(argTemplates []string, data interface{}) (args []string, err error) {
 	var t *template.Template

--- a/pkg/internal/testing/integration/internal/arguments_test.go
+++ b/pkg/internal/testing/integration/internal/arguments_test.go
@@ -82,6 +82,18 @@ var _ = Describe("Arguments", func() {
 		))
 	})
 
+	It("templating single string", func() {
+		template := "one: {{ .One }}, two: {{.Two}}"
+		data := struct {
+			One string
+			Two string
+		}{"one", "two"}
+
+		out, err := RenderTemplate(template, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo("one: one, two: two"))
+	})
+
 	Context("When overriding external default args", func() {
 		It("does not change the internal default args for APIServer", func() {
 			integration.APIServerDefaultArgs[0] = "oh no!"


### PR DESCRIPTION
fixes #983

Bit extended #984, added `token-auth-file` generation with "kubeadmin" user, added couple helpers to envstest for users creation.

This PR added:
    `internal.integration.APIServer`: expose `TLSClientConfig` to connect its secure endpoint (@everpeace)
    `envtest.Environment`: introduce SecureConfig that just contains kube-apiserver's secure endpoint and its TLSClientConfig. (@everpeace)
     `envtest.AddAPIServerUser` helper for adding additional users
     `envtest.GetConfigForUser` helper for getting rest.Config with respective credentials
     token-auth-file creates automatically during APIServer startup
     fixed issue with missing certificates for APIServer after its restart, certs regenerates after controlplane start/stop