### PR TITLE
✨ Structured args in Testing

### DIFF
--- a/pkg/internal/testing/process/arguments.go
+++ b/pkg/internal/testing/process/arguments.go
@@ -6,6 +6,8 @@ import (
 )
 
 // RenderTemplates returns an []string to render the templates
+//
+// Deprecated: this should be removed when we remove APIServer.Args.
 func RenderTemplates(argTemplates []string, data interface{}) (args []string, err error) {
 	var t *template.Template
 
@@ -26,4 +28,217 @@ func RenderTemplates(argTemplates []string, data interface{}) (args []string, er
 	}
 
 	return
+}
+
+// EmptyArguments constructs an empty set of flags with no defaults.
+func EmptyArguments() *Arguments {
+	return &Arguments{
+		values: make(map[string]Arg),
+	}
+}
+
+// Arguments are structured, overridable arguments.
+// Each Arguments object contains some set of default arguments, which may
+// be appended to, or overridden.
+//
+// When ready, you can serialize them to pass to exec.Command and friends using
+// AsStrings.
+//
+// All flag-setting methods return the *same* instance of Arguments so that you
+// can chain calls.
+type Arguments struct {
+	// values contains the user-set values for the arguments.
+	// `values[key] = dontPass` means "don't pass this flag"
+	// `values[key] = passAsName` means "pass this flag without args like --key`
+	// `values[key] = []string{a, b, c}` means "--key=a --key=b --key=c`
+	// any values not explicitly set here will be copied from defaults on final rendering.
+	values map[string]Arg
+}
+
+// Arg is an argument that has one or more values,
+// and optionally falls back to default values.
+type Arg interface {
+	// Append adds new values to this argument, returning
+	// a new instance contain the new value.  The intermediate
+	// argument should generally be assumed to be consumed.
+	Append(vals ...string) Arg
+	// Get returns the full set of values, optionally including
+	// the passed in defaults.  If it returns nil, this will be
+	// skipped.  If it returns a non-nil empty slice, it'll be
+	// assumed that the argument should be passed as name-only.
+	Get(defaults []string) []string
+}
+
+type userArg []string
+
+func (a userArg) Append(vals ...string) Arg {
+	return userArg(append(a, vals...))
+}
+func (a userArg) Get(_ []string) []string {
+	return []string(a)
+}
+
+type defaultedArg []string
+
+func (a defaultedArg) Append(vals ...string) Arg {
+	return defaultedArg(append(a, vals...))
+}
+func (a defaultedArg) Get(defaults []string) []string {
+	res := append([]string(nil), defaults...)
+	return append(res, a...)
+}
+
+type dontPassArg struct{}
+
+func (a dontPassArg) Append(vals ...string) Arg {
+	return userArg(vals)
+}
+func (dontPassArg) Get(_ []string) []string {
+	return nil
+}
+
+type passAsNameArg struct{}
+
+func (a passAsNameArg) Append(_ ...string) Arg {
+	return passAsNameArg{}
+}
+func (passAsNameArg) Get(_ []string) []string {
+	return []string{}
+}
+
+var (
+	// DontPass indicates that the given argument will not actually be
+	// rendered.
+	DontPass Arg = dontPassArg{}
+	// PassAsName indicates that the given flag will be passed as `--key`
+	// without any value.
+	PassAsName Arg = passAsNameArg{}
+)
+
+// AsStrings serializes this set of arguments to a slice of strings appropriate
+// for passing to exec.Command and friends, making use of the given defaults
+// as indicated for each particular argument.
+//
+// - Any flag in defaults that's not in Arguments will be present in the output
+// - Any flag that's present in Arguments will be passed the corresponding
+//   defaults to do with as it will (ignore, append-to, suppress, etc).
+func (a *Arguments) AsStrings(defaults map[string][]string) []string {
+	// sort for deterministic ordering
+	keysInOrder := make([]string, 0, len(defaults)+len(a.values))
+	for key := range defaults {
+		if _, userSet := a.values[key]; userSet {
+			continue
+		}
+		keysInOrder = append(keysInOrder, key)
+	}
+	for key := range a.values {
+		keysInOrder = append(keysInOrder, key)
+	}
+	sort.Strings(keysInOrder)
+
+	var res []string
+	for _, key := range keysInOrder {
+		vals := a.Get(key).Get(defaults[key])
+		switch {
+		case vals == nil: // don't pass
+			continue
+		case len(vals) == 0: // pass as name
+			res = append(res, "--"+key)
+		default:
+			for _, val := range vals {
+				res = append(res, "--"+key+"="+val)
+			}
+		}
+	}
+
+	return res
+}
+
+// Get returns the value of the given flag.  If nil,
+// it will not be passed in AsString, otherwise:
+//
+// len == 0 --> `--key`, len > 0 --> `--key=val1 --key=val2 ...`
+func (a *Arguments) Get(key string) Arg {
+	if vals, ok := a.values[key]; ok {
+		return vals
+	}
+	return defaultedArg(nil)
+}
+
+// Enable configures the given key to be passed as a "name-only" flag,
+// like, `--key`.
+func (a *Arguments) Enable(key string) *Arguments {
+	a.values[key] = PassAsName
+	return a
+}
+
+// Disable prevents this flag from be passed.
+func (a *Arguments) Disable(key string) *Arguments {
+	a.values[key] = DontPass
+	return a
+}
+
+// Append adds additional values to this flag.  If this flag has
+// yet to be set, initial values will include defaults.  If you want
+// to intentionally ignore defaults/start from scratch, call AppendNoDefaults.
+//
+// Multiple values will look like `--key=value1 --key=value2 ...`.
+func (a *Arguments) Append(key string, values ...string) *Arguments {
+	vals, present := a.values[key]
+	if !present {
+		vals = defaultedArg{}
+	}
+	a.values[key] = vals.Append(values...)
+	return a
+}
+
+// AppendNoDefaults adds additional values to this flag.  However,
+// unlike Append, it will *not* copy values from defaults.
+func (a *Arguments) AppendNoDefaults(key string, values ...string) *Arguments {
+	vals, present := a.values[key]
+	if !present {
+		vals = userArg{}
+	}
+	a.values[key] = vals.Append(values...)
+	return a
+}
+
+// Set resets the given flag to the specified values, ignoring any existing
+// values or defaults.
+func (a *Arguments) Set(key string, values ...string) *Arguments {
+	a.values[key] = userArg(values)
+	return a
+}
+
+// SetRaw sets the given flag to the given Arg value directly.  Use this if
+// you need to do some complicated deferred logic or something.
+//
+// Otherwise behaves like Set.
+func (a *Arguments) SetRaw(key string, val Arg) *Arguments {
+	a.values[key] = val
+	return a
+}
+
+// FuncArg is a basic implementation of Arg that can be used for custom argument logic,
+// like pulling values out of APIServer, or dynamically calculating values just before
+// launch.
+//
+// The given function will be mapped directly to Arg#Get, and will generally be
+// used in conjunction with SetRaw.  For example, to set `--some-flag` to the
+// API server's CertDir, you could do:
+//
+//     server.Configure().SetRaw("--some-flag", FuncArg(func(defaults []string) []string {
+//         return []string{server.CertDir}
+//     }))
+//
+// FuncArg ignores Appends; if you need to support appending values too, consider implementing
+// Arg directly.
+type FuncArg func([]string) []string
+
+// Append is a no-op for FuncArg, and just returns itself.
+func (a FuncArg) Append(vals ...string) Arg { return a }
+
+// Get delegates functionality to the FuncArg function itself.
+func (a FuncArg) Get(defaults []string) []string {
+	return a(defaults)
 }

--- a/pkg/internal/testing/process/arguments_test.go
+++ b/pkg/internal/testing/process/arguments_test.go
@@ -1,0 +1,210 @@
+package process_test
+
+import (
+	"net/url"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "sigs.k8s.io/controller-runtime/pkg/internal/testing/process"
+)
+
+var _ = Describe("Arguments Templates", func() {
+	It("templates URLs", func() {
+		templates := []string{
+			"plain URL: {{ .SomeURL }}",
+			"method on URL: {{ .SomeURL.Hostname }}",
+			"empty URL: {{ .EmptyURL }}",
+			"handled empty URL: {{- if .EmptyURL }}{{ .EmptyURL }}{{ end }}",
+		}
+		data := struct {
+			SomeURL  *url.URL
+			EmptyURL *url.URL
+		}{
+			&url.URL{Scheme: "https", Host: "the.host.name:3456"},
+			nil,
+		}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"plain URL: https://the.host.name:3456",
+			"method on URL: the.host.name",
+			"empty URL: &lt;nil&gt;",
+			"handled empty URL:",
+		}))
+	})
+
+	It("templates strings", func() {
+		templates := []string{
+			"a string: {{ .SomeString }}",
+			"empty string: {{- .EmptyString }}",
+		}
+		data := struct {
+			SomeString  string
+			EmptyString string
+		}{
+			"this is some random string",
+			"",
+		}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(BeEquivalentTo([]string{
+			"a string: this is some random string",
+			"empty string:",
+		}))
+	})
+
+	It("has no access to unexported fields", func() {
+		templates := []string{
+			"this is just a string",
+			"this blows up {{ .test }}",
+		}
+		data := struct{ test string }{"ooops private"}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("is an unexported field of struct"),
+		))
+	})
+
+	It("errors when field cannot be found", func() {
+		templates := []string{"this does {{ .NotExist }}"}
+		data := struct{ Unused string }{"unused"}
+
+		out, err := RenderTemplates(templates, data)
+		Expect(out).To(BeEmpty())
+		Expect(err).To(MatchError(
+			ContainSubstring("can't evaluate field"),
+		))
+	})
+})
+
+type plainDefaults map[string][]string
+
+func (d plainDefaults) DefaultArgs() map[string][]string {
+	return d
+}
+
+var _ = Describe("Arguments", func() {
+	Context("when appending", func() {
+		It("should copy from defaults when appending for the first time", func() {
+			args := EmptyArguments().
+				Append("some-key", "val3")
+			Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"val1", "val2", "val3"}))
+		})
+
+		It("should not copy from defaults if the flag has been disabled previously", func() {
+			args := EmptyArguments().
+				Disable("some-key").
+				Append("some-key", "val3")
+			Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"val3"}))
+		})
+
+		It("should only copy defaults the first time", func() {
+			args := EmptyArguments().
+				Append("some-key", "val3", "val4").
+				Append("some-key", "val5")
+			Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"val1", "val2", "val3", "val4", "val5"}))
+		})
+
+		It("should not copy from defaults if the flag has been previously overridden", func() {
+			args := EmptyArguments().
+				Set("some-key", "vala").
+				Append("some-key", "valb", "valc")
+			Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"vala", "valb", "valc"}))
+		})
+
+		Context("when explicitly overriding defaults", func() {
+			It("should not copy from defaults, but should append to previous calls", func() {
+				args := EmptyArguments().
+					AppendNoDefaults("some-key", "vala").
+					AppendNoDefaults("some-key", "valb", "valc")
+				Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"vala", "valb", "valc"}))
+			})
+
+			It("should not copy from defaults, but should respect previous appends' copies", func() {
+				args := EmptyArguments().
+					Append("some-key", "vala").
+					AppendNoDefaults("some-key", "valb", "valc")
+				Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"val1", "val2", "vala", "valb", "valc"}))
+			})
+
+			It("should not copy from defaults if the flag has been previously appended to ignoring defaults", func() {
+				args := EmptyArguments().
+					AppendNoDefaults("some-key", "vala").
+					Append("some-key", "valb", "valc")
+				Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"vala", "valb", "valc"}))
+			})
+		})
+	})
+
+	It("should ignore defaults when overriding", func() {
+		args := EmptyArguments().
+			Set("some-key", "vala")
+		Expect(args.Get("some-key").Get([]string{"val1", "val2"})).To(Equal([]string{"vala"}))
+	})
+
+	It("should allow directly setting the argument value for custom argument types", func() {
+		args := EmptyArguments().
+			SetRaw("custom-key", commaArg{"val3"}).
+			Append("custom-key", "val4")
+		Expect(args.Get("custom-key").Get([]string{"val1", "val2"})).To(Equal([]string{"val1,val2,val3,val4"}))
+	})
+
+	Context("when rendering flags", func() {
+		It("should not render defaults for disabled flags", func() {
+			defs := map[string][]string{
+				"some-key":  []string{"val1", "val2"},
+				"other-key": []string{"val"},
+			}
+			args := EmptyArguments().
+				Disable("some-key")
+			Expect(args.AsStrings(defs)).To(ConsistOf("--other-key=val"))
+		})
+
+		It("should render name-only flags as --key", func() {
+			args := EmptyArguments().
+				Enable("some-key")
+			Expect(args.AsStrings(nil)).To(ConsistOf("--some-key"))
+		})
+
+		It("should render multiple values as --key=val1, --key=val2", func() {
+			args := EmptyArguments().
+				Append("some-key", "val1", "val2").
+				Append("other-key", "vala", "valb")
+			Expect(args.AsStrings(nil)).To(ConsistOf("--other-key=valb", "--other-key=vala", "--some-key=val1", "--some-key=val2"))
+		})
+
+		It("should read from defaults if the user hasn't set a value for a flag", func() {
+			defs := map[string][]string{
+				"some-key": []string{"val1", "val2"},
+			}
+			args := EmptyArguments().
+				Append("other-key", "vala", "valb")
+			Expect(args.AsStrings(defs)).To(ConsistOf("--other-key=valb", "--other-key=vala", "--some-key=val1", "--some-key=val2"))
+		})
+
+		It("should not render defaults if the user has set a value for a flag", func() {
+			defs := map[string][]string{
+				"some-key": []string{"val1", "val2"},
+			}
+			args := EmptyArguments().
+				Set("some-key", "vala")
+			Expect(args.AsStrings(defs)).To(ConsistOf("--some-key=vala"))
+		})
+	})
+})
+
+type commaArg []string
+
+func (a commaArg) Get(defs []string) []string {
+	// not quite, but close enough
+	return []string{strings.Join(defs, ",") + "," + strings.Join(a, ",")}
+}
+func (a commaArg) Append(vals ...string) Arg {
+	return commaArg(append(a, vals...))
+}


### PR DESCRIPTION
This adds structured arguments to the testing package, deprecating the old style where we do templating in favor of a fluent API with defaults that can be overridden.

This should make it easier for consumers to override individual arguments while not breaking the necessary flags that are required for the API server to function, and should make it easier for us to deal with upcoming changes in the k8s API server that requiring setting flags in some conditions, but not in others that are unrelated to the value of the flag (e.g. certain flags *must* be passed for older versions, but must *NOT* be passed for newer versions).

The new API looks roughly like:

```go
apiServer.Configure().
  Disable("insecure-port").
  Append("vmodule", "httplog.go=10").
  Set("v", "5")
```

There's also a helper to merge the new arguments with the older style ones.  To preserve existing behavior, if the end user explicitly passes a template, we'll consider those to be the "defaults", otherwise we'll use our normal new default logic.

Depends on #1540
Part of #1486
