### PR TITLE
:bug: Run unittests in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@
 SHELL:=/usr/bin/env bash
 .DEFAULT_GOAL:=help
 
-export WHAT ?= ./...
-
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)

--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -20,7 +20,7 @@ source $(dirname ${BASH_SOURCE})/common.sh
 
 header_text "running go test"
 
-go test -race ${MOD_OPT} ${WHAT}
+go test -race ${MOD_OPT} ./...
 
 if [[ -n ${ARTIFACTS:-} ]]; then
   if grep -Rin '<failure type="Failure">' ${ARTIFACTS}/*; then exit 1; fi


### PR DESCRIPTION
This accidentally got disabled in
cd065bf2f63c3057db307990c21316483fa60ce8 under the assumption that the
CI entrypoint is the Makefile in an attempt to make this configurable.
Since the script is called `test_all.sh`, it is reasonable to assume it
always test verything. If ppl want something else, they can just add
another script/maketarget.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @estroz @vincepri 
