### PR TITLE
:book: Remove reference to ClientBuilder in Cluster docs

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -50,7 +50,7 @@ type Cluster interface {
 
 	// GetClient returns a client configured with the Config. This client may
 	// not be a fully "direct" client -- it may read from a cache, for
-	// instance.  See Options.ClientBuilder for more information on how the default
+	// instance.  See Options.NewClient for more information on how the default
 	// implementation works.
 	GetClient() client.Client
 


### PR DESCRIPTION
The Cluster interface docs still had a reference to client, despite
being removed in aa1bfee605cea988a4a79e9021ad1d4334b09eb8.

This restores those docs to talk about NewClient instead.

Follow up from #1409 
