### PR TITLE
✨ Cleanup Webhook server setup

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -23,11 +23,13 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -65,8 +67,8 @@ var _ = Describe("Test", func() {
 				Name: crd.GetName(),
 			}
 			var placeholder v1beta1.CustomResourceDefinition
-			err := c.Get(context.TODO(), crdObjectKey, &placeholder)
-			if err != nil && apierrors.IsNotFound(err) {
+			if err = c.Get(context.TODO(), crdObjectKey, &placeholder); err != nil &&
+				apierrors.IsNotFound(err) {
 				// CRD doesn't need to be deleted.
 				continue
 			}
@@ -842,6 +844,19 @@ var _ = Describe("Test", func() {
 			_, err := env.Start()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env.Stop()).To(Succeed())
+			close(done)
+		}, 30)
+	})
+
+	Describe("Stop", func() {
+		It("should cleanup webhook /tmp folder with no error when using existing cluster", func(done Done) {
+			env := &Environment{}
+			_, err := env.Start()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(env.Stop()).To(Succeed())
+
+			// check if the /tmp/envtest-serving-certs-* dir doesnt exists any more
+			Expect(env.WebhookInstallOptions.LocalServingCertDir).ShouldNot(BeADirectory())
 			close(done)
 		}, 30)
 	})

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -158,13 +158,15 @@ func (te *Environment) Stop() error {
 			return err
 		}
 	}
+
+	if err := te.WebhookInstallOptions.Cleanup(); err != nil {
+		return err
+	}
+
 	if te.useExistingCluster() {
 		return nil
 	}
-	err := te.WebhookInstallOptions.Cleanup()
-	if err != nil {
-		return err
-	}
+
 	return te.ControlPlane.Stop()
 }
 

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -167,6 +167,7 @@ func (o *WebhookInstallOptions) PrepWithoutInstalling() error {
 	if err := o.setupCA(); err != nil {
 		return err
 	}
+
 	if err := parseWebhook(o); err != nil {
 		return err
 	}

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -100,6 +100,6 @@ var _ = Describe("Test", func() {
 type rejectingValidator struct {
 }
 
-func (v *rejectingValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
+func (v *rejectingValidator) Handle(_ context.Context, _ admission.Request) admission.Response {
 	return admission.Denied(fmt.Sprint("Always denied"))
 }

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Webhook Server", func() {
 
 	BeforeEach(func() {
 		ctx, ctxCancel = context.WithCancel(context.Background())
-		// closed in indivual tests differently
+		// closed in individual tests differently
 
 		servingOpts = envtest.WebhookInstallOptions{}
 		Expect(servingOpts.PrepWithoutInstalling()).To(Succeed())


### PR DESCRIPTION
- Called the webhook server cleanup function

- Only ignore controlplane cleanup when using existing cluster

- Added test to check the cleanup for Webhook after `Stop()`

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes #1496 
