### PR TITLE
🐛 fix nil Decoder in multiValidating and multiMutating handlers by implementing DecoderInjector

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -225,6 +225,9 @@ func (cm *controllerManager) Add(r Runnable) error {
 
 // Deprecated: use the equivalent Options field to set a field. This method will be removed in v0.10.
 func (cm *controllerManager) SetFields(i interface{}) error {
+	if err := cm.cluster.SetFields(i); err != nil {
+		return err
+	}
 	if _, err := inject.InjectorInto(cm.SetFields, i); err != nil {
 		return err
 	}
@@ -232,9 +235,6 @@ func (cm *controllerManager) SetFields(i interface{}) error {
 		return err
 	}
 	if _, err := inject.LoggerInto(cm.logger, i); err != nil {
-		return err
-	}
-	if err := cm.cluster.SetFields(i); err != nil {
 		return err
 	}
 

--- a/pkg/webhook/admission/multi.go
+++ b/pkg/webhook/admission/multi.go
@@ -77,6 +77,16 @@ func (hs multiMutating) InjectFunc(f inject.Func) error {
 	return nil
 }
 
+// InjectDecoder injects the decoder into the handlers.
+func (hs multiMutating) InjectDecoder(d *Decoder) error {
+	for _, handler := range hs {
+		if _, err := InjectDecoderInto(d, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // MultiMutatingHandler combines multiple mutating webhook handlers into a single
 // mutating webhook handler.  Handlers are called in sequential order, and the first
 // `allowed: false`	response may short-circuit the rest.  Users must take care to
@@ -123,5 +133,15 @@ func (hs multiValidating) InjectFunc(f inject.Func) error {
 		}
 	}
 
+	return nil
+}
+
+// InjectDecoder injects the decoder into the handlers.
+func (hs multiValidating) InjectDecoder(d *Decoder) error {
+	for _, handler := range hs {
+		if _, err := InjectDecoderInto(d, handler); err != nil {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
**TL;DR**
Webhooks with `multiValidating` and `multiMutating` handlers currently fail to inject decoders into their sub-handlers, resulting in nil pointer panics. This PR is fixing it.

**Full description**
Before the change in https://github.com/kubernetes-sigs/controller-runtime/pull/1307, webhook method `webhook.InjectScheme` was called before `webhook.InjectFunc`, meaning that decoder intstantiation was happening before injecting it  by `webhook.InjectFunc`.
After that PR (specifically, the changes to `controllerManager.SetFields` in `pkg/manager/internal.go`) , the order has changed, and now `webhook.InjectFunc` gets called before `webhook.InjectScheme`, meaning that we  `webhook.InjectFunc` injects a `nil` decoder.
It appears that such re-ordering was anticipated, because in the `webhook.InjectScheme` it [tries to inject decoder again, just in case](https://github.com/kubernetes-sigs/controller-runtime/blob/2c238def1a48d4ff480f4745be2b258958acade0/pkg/webhook/admission/webhook.go#L165), with this comment:
```
// inject the decoder here too, just in case the order of calling this is not
// scheme first, then inject func
if w.Handler != nil {
	if _, err := InjectDecoderInto(w.GetDecoder(), w.Handler); err != nil {
		return err
	}
}
```
This second attempt at decoder injection works just fine for regular webhooks, but fails if the weebhook's handler is a `multiValidating` or `multiMutating` handler, because those handlers do not implement `DecoderInjector` interface.
Note that for regular handlers, it is the responsibility of the user to implement `DecoderInjector` interface, but because both `multiValidating` and `multiMutating` are unexported types, a user cannot do so for them.

The fix proposed in this PR is not the only possible solution. Another one could be to switch back the order of `inject.InjectorInto` and `cm.cluster.SetFields` in https://github.com/kubernetes-sigs/controller-runtime/blob/2c238def1a48d4ff480f4745be2b258958acade0/pkg/manager/internal.go#L227. And yet another one is proposed in https://github.com/kubernetes-sigs/controller-runtime/pull/1437

Link to the issue that was filed for this bug: https://github.com/kubernetes-sigs/controller-runtime/issues/1487

Tagging @porridge since you were looking at that issue and @alvaroaleman as the author of the PR that re-ordered `webhook.InjectScheme` and `webhook.InjectFunc`.

Happy to make any changes or implement a different fix for this bug.