### PR TITLE
🐛 Actually inject the scheme in StandaloneWebhook

### DIFF
--- a/pkg/webhook/admission/admissiontest/doc.go
+++ b/pkg/webhook/admission/admissiontest/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package admissiontest contains fake webhooks for validating admission webhooks
+package admissiontest

--- a/pkg/webhook/admission/admissiontest/util.go
+++ b/pkg/webhook/admission/admissiontest/util.go
@@ -1,0 +1,50 @@
+package admissiontest
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// FakeValidator provides fake validating webhook functionality for testing
+// It implements the admission.Validator interface and
+// rejects all requests with the same configured error
+// or passes if ErrorToReturn is nil.
+type FakeValidator struct {
+	// ErrorToReturn is the error for which the FakeValidator rejects all requests
+	ErrorToReturn error `json:"ErrorToReturn,omitempty"`
+	// GVKToReturn is the GroupVersionKind that the webhook operates on
+	GVKToReturn schema.GroupVersionKind
+}
+
+// ValidateCreate implements admission.Validator
+func (v *FakeValidator) ValidateCreate() error {
+	return v.ErrorToReturn
+}
+
+// ValidateUpdate implements admission.Validator
+func (v *FakeValidator) ValidateUpdate(old runtime.Object) error {
+	return v.ErrorToReturn
+}
+
+// ValidateDelete implements admission.Validator
+func (v *FakeValidator) ValidateDelete() error {
+	return v.ErrorToReturn
+}
+
+// GetObjectKind implements admission.Validator
+func (v *FakeValidator) GetObjectKind() schema.ObjectKind { return v }
+
+// DeepCopyObject implements admission.Validator
+func (v *FakeValidator) DeepCopyObject() runtime.Object {
+	return &FakeValidator{ErrorToReturn: v.ErrorToReturn, GVKToReturn: v.GVKToReturn}
+}
+
+// GroupVersionKind implements admission.Validator
+func (v *FakeValidator) GroupVersionKind() schema.GroupVersionKind {
+	return v.GVKToReturn
+}
+
+// SetGroupVersionKind implements admission.Validator
+func (v *FakeValidator) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	v.GVKToReturn = gvk
+}

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -235,9 +235,7 @@ func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, err
 		opts.Scheme = scheme.Scheme
 	}
 
-	var err error
-	hook.decoder, err = NewDecoder(opts.Scheme)
-	if err != nil {
+	if err := hook.InjectScheme(opts.Scheme); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes a bug from https://github.com/kubernetes-sigs/controller-runtime/pull/1429 where `StandaloneWebhook` never injects  the scheme and refactors the FakeValidator so it can be used to test `StandaloneWebhook`
