### PR TITLE
:bug: add manager.Options.WebhookServer so webhook server can be set

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -365,7 +365,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
-	cm := &controllerManager{
+	return &controllerManager{
 		cluster:                 cluster,
 		recorderProvider:        recorderProvider,
 		resourceLock:            resourceLock,
@@ -387,17 +387,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		gracefulShutdownTimeout: *options.GracefulShutdownTimeout,
 		internalProceduresStop:  make(chan struct{}),
 		leaderElectionStopped:   make(chan struct{}),
-	}
-
-	// A webhook server set by New's caller should be added now
-	// so GetWebhookServer can construct a new one if unset and add it only once.
-	if cm.webhookServer != nil {
-		if err := cm.Add(cm.webhookServer); err != nil {
-			return nil, err
-		}
-	}
-
-	return cm, nil
+	}, nil
 }
 
 // AndFrom will use a supplied type and convert to Options

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -209,17 +209,24 @@ type Options struct {
 	LivenessEndpointName string
 
 	// Port is the port that the webhook server serves at.
-	// It is used to set webhook.Server.Port.
+	// It is used to set webhook.Server.Port if WebhookServer is not set.
 	Port int
 	// Host is the hostname that the webhook server binds to.
-	// It is used to set webhook.Server.Host.
+	// It is used to set webhook.Server.Host if WebhookServer is not set.
 	Host string
 
 	// CertDir is the directory that contains the server key and certificate.
-	// if not set, webhook server would look up the server key and certificate in
+	// If not set, webhook server would look up the server key and certificate in
 	// {TempDir}/k8s-webhook-server/serving-certs. The server key and certificate
 	// must be named tls.key and tls.crt, respectively.
+	// It is used to set webhook.Server.CertDir if WebhookServer is not set.
 	CertDir string
+
+	// WebhookServer is an externally configured webhook.Server. By default,
+	// a Manager will create a default server using Port, Host, and CertDir;
+	// if this is set, the Manager will use this server instead.
+	WebhookServer *webhook.Server
+
 	// Functions to all for a user to customize the values that will be injected.
 
 	// NewCache is the function that will create the cache to be used
@@ -358,7 +365,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, err
 	}
 
-	return &controllerManager{
+	cm := &controllerManager{
 		cluster:                 cluster,
 		recorderProvider:        recorderProvider,
 		resourceLock:            resourceLock,
@@ -370,6 +377,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		port:                    options.Port,
 		host:                    options.Host,
 		certDir:                 options.CertDir,
+		webhookServer:           options.WebhookServer,
 		leaseDuration:           *options.LeaseDuration,
 		renewDeadline:           *options.RenewDeadline,
 		retryPeriod:             *options.RetryPeriod,
@@ -379,7 +387,17 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		gracefulShutdownTimeout: *options.GracefulShutdownTimeout,
 		internalProceduresStop:  make(chan struct{}),
 		leaderElectionStopped:   make(chan struct{}),
-	}, nil
+	}
+
+	// A webhook server set by New's caller should be added now
+	// so GetWebhookServer can construct a new one if unset and add it only once.
+	if cm.webhookServer != nil {
+		if err := cm.Add(cm.webhookServer); err != nil {
+			return nil, err
+		}
+	}
+
+	return cm, nil
 }
 
 // AndFrom will use a supplied type and convert to Options

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -280,12 +280,6 @@ var _ = Describe("manger.Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(m).NotTo(BeNil())
 
-			By("checking the webhook server was added to non-leader-election runnables")
-			Expect(m).To(BeAssignableToTypeOf(&controllerManager{}))
-			nonLERunnables := m.(*controllerManager).nonLeaderElectionRunnables
-			Expect(nonLERunnables).To(HaveLen(1))
-			Expect(nonLERunnables[0]).To(BeAssignableToTypeOf(&webhook.Server{}))
-
 			By("checking the server contains the Port set on the webhook server and not passed to Options")
 			svr := m.GetWebhookServer()
 			Expect(svr).NotTo(BeNil())

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -53,6 +53,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var _ = Describe("manger.Manager", func() {
@@ -269,6 +270,26 @@ var _ = Describe("manger.Manager", func() {
 			Expect(svr).NotTo(BeNil())
 			Expect(svr.Port).To(Equal(9440))
 			Expect(svr.Host).To(Equal("foo.com"))
+
+			close(done)
+		})
+
+		It("should not initialize a webhook server if Options.WebhookServer is set", func(done Done) {
+			By("creating a manager with options")
+			m, err := New(cfg, Options{Port: 9441, WebhookServer: &webhook.Server{Port: 9440}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m).NotTo(BeNil())
+
+			By("checking the webhook server was added to non-leader-election runnables")
+			Expect(m).To(BeAssignableToTypeOf(&controllerManager{}))
+			nonLERunnables := m.(*controllerManager).nonLeaderElectionRunnables
+			Expect(nonLERunnables).To(HaveLen(1))
+			Expect(nonLERunnables[0]).To(BeAssignableToTypeOf(&webhook.Server{}))
+
+			By("checking the server contains the Port set on the webhook server and not passed to Options")
+			svr := m.GetWebhookServer()
+			Expect(svr).NotTo(BeNil())
+			Expect(svr.Port).To(Equal(9440))
 
 			close(done)
 		})


### PR DESCRIPTION
This PR adds `pkg/manager.Options.WebhookServer` to allow external configuration of a webhook server. Currently there is no way to add a custom webhook server, since `Manager.Add()` will not set `controllerManager.webhookServer`. I am treating this as a bug since the manager's internals appear to allow external webhook configuration, but no code API was ever exposed to allow this.

/kind bug

Signed-off-by: Eric Stroczynski <ericstroczynski@gmail.com>
