### PR TITLE
[WIP]🌱 Add OWNERS for pkg/client/fake to support maintaining the fake client

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -34,6 +34,15 @@ aliases:
   - apelisse
   - hoegaarden
 
+  # folks who can approve things related to the fake client
+  fake-client-approvers:
+  - detiber
+
+  # folks wo can review and LGTM any PRs related to the fake client
+  fake-client-reviewers:
+  - detiber
+  - sbueringer
+
   # folks who may have context on ancient history,
   # but are no longer directly involved
   # controller-runtime-emeritus-maintainers:

--- a/pkg/client/fake/OWNERS
+++ b/pkg/client/fake/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - fake-client-approvers
+reviewers:
+  - fake-client-reviewers


### PR DESCRIPTION
Following up on the issue related to the deprecation/undeprecation of the fake client: https://github.com/kubernetes-sigs/controller-runtime/issues/768

Adds an OWNERS file for pkg/client/fake and related aliases in OWNERS_ALIASES

