### PR TITLE
🐛 Envtest conversion mods should set strategy and review versions

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -273,6 +273,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDInstallOptions.CRDs = mergeCRDs(te.CRDInstallOptions.CRDs, te.CRDs)
 	te.CRDInstallOptions.Paths = mergePaths(te.CRDInstallOptions.Paths, te.CRDDirectoryPaths)
 	te.CRDInstallOptions.ErrorIfPathMissing = te.ErrorIfCRDPathMissing
+	te.CRDInstallOptions.WebhookOptions = te.WebhookInstallOptions
 	crds, err := InstallCRDs(te.Config, te.CRDInstallOptions)
 	if err != nil {
 		return te.Config, err


### PR DESCRIPTION
Conversion webhooks require the strategy to be set and all the supported
review versions.

This change also fixes an issue where the CABundle wasn't previously
base64 encoded.

Related: Need to spend some time to make sure the whole conversion webhooks are properly tested and run correctly within envtest. I'll wait for the 1.20 refactor that @DirectXMan12 is working on.

