### PR TITLE
🐛Warn if logger is not explicitly set in two situations

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -150,7 +150,7 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 func GetConfigOrDie() *rest.Config {
 	config, err := GetConfig()
 	if err != nil {
-		log.Error(err, "unable to get kubeconfig")
+		fmt.Fprintln(os.Stderr, "error: unable to get kubeconfig")
 		os.Exit(1)
 	}
 	return config


### PR DESCRIPTION
What type of PR is this?
/kind bugfix

What this PR does / why we need it:
print error reason when call `config.GetConfigOrDie()` failed instead of log nothing

Which issue(s) this PR fixes:
Part of #1475 
