### PR TITLE
:bug: Metadata only objects should always preserve GroupVersionKind

### DIFF
--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -408,8 +408,17 @@ var _ = Describe("application", func() {
 				Owns(&appsv1.ReplicaSet{}, OnlyMetadata).
 				Watches(&source.Kind{Type: &appsv1.StatefulSet{}},
 					handler.EnqueueRequestsFromMapFunc(func(o client.Object) []reconcile.Request {
+						defer GinkgoRecover()
+
 						ometa := o.(*metav1.PartialObjectMetadata)
 						statefulSetMaps <- ometa
+
+						// Validate that the GVK is not empty when dealing with PartialObjectMetadata objects.
+						Expect(o.GetObjectKind().GroupVersionKind()).To(Equal(schema.GroupVersionKind{
+							Group:   "apps",
+							Version: "v1",
+							Kind:    "StatefulSet",
+						}))
 						return nil
 					}),
 					OnlyMetadata)

--- a/pkg/cache/internal/metadata_infomer_wrapper.go
+++ b/pkg/cache/internal/metadata_infomer_wrapper.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package internal
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+)
+
+func metadataSharedIndexInformerPreserveGVK(gvk schema.GroupVersionKind, si cache.SharedIndexInformer) cache.SharedIndexInformer {
+	return &sharedInformerWrapper{
+		gvk:                 gvk,
+		SharedIndexInformer: si,
+	}
+}
+
+type sharedInformerWrapper struct {
+	gvk schema.GroupVersionKind
+	cache.SharedIndexInformer
+}
+
+func (s *sharedInformerWrapper) AddEventHandler(handler cache.ResourceEventHandler) {
+	s.SharedIndexInformer.AddEventHandler(&handlerPreserveGVK{s.gvk, handler})
+}
+
+func (s *sharedInformerWrapper) AddEventHandlerWithResyncPeriod(handler cache.ResourceEventHandler, resyncPeriod time.Duration) {
+	s.SharedIndexInformer.AddEventHandlerWithResyncPeriod(&handlerPreserveGVK{s.gvk, handler}, resyncPeriod)
+}
+
+type handlerPreserveGVK struct {
+	gvk schema.GroupVersionKind
+	cache.ResourceEventHandler
+}
+
+func (h *handlerPreserveGVK) resetGroupVersionKind(obj interface{}) {
+	if v, ok := obj.(schema.ObjectKind); ok {
+		v.SetGroupVersionKind(h.gvk)
+	}
+}
+
+func (h *handlerPreserveGVK) OnAdd(obj interface{}) {
+	h.resetGroupVersionKind(obj)
+	h.ResourceEventHandler.OnAdd(obj)
+}
+
+func (h *handlerPreserveGVK) OnUpdate(oldObj, newObj interface{}) {
+	h.resetGroupVersionKind(oldObj)
+	h.resetGroupVersionKind(newObj)
+	h.ResourceEventHandler.OnUpdate(oldObj, newObj)
+}
+
+func (h *handlerPreserveGVK) OnDelete(obj interface{}) {
+	h.resetGroupVersionKind(obj)
+	h.ResourceEventHandler.OnDelete(obj)
+}

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -118,15 +118,24 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 // with the given GroupVersionKind. The REST client will be configured to use the negotiated serializer from
 // baseConfig, if set, otherwise a default serializer will be set.
 func RESTClientForGVK(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config, codecs serializer.CodecFactory) (rest.Interface, error) {
-	cfg := createRestConfig(gvk, isUnstructured, baseConfig)
-	if cfg.NegotiatedSerializer == nil {
-		cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
-	}
-	return rest.RESTClientFor(cfg)
+	return rest.RESTClientFor(createRestConfig(gvk, isUnstructured, baseConfig, codecs))
+}
+
+// serializerWithDecodedGVK is a CodecFactory that overrides the DecoderToVersion of a WithoutConversionCodecFactory
+// in order to avoid clearing the GVK from the decoded object.
+//
+// See https://github.com/kubernetes/kubernetes/issues/80609.
+type serializerWithDecodedGVK struct {
+	serializer.WithoutConversionCodecFactory
+}
+
+// DecoderToVersion returns an decoder that does not do conversion.
+func (f serializerWithDecodedGVK) DecoderToVersion(serializer runtime.Decoder, _ runtime.GroupVersioner) runtime.Decoder {
+	return serializer
 }
 
 //createRestConfig copies the base config and updates needed fields for a new rest config
-func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config) *rest.Config {
+func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config, codecs serializer.CodecFactory) *rest.Config {
 	gv := gvk.GroupVersion()
 
 	cfg := rest.CopyConfig(baseConfig)
@@ -147,5 +156,16 @@ func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConf
 		}
 		protobufSchemeLock.RUnlock()
 	}
+
+	if cfg.NegotiatedSerializer == nil {
+		if isUnstructured {
+			// If the object is unstructured, we need to preserve the GVK information.
+			// Use our own custom serializer.
+			cfg.NegotiatedSerializer = serializerWithDecodedGVK{serializer.WithoutConversionCodecFactory{CodecFactory: codecs}}
+		} else {
+			cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: codecs}
+		}
+	}
+
 	return cfg
 }

--- a/pkg/client/client_cache.go
+++ b/pkg/client/client_cache.go
@@ -133,7 +133,6 @@ type resourceMeta struct {
 // isNamespaced returns true if the type is namespaced
 func (r *resourceMeta) isNamespaced() bool {
 	return r.mapping.Scope.Name() != meta.RESTScopeNameRoot
-
 }
 
 // resource returns the resource name of the type


### PR DESCRIPTION
Currently we have a bug that GVK information is not passed into mapping
functions when using the OnlyMetadata option in the builder. This patch
adds a wrapper that preserves the GVK information when events come in.

This issue is most likely caused by https://github.com/kubernetes/kubernetes/issues/80609
which we have been bumping into every once in a while here and there.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/hold

for further review
