### PR TITLE
:sparkles: Expose function to find controller namespace in controllerutil

### DIFF
--- a/pkg/controller/controllerutil/controllerutil_internal_test.go
+++ b/pkg/controller/controllerutil/controllerutil_internal_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllerutil
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Controllerutil internal", func() {
+
+	Describe("ReadInClusterNamespaceCached", func() {
+		It("shouldn't provide a namespace if running outside of the cluster", func() {
+			_, err := ReadInClusterNamespaceCached()
+			// For the env test case, the controller is not run in a cluster
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, ErrNotRunningInCluster)).To(Equal(true))
+		})
+		It("should return a namespace if file exists", func() {
+			file, err := ioutil.TempFile("", "namespace")
+			Expect(err).NotTo(HaveOccurred())
+			_, err = file.WriteString("kube-system")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file.Close()).To(Succeed())
+			inClusterNamespacePath = file.Name()
+			namespace, err := ReadInClusterNamespaceCached()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(namespace).To(Equal("kube-system"))
+			Expect(os.Remove(file.Name())).To(Succeed())
+			inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+		})
+
+	})
+})

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -36,6 +36,7 @@ import (
 )
 
 var _ = Describe("Controllerutil", func() {
+
 	Describe("SetOwnerReference", func() {
 		It("should set ownerRef on an empty list", func() {
 			rs := &appsv1.ReplicaSet{}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -440,7 +440,7 @@ var _ = Describe("manger.Manager", func() {
 				m, err := New(cfg, Options{LeaderElection: true, LeaderElectionID: "controller-runtime"})
 				Expect(m).To(BeNil())
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unable to find leader election namespace: not running in-cluster, please specify LeaderElectionNamespace"))
+				Expect(err.Error()).To(ContainSubstring("unable to find leader election namespace, please specify LeaderElectionNamespace"))
 			})
 
 			// We must keep this default until we are sure all controller-runtime users have upgraded from the original default


### PR DESCRIPTION
A number of downstream CRs have been re-implementing the ability to
find the namespace the controller is running under, so we make this
a public function, and ensure memoization of the resolution.

Signed-off-by: Naadir Jeewa <jeewan@vmware.com>

Follow up from https://github.com/kubernetes-sigs/cluster-api/pull/4514