### PR TITLE
🐛 typeMeta: typeMeta is empty when using client.Get()

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1442,6 +1442,13 @@ var _ = Describe("Client", func() {
 				Expect(actual).NotTo(BeNil())
 
 				By("validating the fetched deployment equals the created one")
+				gvk := schema.GroupVersionKind{
+					Group:   "apps",
+					Version: "v1",
+					Kind:    "Deployment",
+				}
+				dep.SetGroupVersionKind(gvk)
+
 				Expect(dep).To(Equal(&actual))
 
 				close(done)
@@ -1462,7 +1469,11 @@ var _ = Describe("Client", func() {
 				err = cl.Get(context.TODO(), key, &actual)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(actual).NotTo(BeNil())
-
+				node.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "",
+					Version: "v1",
+					Kind:    "Node",
+				})
 				Expect(node).To(Equal(&actual))
 
 				close(done)

--- a/pkg/client/dryrun_test.go
+++ b/pkg/client/dryrun_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -80,6 +81,11 @@ var _ = Describe("DryRunClient", func() {
 		result := &appsv1.Deployment{}
 
 		Expect(getClient().Get(ctx, name, result)).NotTo(HaveOccurred())
+		Expect(result.TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		}))
+		result.SetGroupVersionKind(schema.GroupVersionKind{})
 		Expect(result).To(BeEquivalentTo(dep))
 	})
 
@@ -88,8 +94,16 @@ var _ = Describe("DryRunClient", func() {
 		opts := client.MatchingLabels(dep.Labels)
 
 		Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
-
+		Expect(result.TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "DeploymentList",
+		}))
 		Expect(len(result.Items)).To(BeEquivalentTo(1))
+		Expect(result.Items[0].TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		}))
+		result.Items[0].SetGroupVersionKind(schema.GroupVersionKind{})
 		Expect(result.Items[0]).To(BeEquivalentTo(*dep))
 	})
 

--- a/pkg/client/namespaced_client_test.go
+++ b/pkg/client/namespaced_client_test.go
@@ -93,6 +93,11 @@ var _ = Describe("NamespacedClient", func() {
 			result := &appsv1.Deployment{}
 
 			Expect(getClient().Get(ctx, name, result)).NotTo(HaveOccurred())
+			Expect(result.TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			}))
+			result.SetGroupVersionKind(schema.GroupVersionKind{})
 			Expect(result).To(BeEquivalentTo(dep))
 		})
 
@@ -121,7 +126,16 @@ var _ = Describe("NamespacedClient", func() {
 			opts := client.MatchingLabels(dep.Labels)
 
 			Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
+			Expect(result.TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "DeploymentList",
+			}))
 			Expect(len(result.Items)).To(BeEquivalentTo(1))
+			Expect(result.Items[0].TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			}))
+			result.Items[0].SetGroupVersionKind(schema.GroupVersionKind{})
 			Expect(result.Items[0]).To(BeEquivalentTo(*dep))
 		})
 
@@ -130,7 +144,16 @@ var _ = Describe("NamespacedClient", func() {
 			opts := client.InNamespace("non-default")
 
 			Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
+			Expect(result.TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "DeploymentList",
+			}))
 			Expect(len(result.Items)).To(BeEquivalentTo(1))
+			Expect(result.Items[0].TypeMeta).To(BeEquivalentTo(metav1.TypeMeta{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+			}))
+			result.Items[0].SetGroupVersionKind(schema.GroupVersionKind{})
 			Expect(result.Items[0]).To(BeEquivalentTo(*dep))
 		})
 	})


### PR DESCRIPTION
Signed-off-by: cndoit18 [cndoit18@outlook.com](mailto:cndoit18@outlook.com)
 
**What type of PR is this?**
 
**What this PR does / why we need it**:

This is a temporary repair that solves the problem of typeMate is empty.

**Which issue(s) this PR fixes**:

Fixes #1517
 
**Special notes for your reviewer**:
 
**Does this PR introduce a user-facing change?**:
 
```release-note
none
```
