### PR TITLE
:book: Mark all templated flag pieces as deprecated

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -163,6 +163,8 @@ type Environment struct {
 	ControlPlaneStopTimeout time.Duration
 
 	// KubeAPIServerFlags is the set of flags passed while starting the api server.
+	//
+	// Deprecated: use ControlPlane.GetAPIServer().Configure() instead.
 	KubeAPIServerFlags []string
 
 	// AttachControlPlaneOutput indicates if control plane output will be attached to os.Stdout and os.Stderr.
@@ -368,4 +370,6 @@ func (te *Environment) useExistingCluster() bool {
 
 // DefaultKubeAPIServerFlags exposes the default args for the APIServer so that
 // you can use those to append your own additional arguments.
+//
+// Deprecated: use APIServer.Configure() instead.
 var DefaultKubeAPIServerFlags = controlplane.APIServerDefaultArgs


### PR DESCRIPTION
The underlying templated flag machinery was marked as deprecated as part
of the envtest refactor (see ddfdfdff7), but a couple fields in the
higher-level bits of envtest were not marked as deprecated.  This fixes
that.

See also #1541 
