### PR TITLE
 ⚠️ fix the leader election precedence over config file

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -21,6 +21,7 @@ package apiutil
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -168,4 +169,26 @@ func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConf
 	}
 
 	return cfg
+}
+
+// BoolPointerFlagFunc returns a function to be associated with the custom bool flag func
+//
+// Example:
+//
+// var fooPtr *bool
+// flag.Func("foo", "foo usage", apiutil.BoolPointerFlagFunc(fooPtr))
+func BoolPointerFlagFunc(ptr *bool) func(flagVal string) error {
+	return func(flagVal string) error {
+		// flagVal is empty, consider flag as not passed
+		if flagVal == "" {
+			return nil
+		}
+
+		boolVal, err := strconv.ParseBool(flagVal)
+		if err != nil {
+			return err
+		}
+		ptr = &boolVal
+		return nil
+	}
 }

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -370,9 +370,8 @@ var _ = Describe("manger.Manager", func() {
 
 		Context("with leader election enabled", func() {
 			It("should only cancel the leader election after all runnables are done", func() {
-				leaderElectOpt := true
 				m, err := New(cfg, Options{
-					LeaderElection:          &leaderElectOpt,
+					LeaderElection:          pointer.BoolPtr(true),
 					LeaderElectionNamespace: "default",
 					LeaderElectionID:        "test-leader-election-id-2",
 					HealthProbeBindAddress:  "0",
@@ -416,9 +415,8 @@ var _ = Describe("manger.Manager", func() {
 
 			})
 			It("should disable gracefulShutdown when stopping to lead", func() {
-				leaderElectOpt := true
 				m, err := New(cfg, Options{
-					LeaderElection:          &leaderElectOpt,
+					LeaderElection:          pointer.BoolPtr(true),
 					LeaderElectionNamespace: "default",
 					LeaderElectionID:        "test-leader-election-id-3",
 					HealthProbeBindAddress:  "0",
@@ -446,9 +444,8 @@ var _ = Describe("manger.Manager", func() {
 			})
 			It("should default ID to controller-runtime if ID is not set", func() {
 				var rl resourcelock.Interface
-				leaderElectOpt := true
 				m1, err := New(cfg, Options{
-					LeaderElection:          &leaderElectOpt,
+					LeaderElection:          pointer.BoolPtr(true),
 					LeaderElectionNamespace: "default",
 					LeaderElectionID:        "test-leader-election-id",
 					newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
@@ -466,10 +463,9 @@ var _ = Describe("manger.Manager", func() {
 				m1cm, ok := m1.(*controllerManager)
 				Expect(ok).To(BeTrue())
 				m1cm.onStoppedLeading = func() {}
-				leaderElectOpt = true
 
 				m2, err := New(cfg, Options{
-					LeaderElection:          &leaderElectOpt,
+					LeaderElection:          pointer.BoolPtr(true),
 					LeaderElectionNamespace: "default",
 					LeaderElectionID:        "test-leader-election-id",
 					newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
@@ -536,8 +532,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err).To(MatchError(ContainSubstring("expected error")))
 			})
 			It("should return an error if namespace not set and not running in cluster", func() {
-				leaderElectOpt := true
-				m, err := New(cfg, Options{LeaderElection: &leaderElectOpt, LeaderElectionID: "controller-runtime"})
+				m, err := New(cfg, Options{LeaderElection: pointer.BoolPtr(true), LeaderElectionID: "controller-runtime"})
 				Expect(m).To(BeNil())
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace"))
@@ -547,8 +542,7 @@ var _ = Describe("manger.Manager", func() {
 			// ConfigMap lock to a controller-runtime version that has this new default. Many users of controller-runtime skip
 			// versions, so we should be extremely conservative here.
 			It("should default to ConfigMapsLeasesResourceLock", func() {
-				leaderElectOpt := true
-				m, err := New(cfg, Options{LeaderElection: &leaderElectOpt, LeaderElectionID: "controller-runtime", LeaderElectionNamespace: "my-ns"})
+				m, err := New(cfg, Options{LeaderElection: pointer.BoolPtr(true), LeaderElectionID: "controller-runtime", LeaderElectionNamespace: "my-ns"})
 				Expect(m).ToNot(BeNil())
 				Expect(err).ToNot(HaveOccurred())
 				cm, ok := m.(*controllerManager)
@@ -562,9 +556,8 @@ var _ = Describe("manger.Manager", func() {
 
 			})
 			It("should use the specified ResourceLock", func() {
-				leaderElectOpt := true
 				m, err := New(cfg, Options{
-					LeaderElection:             &leaderElectOpt,
+					LeaderElection:             pointer.BoolPtr(true),
 					LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 					LeaderElectionID:           "controller-runtime",
 					LeaderElectionNamespace:    "my-ns",
@@ -1130,10 +1123,9 @@ var _ = Describe("manger.Manager", func() {
 		})
 
 		Context("with leaderelection enabled", func() {
-			leaderElectOpt := true
 			startSuite(
 				Options{
-					LeaderElection:          &leaderElectOpt,
+					LeaderElection:          pointer.BoolPtr(true),
 					LeaderElectionID:        "controller-runtime",
 					LeaderElectionNamespace: "default",
 					newResourceLock:         fakeleaderelection.NewResourceLock,

--- a/pkg/webhook/conversion/testdata/main.go
+++ b/pkg/webhook/conversion/testdata/main.go
@@ -24,6 +24,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	jobsv1 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v1"
 	jobsv2 "sigs.k8s.io/controller-runtime/pkg/webhook/conversion/testdata/api/v2"
@@ -46,10 +47,12 @@ func init() {
 
 func main() {
 	var metricsAddr string
-	var enableLeaderElection bool
+	var enableLeaderElection *bool
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.Func("enable-leader-election",
+		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager. Possible values [true/false]",
+		apiutil.BoolPointerFlagFunc(enableLeaderElection),
+	)
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
@@ -67,7 +70,7 @@ func main() {
 	// +kubebuilder:scaffold:builder
 
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err = mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes: #1463 

According to the documentation, flags to the cli should be considered over the properties in config files. But in the case of `--enable-leader-election` flag, there was a corner case which was not compliant to the statement.

case: If the user explicitly gives `false` to the leader election flag, but config file has true, the manager option is actually having the config value. Because of the fact that since it is a bool variable, its difficult to differentiate if the flag is given with value false or the zero value of the variable is being considered

Update LeaderElection Manager Option type to *bool

- Changed the datatype of leader election for manager option from bool to *bool

- Changed the flag parsing logic in Webhook main according to the new datatype
If the flag is not passed, it will be nil, otherwise false or true

- Added test to check the condition if true in config file and false in flag
