### PR TITLE
:seedling: Remove async ginkgo tests

### DIFF
--- a/pkg/builder/builder_suite_test.go
+++ b/pkg/builder/builder_suite_test.go
@@ -45,7 +45,7 @@ func TestBuilder(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -63,8 +63,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	webhook.DefaultPort, _, err = addr.Suggest("")
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -297,7 +297,7 @@ var _ = Describe("application", func() {
 	})
 
 	Describe("Start with ControllerManagedBy", func() {
-		It("should Reconcile Owns objects", func(done Done) {
+		It("should Reconcile Owns objects", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -308,10 +308,9 @@ var _ = Describe("application", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			doReconcileTest(ctx, "3", bldr, m, false)
-			close(done)
 		}, 10)
 
-		It("should Reconcile Watches objects", func(done Done) {
+		It("should Reconcile Watches objects", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -324,12 +323,11 @@ var _ = Describe("application", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			doReconcileTest(ctx, "4", bldr, m, true)
-			close(done)
 		}, 10)
 	})
 
 	Describe("Set custom predicates", func() {
-		It("should execute registered predicates only for assigned kind", func(done Done) {
+		It("should execute registered predicates only for assigned kind", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -385,8 +383,6 @@ var _ = Describe("application", func() {
 			Expect(deployPrctExecuted).To(BeTrue(), "Deploy predicated should be called at least once")
 			Expect(replicaSetPrctExecuted).To(BeTrue(), "ReplicaSet predicated should be called at least once")
 			Expect(allPrctExecuted).To(BeNumerically(">=", 2), "Global Predicated should be called at least twice")
-
-			close(done)
 		})
 	})
 

--- a/pkg/cache/cache_suite_test.go
+++ b/pkg/cache/cache_suite_test.go
@@ -39,7 +39,7 @@ var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -50,8 +50,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -885,7 +885,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 		})
 		Describe("as an Informer", func() {
 			Context("with structured objects", func() {
-				It("should be able to get informer for the object", func(done Done) {
+				It("should be able to get informer for the object", func() {
 					By("getting a shared index informer for a pod")
 					pod := &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -921,9 +921,8 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
-					close(done)
 				})
-				It("should be able to get an informer by group/version/kind", func(done Done) {
+				It("should be able to get an informer by group/version/kind", func() {
 					By("getting an shared index informer for gvk = core/v1/pod")
 					gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
 					sii, err := informerCache.GetInformerForKind(context.TODO(), gvk)
@@ -960,7 +959,6 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
-					close(done)
 				})
 				It("should be able to index an object field then retrieve objects by that field", func() {
 					By("creating the cache")
@@ -1030,7 +1028,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				})
 			})
 			Context("with unstructured objects", func() {
-				It("should be able to get informer for the object", func(done Done) {
+				It("should be able to get informer for the object", func() {
 					By("getting a shared index informer for a pod")
 
 					pod := &unstructured.Unstructured{
@@ -1072,7 +1070,6 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
-					close(done)
 				}, 3)
 
 				It("should be able to index an object field then retrieve objects by that field", func() {
@@ -1145,7 +1142,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				})
 			})
 			Context("with metadata-only objects", func() {
-				It("should be able to get informer for the object", func(done Done) {
+				It("should be able to get informer for the object", func() {
 					By("getting a shared index informer for a pod")
 
 					pod := &corev1.Pod{
@@ -1193,7 +1190,6 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying the object's metadata is received on the channel")
 					Eventually(out).Should(Receive(Equal(podMeta)))
-					close(done)
 				}, 3)
 
 				It("should be able to index an object field then retrieve objects by that field", func() {

--- a/pkg/certwatcher/certwatcher_suite_test.go
+++ b/pkg/certwatcher/certwatcher_suite_test.go
@@ -38,15 +38,12 @@ func TestSource(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	close(done)
 }, 60)
 
-var _ = AfterSuite(func(done Done) {
+var _ = AfterSuite(func() {
 	for _, file := range []string{certPath, keyPath} {
 		_ = os.Remove(file)
 	}
-	close(done)
 }, 60)

--- a/pkg/client/apiutil/apiutil_suite_test.go
+++ b/pkg/client/apiutil/apiutil_suite_test.go
@@ -36,11 +36,9 @@ func TestSource(t *testing.T) {
 
 var cfg *rest.Config
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	// for things that technically need a rest.Config for defaulting, but don't actually use them
 	cfg = &rest.Config{}
-
-	close(done)
 }, 60)

--- a/pkg/client/client_suite_test.go
+++ b/pkg/client/client_suite_test.go
@@ -40,7 +40,7 @@ var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -51,8 +51,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/client/config/config_suite_test.go
+++ b/pkg/client/config/config_suite_test.go
@@ -33,8 +33,6 @@ func TestConfig(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	close(done)
 }, 60)

--- a/pkg/client/fake/client_suite_test.go
+++ b/pkg/client/fake/client_suite_test.go
@@ -33,7 +33,6 @@ func TestSource(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-	close(done)
 }, 60)

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -813,17 +813,16 @@ var _ = Describe("Fake client", func() {
 	}
 
 	Context("with default scheme.Scheme", func() {
-		BeforeEach(func(done Done) {
+		BeforeEach(func() {
 			cl = NewClientBuilder().
 				WithObjects(dep, dep2, cm).
 				Build()
-			close(done)
 		})
 		AssertClientBehavior()
 	})
 
 	Context("with given scheme", func() {
-		BeforeEach(func(done Done) {
+		BeforeEach(func() {
 			scheme := runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
 			Expect(appsv1.AddToScheme(scheme)).To(Succeed())
@@ -833,7 +832,6 @@ var _ = Describe("Fake client", func() {
 				WithObjects(cm).
 				WithLists(&appsv1.DeploymentList{Items: []appsv1.Deployment{*dep, *dep2}}).
 				Build()
-			close(done)
 		})
 		AssertClientBehavior()
 	})

--- a/pkg/client/watch_test.go
+++ b/pkg/client/watch_test.go
@@ -40,7 +40,7 @@ var _ = Describe("ClientWithWatch", func() {
 	var ns = "kube-public"
 	ctx := context.TODO()
 
-	BeforeEach(func(done Done) {
+	BeforeEach(func() {
 		atomic.AddUint64(&count, 1)
 		dep = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("watch-deployment-name-%v", count), Namespace: ns, Labels: map[string]string{"app": fmt.Sprintf("bar-%v", count)}},
@@ -59,21 +59,17 @@ var _ = Describe("ClientWithWatch", func() {
 		var err error
 		dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		close(done)
 	}, serverSideTimeoutSeconds)
 
-	AfterEach(func(done Done) {
+	AfterEach(func() {
 		deleteDeployment(ctx, dep, ns)
-		close(done)
 	}, serverSideTimeoutSeconds)
 
 	Describe("NewWithWatch", func() {
-		It("should return a new Client", func(done Done) {
+		It("should return a new Client", func() {
 			cl, err := client.NewWithWatch(cfg, client.Options{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cl).NotTo(BeNil())
-
-			close(done)
 		})
 
 		watchSuite := func(through client.ObjectList, expectedType client.Object) {
@@ -105,12 +101,11 @@ var _ = Describe("ClientWithWatch", func() {
 
 		}
 
-		It("should receive a create event when watching the typed object", func(done Done) {
+		It("should receive a create event when watching the typed object", func() {
 			watchSuite(&appsv1.DeploymentList{}, &appsv1.Deployment{})
-			close(done)
 		}, 15)
 
-		It("should receive a create event when watching the unstructured object", func(done Done) {
+		It("should receive a create event when watching the unstructured object", func() {
 			u := &unstructured.UnstructuredList{}
 			u.SetGroupVersionKind(schema.GroupVersionKind{
 				Group:   "apps",
@@ -118,13 +113,11 @@ var _ = Describe("ClientWithWatch", func() {
 				Version: "v1",
 			})
 			watchSuite(u, &unstructured.Unstructured{})
-			close(done)
 		}, 15)
 
-		It("should receive a create event when watching the metadata object", func(done Done) {
+		It("should receive a create event when watching the metadata object", func() {
 			m := &metav1.PartialObjectMetadataList{TypeMeta: metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"}}
 			watchSuite(m, &metav1.PartialObjectMetadata{})
-			close(done)
 		}, 15)
 	})
 

--- a/pkg/cluster/cluster_suite_test.go
+++ b/pkg/cluster/cluster_suite_test.go
@@ -43,7 +43,7 @@ var clientset *kubernetes.Clientset
 // clientTransport is used to force-close keep-alives in tests that check for leaks.
 var clientTransport *http.Transport
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -63,8 +63,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -55,7 +55,7 @@ var _ = Describe("cluster.Cluster", func() {
 
 		})
 
-		It("should return an error it can't create a client.Client", func(done Done) {
+		It("should return an error it can't create a client.Client", func() {
 			c, err := New(cfg, func(o *Options) {
 				o.NewClient = func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 					return nil, errors.New("expected error")
@@ -64,11 +64,9 @@ var _ = Describe("cluster.Cluster", func() {
 			Expect(c).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should return an error it can't create a cache.Cache", func(done Done) {
+		It("should return an error it can't create a cache.Cache", func() {
 			c, err := New(cfg, func(o *Options) {
 				o.NewCache = func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 					return nil, fmt.Errorf("expected error")
@@ -77,11 +75,9 @@ var _ = Describe("cluster.Cluster", func() {
 			Expect(c).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should create a client defined in by the new client function", func(done Done) {
+		It("should create a client defined in by the new client function", func() {
 			c, err := New(cfg, func(o *Options) {
 				o.NewClient = func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 					return nil, nil
@@ -90,11 +86,9 @@ var _ = Describe("cluster.Cluster", func() {
 			Expect(c).ToNot(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.GetClient()).To(BeNil())
-
-			close(done)
 		})
 
-		It("should return an error it can't create a recorder.Provider", func(done Done) {
+		It("should return an error it can't create a recorder.Provider", func() {
 			c, err := New(cfg, func(o *Options) {
 				o.newRecorderProvider = func(_ *rest.Config, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
 					return nil, fmt.Errorf("expected error")
@@ -103,26 +97,22 @@ var _ = Describe("cluster.Cluster", func() {
 			Expect(c).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
 	})
 
 	Describe("Start", func() {
-		It("should stop when context is cancelled", func(done Done) {
+		It("should stop when context is cancelled", func() {
 			c, err := New(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 			Expect(c.Start(ctx)).NotTo(HaveOccurred())
-
-			close(done)
 		})
 	})
 
 	Describe("SetFields", func() {
-		It("should inject field values", func(done Done) {
+		It("should inject field values", func() {
 			c, err := New(cfg, func(o *Options) {
 				o.NewCache = func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
 					return &informertest.FakeInformers{}, nil
@@ -190,8 +180,6 @@ var _ = Describe("cluster.Cluster", func() {
 				},
 			})
 			Expect(err).To(Equal(expected))
-
-			close(done)
 		})
 	})
 

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -48,7 +48,7 @@ var _ = Describe("controller", func() {
 	Describe("controller", func() {
 		// TODO(directxman12): write a whole suite of controller-client interaction tests
 
-		It("should reconcile", func(done Done) {
+		It("should reconcile", func() {
 			By("Creating the Manager")
 			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
@@ -169,8 +169,6 @@ var _ = Describe("controller", func() {
 			err = cm.GetClient().
 				List(context.Background(), &controllertest.UnconventionalListTypeList{})
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 5)
 	})
 })

--- a/pkg/controller/controller_suite_test.go
+++ b/pkg/controller/controller_suite_test.go
@@ -49,7 +49,7 @@ var clientset *kubernetes.Clientset
 // clientTransport is used to force-close keep-alives in tests that check for leaks.
 var clientTransport *http.Transport
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	err := (&crscheme.Builder{
@@ -82,8 +82,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	// Prevent the metrics listener being created
 	metrics.DefaultBindAddress = "0"
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -42,28 +42,24 @@ var _ = Describe("controller.Controller", func() {
 	})
 
 	Describe("New", func() {
-		It("should return an error if Name is not Specified", func(done Done) {
+		It("should return an error if Name is not Specified", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 			c, err := controller.New("", m, controller.Options{Reconciler: rec})
 			Expect(c).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("must specify Name for Controller"))
-
-			close(done)
 		})
 
-		It("should return an error if Reconciler is not Specified", func(done Done) {
+		It("should return an error if Reconciler is not Specified", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("foo", m, controller.Options{})
 			Expect(c).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("must specify Reconciler"))
-
-			close(done)
 		})
 
-		It("NewController should return an error if injecting Reconciler fails", func(done Done) {
+		It("NewController should return an error if injecting Reconciler fails", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -71,11 +67,9 @@ var _ = Describe("controller.Controller", func() {
 			Expect(c).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should not return an error if two controllers are registered with different names", func(done Done) {
+		It("should not return an error if two controllers are registered with different names", func() {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -86,8 +80,6 @@ var _ = Describe("controller.Controller", func() {
 			c2, err := controller.New("c2", m, controller.Options{Reconciler: rec})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(c2).ToNot(BeNil())
-
-			close(done)
 		})
 
 		It("should not leak goroutines when stopped", func() {

--- a/pkg/controller/controllerutil/controllerutil_suite_test.go
+++ b/pkg/controller/controllerutil/controllerutil_suite_test.go
@@ -34,16 +34,16 @@ func TestControllerutil(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var t *envtest.Environment
+var testenv *envtest.Environment
 var cfg *rest.Config
 var c client.Client
 
 var _ = BeforeSuite(func() {
 	var err error
 
-	t = &envtest.Environment{}
+	testenv = &envtest.Environment{}
 
-	cfg, err = t.Start()
+	cfg, err = testenv.Start()
 	Expect(err).NotTo(HaveOccurred())
 
 	c, err = client.New(cfg, client.Options{})
@@ -51,5 +51,5 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	Expect(t.Stop()).To(Succeed())
+	Expect(testenv.Stop()).To(Succeed())
 })

--- a/pkg/envtest/envtest_suite_test.go
+++ b/pkg/envtest/envtest_suite_test.go
@@ -38,15 +38,13 @@ func TestSource(t *testing.T) {
 
 var env *Environment
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	env = &Environment{}
 	// we're initializing webhook here and not in webhook.go to also test the envtest install code via WebhookOptions
 	initializeWebhookInEnvironment()
 	_, err := env.Start()
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, StartTimeout)
 
 func initializeWebhookInEnvironment() {
@@ -136,8 +134,6 @@ func initializeWebhookInEnvironment() {
 	}
 }
 
-var _ = AfterSuite(func(done Done) {
+var _ = AfterSuite(func() {
 	Expect(env.Stop()).NotTo(HaveOccurred())
-
-	close(done)
 }, StopTimeout)

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Test", func() {
 	var teardownTimeoutSeconds float64 = 10
 
 	// Initialize the client
-	BeforeEach(func(done Done) {
+	BeforeEach(func() {
 		crds = []client.Object{}
 		s = runtime.NewScheme()
 		err = v1beta1.AddToScheme(s)
@@ -55,12 +55,10 @@ var _ = Describe("Test", func() {
 
 		c, err = client.New(env.Config, client.Options{Scheme: s})
 		Expect(err).NotTo(HaveOccurred())
-
-		close(done)
 	})
 
 	// Cleanup CRDs
-	AfterEach(func(done Done) {
+	AfterEach(func() {
 		for _, crd := range runtimeCRDListToUnstructured(crds) {
 			// Delete only if CRD exists.
 			crdObjectKey := client.ObjectKey{
@@ -79,7 +77,6 @@ var _ = Describe("Test", func() {
 				return apierrors.IsNotFound(err)
 			}, 5*time.Second).Should(BeTrue())
 		}
-		close(done)
 	}, teardownTimeoutSeconds)
 
 	Describe("InstallCRDs", func() {
@@ -121,7 +118,7 @@ var _ = Describe("Test", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("should install the CRDs into the cluster using directory", func(done Done) {
+		It("should install the CRDs into the cluster using directory", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
@@ -221,11 +218,9 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should install the CRDs into the cluster using file", func(done Done) {
+		It("should install the CRDs into the cluster using file", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "examplecrd3.yaml")},
 			})
@@ -249,11 +244,9 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 10)
 
-		It("should be able to install CRDs using multiple files", func(done Done) {
+		It("should be able to install CRDs using multiple files", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{
 					filepath.Join(".", "testdata", "examplecrd.yaml"),
@@ -262,11 +255,9 @@ var _ = Describe("Test", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crds).To(HaveLen(2))
-
-			close(done)
 		}, 10)
 
-		It("should filter out already existent CRD", func(done Done) {
+		It("should filter out already existent CRD", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{
 					filepath.Join(".", "testdata"),
@@ -304,36 +295,28 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 10)
 
-		It("should not return an not error if the directory doesn't exist", func(done Done) {
+		It("should not return an not error if the directory doesn't exist", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{Paths: []string{invalidDirectory}})
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should return an error if the directory doesn't exist", func(done Done) {
+		It("should return an error if the directory doesn't exist", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{invalidDirectory}, ErrorIfPathMissing: true,
 			})
 			Expect(err).To(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should return an error if the file doesn't exist", func(done Done) {
+		It("should return an error if the file doesn't exist", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{Paths: []string{
 				filepath.Join(".", "testdata", "fake.yaml")}, ErrorIfPathMissing: true,
 			})
 			Expect(err).To(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should return an error if the resource group version isn't found", func(done Done) {
+		It("should return an error if the resource group version isn't found", func() {
 			// Wait for a CRD where the Group and Version don't exist
 			err := WaitForCRDs(env.Config,
 				[]client.Object{
@@ -348,11 +331,9 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).To(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should return an error if the resource isn't found in the group version", func(done Done) {
+		It("should return an error if the resource isn't found in the group version", func() {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{"."},
 			})
@@ -379,11 +360,9 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).To(HaveOccurred())
-
-			close(done)
 		}, 5)
 
-		It("should reinstall the CRDs if already present in the cluster", func(done Done) {
+		It("should reinstall the CRDs if already present in the cluster", func() {
 
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata")},
@@ -586,12 +565,10 @@ var _ = Describe("Test", func() {
 				CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 			)
 			Expect(err).NotTo(HaveOccurred())
-
-			close(done)
 		}, 5)
 	})
 
-	It("should update CRDs if already present in the cluster", func(done Done) {
+	It("should update CRDs if already present in the cluster", func() {
 
 		// Install only the CRDv1 multi-version example
 		crds, err = InstallCRDs(env.Config, CRDInstallOptions{
@@ -679,12 +656,10 @@ var _ = Describe("Test", func() {
 			CRDInstallOptions{MaxTime: 50 * time.Millisecond, PollInterval: 15 * time.Millisecond},
 		)
 		Expect(err).NotTo(HaveOccurred())
-
-		close(done)
 	}, 5)
 
 	Describe("UninstallCRDs", func() {
-		It("should uninstall the CRDs from the cluster", func(done Done) {
+		It("should uninstall the CRDs from the cluster", func() {
 
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
@@ -825,31 +800,27 @@ var _ = Describe("Test", func() {
 				}
 				return true
 			}, 20).Should(BeTrue())
-
-			close(done)
 		}, 30)
 	})
 
 	Describe("Start", func() {
-		It("should raise an error on invalid dir when flag is enabled", func(done Done) {
+		It("should raise an error on invalid dir when flag is enabled", func() {
 			env := &Environment{ErrorIfCRDPathMissing: true, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).To(HaveOccurred())
 			Expect(env.Stop()).To(Succeed())
-			close(done)
 		}, 30)
 
-		It("should not raise an error on invalid dir when flag is disabled", func(done Done) {
+		It("should not raise an error on invalid dir when flag is disabled", func() {
 			env := &Environment{ErrorIfCRDPathMissing: false, CRDDirectoryPaths: []string{invalidDirectory}}
 			_, err := env.Start()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(env.Stop()).To(Succeed())
-			close(done)
 		}, 30)
 	})
 
 	Describe("Stop", func() {
-		It("should cleanup webhook /tmp folder with no error when using existing cluster", func(done Done) {
+		It("should cleanup webhook /tmp folder with no error when using existing cluster", func() {
 			env := &Environment{}
 			_, err := env.Start()
 			Expect(err).NotTo(HaveOccurred())
@@ -857,7 +828,6 @@ var _ = Describe("Test", func() {
 
 			// check if the /tmp/envtest-serving-certs-* dir doesnt exists any more
 			Expect(env.WebhookInstallOptions.LocalServingCertDir).ShouldNot(BeADirectory())
-			close(done)
 		}, 30)
 	})
 })

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -36,7 +36,7 @@ import (
 var _ = Describe("Test", func() {
 
 	Describe("Webhook", func() {
-		It("should reject create request for webhook that rejects all requests", func(done Done) {
+		It("should reject create request for webhook that rejects all requests", func() {
 			m, err := manager.New(env.Config, manager.Options{
 				Port:    env.WebhookInstallOptions.LocalServingPort,
 				Host:    env.WebhookInstallOptions.LocalServingHost,
@@ -87,7 +87,6 @@ var _ = Describe("Test", func() {
 			}, 1*time.Second).Should(BeTrue())
 
 			cancel()
-			close(done)
 		})
 
 		It("should load webhooks from directory", func() {

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Eventhandler", func() {
 	})
 
 	Describe("EnqueueRequestForObject", func() {
-		It("should enqueue a Request with the Name / Namespace of the object in the CreateEvent.", func(done Done) {
+		It("should enqueue a Request with the Name / Namespace of the object in the CreateEvent.", func() {
 			evt := event.CreateEvent{
 				Object: pod,
 			}
@@ -66,11 +66,9 @@ var _ = Describe("Eventhandler", func() {
 			req, ok := i.(reconcile.Request)
 			Expect(ok).To(BeTrue())
 			Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
-
-			close(done)
 		})
 
-		It("should enqueue a Request with the Name / Namespace of the object in the DeleteEvent.", func(done Done) {
+		It("should enqueue a Request with the Name / Namespace of the object in the DeleteEvent.", func() {
 			evt := event.DeleteEvent{
 				Object: pod,
 			}
@@ -82,12 +80,10 @@ var _ = Describe("Eventhandler", func() {
 			req, ok := i.(reconcile.Request)
 			Expect(ok).To(BeTrue())
 			Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
-
-			close(done)
 		})
 
 		It("should enqueue a Request with the Name / Namespace of one object in the UpdateEvent.",
-			func(done Done) {
+			func() {
 				newPod := pod.DeepCopy()
 				newPod.Name = "baz2"
 				newPod.Namespace = "biz2"
@@ -104,11 +100,9 @@ var _ = Describe("Eventhandler", func() {
 				req, ok := i.(reconcile.Request)
 				Expect(ok).To(BeTrue())
 				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz2", Name: "baz2"}))
-
-				close(done)
 			})
 
-		It("should enqueue a Request with the Name / Namespace of the object in the GenericEvent.", func(done Done) {
+		It("should enqueue a Request with the Name / Namespace of the object in the GenericEvent.", func() {
 			evt := event.GenericEvent{
 				Object: pod,
 			}
@@ -119,21 +113,18 @@ var _ = Describe("Eventhandler", func() {
 			req, ok := i.(reconcile.Request)
 			Expect(ok).To(BeTrue())
 			Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
-
-			close(done)
 		})
 
 		Context("for a runtime.Object without Object", func() {
-			It("should do nothing if the Object is missing for a CreateEvent.", func(done Done) {
+			It("should do nothing if the Object is missing for a CreateEvent.", func() {
 				evt := event.CreateEvent{
 					Object: nil,
 				}
 				instance.Create(evt, q)
 				Expect(q.Len()).To(Equal(0))
-				close(done)
 			})
 
-			It("should do nothing if the Object is missing for a UpdateEvent.", func(done Done) {
+			It("should do nothing if the Object is missing for a UpdateEvent.", func() {
 				newPod := pod.DeepCopy()
 				newPod.Name = "baz2"
 				newPod.Namespace = "biz2"
@@ -159,26 +150,22 @@ var _ = Describe("Eventhandler", func() {
 				req, ok = i.(reconcile.Request)
 				Expect(ok).To(BeTrue())
 				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
-
-				close(done)
 			})
 
-			It("should do nothing if the Object is missing for a DeleteEvent.", func(done Done) {
+			It("should do nothing if the Object is missing for a DeleteEvent.", func() {
 				evt := event.DeleteEvent{
 					Object: nil,
 				}
 				instance.Delete(evt, q)
 				Expect(q.Len()).To(Equal(0))
-				close(done)
 			})
 
-			It("should do nothing if the Object is missing for a GenericEvent.", func(done Done) {
+			It("should do nothing if the Object is missing for a GenericEvent.", func() {
 				evt := event.GenericEvent{
 					Object: nil,
 				}
 				instance.Generic(evt, q)
 				Expect(q.Len()).To(Equal(0))
-				close(done)
 			})
 		})
 	})
@@ -823,7 +810,7 @@ var _ = Describe("Eventhandler", func() {
 			},
 		}
 
-		It("should call CreateFunc for a CreateEvent if provided.", func(done Done) {
+		It("should call CreateFunc for a CreateEvent if provided.", func() {
 			instance := failingFuncs
 			evt := event.CreateEvent{
 				Object: pod,
@@ -834,20 +821,18 @@ var _ = Describe("Eventhandler", func() {
 				Expect(evt2).To(Equal(evt))
 			}
 			instance.Create(evt, q)
-			close(done)
 		})
 
-		It("should NOT call CreateFunc for a CreateEvent if NOT provided.", func(done Done) {
+		It("should NOT call CreateFunc for a CreateEvent if NOT provided.", func() {
 			instance := failingFuncs
 			instance.CreateFunc = nil
 			evt := event.CreateEvent{
 				Object: pod,
 			}
 			instance.Create(evt, q)
-			close(done)
 		})
 
-		It("should call UpdateFunc for an UpdateEvent if provided.", func(done Done) {
+		It("should call UpdateFunc for an UpdateEvent if provided.", func() {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
@@ -864,10 +849,9 @@ var _ = Describe("Eventhandler", func() {
 			}
 
 			instance.Update(evt, q)
-			close(done)
 		})
 
-		It("should NOT call UpdateFunc for an UpdateEvent if NOT provided.", func(done Done) {
+		It("should NOT call UpdateFunc for an UpdateEvent if NOT provided.", func() {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
@@ -876,10 +860,9 @@ var _ = Describe("Eventhandler", func() {
 				ObjectNew: newPod,
 			}
 			instance.Update(evt, q)
-			close(done)
 		})
 
-		It("should call DeleteFunc for a DeleteEvent if provided.", func(done Done) {
+		It("should call DeleteFunc for a DeleteEvent if provided.", func() {
 			instance := failingFuncs
 			evt := event.DeleteEvent{
 				Object: pod,
@@ -890,20 +873,18 @@ var _ = Describe("Eventhandler", func() {
 				Expect(evt2).To(Equal(evt))
 			}
 			instance.Delete(evt, q)
-			close(done)
 		})
 
-		It("should NOT call DeleteFunc for a DeleteEvent if NOT provided.", func(done Done) {
+		It("should NOT call DeleteFunc for a DeleteEvent if NOT provided.", func() {
 			instance := failingFuncs
 			instance.DeleteFunc = nil
 			evt := event.DeleteEvent{
 				Object: pod,
 			}
 			instance.Delete(evt, q)
-			close(done)
 		})
 
-		It("should call GenericFunc for a GenericEvent if provided.", func(done Done) {
+		It("should call GenericFunc for a GenericEvent if provided.", func() {
 			instance := failingFuncs
 			evt := event.GenericEvent{
 				Object: pod,
@@ -914,17 +895,15 @@ var _ = Describe("Eventhandler", func() {
 				Expect(evt2).To(Equal(evt))
 			}
 			instance.Generic(evt, q)
-			close(done)
 		})
 
-		It("should NOT call GenericFunc for a GenericEvent if NOT provided.", func(done Done) {
+		It("should NOT call GenericFunc for a GenericEvent if NOT provided.", func() {
 			instance := failingFuncs
 			instance.GenericFunc = nil
 			evt := event.GenericEvent{
 				Object: pod,
 			}
 			instance.Generic(evt, q)
-			close(done)
 		})
 	})
 })

--- a/pkg/internal/controller/controller_suite_test.go
+++ b/pkg/internal/controller/controller_suite_test.go
@@ -39,7 +39,7 @@ var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -50,8 +50,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -91,7 +91,7 @@ var _ = Describe("controller", func() {
 	})
 
 	Describe("Start", func() {
-		It("should return an error if there is an error waiting for the informers", func(done Done) {
+		It("should return an error if there is an error waiting for the informers", func() {
 			f := false
 			ctrl.startWatches = []watchDescription{{
 				src: source.NewKindWithCache(&corev1.Pod{}, &informertest.FakeInformers{Synced: &f}),
@@ -102,11 +102,9 @@ var _ = Describe("controller", func() {
 			err := ctrl.Start(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to wait for foo caches to sync"))
-
-			close(done)
 		})
 
-		It("should error when cache sync timeout occurs", func(done Done) {
+		It("should error when cache sync timeout occurs", func() {
 			ctrl.CacheSyncTimeout = 10 * time.Nanosecond
 
 			c, err := cache.New(cfg, cache.Options{})
@@ -121,11 +119,9 @@ var _ = Describe("controller", func() {
 			err = ctrl.Start(context.TODO())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to wait for testcontroller caches to sync: timed out waiting for cache to be synced"))
-
-			close(done)
 		})
 
-		It("should not error when cache sync timeout is of sufficiently high", func(done Done) {
+		It("should not error when cache sync timeout is of sufficiently high", func() {
 			ctrl.CacheSyncTimeout = 1 * time.Second
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -152,10 +148,9 @@ var _ = Describe("controller", func() {
 			}()
 
 			<-sourceSynced
-			close(done)
 		}, 10.0)
 
-		It("should process events from source.Channel", func(done Done) {
+		It("should process events from source.Channel", func() {
 			// channel to be closed when event is processed
 			processed := make(chan struct{})
 			// source channel to be injected
@@ -194,10 +189,9 @@ var _ = Describe("controller", func() {
 				Expect(ctrl.Start(ctx)).To(Succeed())
 			}()
 			<-processed
-			close(done)
 		})
 
-		It("should error when channel is passed as a source but stop channel is not injected", func(done Done) {
+		It("should error when channel is passed as a source but stop channel is not injected", func() {
 			ch := make(chan event.GenericEvent)
 			ctx, cancel := context.WithCancel(context.TODO())
 			defer cancel()
@@ -211,10 +205,9 @@ var _ = Describe("controller", func() {
 
 			Expect(e).NotTo(BeNil())
 			Expect(e.Error()).To(ContainSubstring("must call InjectStop on Channel before calling Start"))
-			close(done)
 		})
 
-		It("should error when channel source is not specified", func(done Done) {
+		It("should error when channel source is not specified", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -228,8 +221,6 @@ var _ = Describe("controller", func() {
 			e := ctrl.Start(ctx)
 			Expect(e).NotTo(BeNil())
 			Expect(e.Error()).To(ContainSubstring("must specify Channel.Source"))
-
-			close(done)
 		})
 
 		It("should call Start on sources with the appropriate EventHandler, Queue, and Predicates", func() {
@@ -403,7 +394,7 @@ var _ = Describe("controller", func() {
 	})
 
 	Describe("Processing queue items from a Controller", func() {
-		It("should call Reconciler if an item is enqueued", func(done Done) {
+		It("should call Reconciler if an item is enqueued", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			go func() {
@@ -419,11 +410,9 @@ var _ = Describe("controller", func() {
 			By("Removing the item from the queue")
 			Eventually(queue.Len).Should(Equal(0))
 			Eventually(func() int { return queue.NumRequeues(request) }).Should(Equal(0))
-
-			close(done)
 		})
 
-		It("should continue to process additional queue items after the first", func(done Done) {
+		It("should continue to process additional queue items after the first", func() {
 			ctrl.Do = reconcile.Func(func(context.Context, reconcile.Request) (reconcile.Result, error) {
 				defer GinkgoRecover()
 				Fail("Reconciler should not have been called")
@@ -443,15 +432,13 @@ var _ = Describe("controller", func() {
 			By("expecting both of them to be skipped")
 			Eventually(queue.Len).Should(Equal(0))
 			Eventually(func() int { return queue.NumRequeues(request) }).Should(Equal(0))
-
-			close(done)
 		})
 
 		PIt("should forget an item if it is not a Request and continue processing items", func() {
 			// TODO(community): write this test
 		})
 
-		It("should requeue a Request if there is an error and continue processing items", func(done Done) {
+		It("should requeue a Request if there is an error and continue processing items", func() {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
@@ -473,8 +460,6 @@ var _ = Describe("controller", func() {
 			By("Removing the item from the queue")
 			Eventually(queue.Len).Should(Equal(0))
 			Eventually(func() int { return queue.NumRequeues(request) }).Should(Equal(0))
-
-			close(done)
 		}, 1.0)
 
 		// TODO(directxman12): we should ensure that backoff occurrs with error requeue
@@ -624,7 +609,7 @@ var _ = Describe("controller", func() {
 				reconcileTotal.Reset()
 			})
 
-			It("should get updated on successful reconciliation", func(done Done) {
+			It("should get updated on successful reconciliation", func() {
 				Expect(func() error {
 					Expect(ctrlmetrics.ReconcileTotal.WithLabelValues(ctrl.Name, "success").Write(&reconcileTotal)).To(Succeed())
 					if reconcileTotal.GetCounter().GetValue() != 0.0 {
@@ -651,11 +636,9 @@ var _ = Describe("controller", func() {
 					}
 					return nil
 				}, 2.0).Should(Succeed())
-
-				close(done)
 			}, 2.0)
 
-			It("should get updated on reconcile errors", func(done Done) {
+			It("should get updated on reconcile errors", func() {
 				Expect(func() error {
 					Expect(ctrlmetrics.ReconcileTotal.WithLabelValues(ctrl.Name, "error").Write(&reconcileTotal)).To(Succeed())
 					if reconcileTotal.GetCounter().GetValue() != 0.0 {
@@ -682,11 +665,9 @@ var _ = Describe("controller", func() {
 					}
 					return nil
 				}, 2.0).Should(Succeed())
-
-				close(done)
 			}, 2.0)
 
-			It("should get updated when reconcile returns with retry enabled", func(done Done) {
+			It("should get updated when reconcile returns with retry enabled", func() {
 				Expect(func() error {
 					Expect(ctrlmetrics.ReconcileTotal.WithLabelValues(ctrl.Name, "retry").Write(&reconcileTotal)).To(Succeed())
 					if reconcileTotal.GetCounter().GetValue() != 0.0 {
@@ -714,11 +695,9 @@ var _ = Describe("controller", func() {
 					}
 					return nil
 				}, 2.0).Should(Succeed())
-
-				close(done)
 			}, 2.0)
 
-			It("should get updated when reconcile returns with retryAfter enabled", func(done Done) {
+			It("should get updated when reconcile returns with retryAfter enabled", func() {
 				Expect(func() error {
 					Expect(ctrlmetrics.ReconcileTotal.WithLabelValues(ctrl.Name, "retry_after").Write(&reconcileTotal)).To(Succeed())
 					if reconcileTotal.GetCounter().GetValue() != 0.0 {
@@ -745,13 +724,11 @@ var _ = Describe("controller", func() {
 					}
 					return nil
 				}, 2.0).Should(Succeed())
-
-				close(done)
 			}, 2.0)
 		})
 
 		Context("should update prometheus metrics", func() {
-			It("should requeue a Request if there is an error and continue processing items", func(done Done) {
+			It("should requeue a Request if there is an error and continue processing items", func() {
 				var reconcileErrs dto.Metric
 				ctrlmetrics.ReconcileErrors.Reset()
 				Expect(func() error {
@@ -788,11 +765,9 @@ var _ = Describe("controller", func() {
 				By("Removing the item from the queue")
 				Eventually(queue.Len).Should(Equal(0))
 				Eventually(func() int { return queue.NumRequeues(request) }).Should(Equal(0))
-
-				close(done)
 			}, 2.0)
 
-			It("should add a reconcile time to the reconcile time histogram", func(done Done) {
+			It("should add a reconcile time to the reconcile time histogram", func() {
 				var reconcileTime dto.Metric
 				ctrlmetrics.ReconcileTime.Reset()
 
@@ -831,8 +806,6 @@ var _ = Describe("controller", func() {
 					}
 					return nil
 				}, 2.0).Should(Succeed())
-
-				close(done)
 			}, 4.0)
 		})
 	})

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("recorder", func() {
 	Describe("recorder", func() {
-		It("should publish events", func(done Done) {
+		It("should publish events", func() {
 			By("Creating the Manager")
 			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
@@ -108,8 +108,6 @@ var _ = Describe("recorder", func() {
 			Expect(evt.Type).To(Equal(corev1.EventTypeNormal))
 			Expect(evt.Reason).To(Equal("test-reason"))
 			Expect(evt.Message).To(Equal("test-msg"))
-
-			close(done)
 		})
 	})
 })

--- a/pkg/internal/recorder/recorder_suite_test.go
+++ b/pkg/internal/recorder/recorder_suite_test.go
@@ -39,7 +39,7 @@ var testenv *envtest.Environment
 var cfg *rest.Config
 var clientset *kubernetes.Clientset
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -50,8 +50,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/manager/manager_suite_test.go
+++ b/pkg/manager/manager_suite_test.go
@@ -45,7 +45,7 @@ var clientset *kubernetes.Clientset
 // clientTransport is used to force-close keep-alives in tests that check for leaks.
 var clientTransport *http.Transport
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -72,8 +72,6 @@ var _ = BeforeSuite(func(done Done) {
 
 	// Prevent the metrics listener being created
 	metrics.DefaultBindAddress = "0"
-
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -75,7 +75,7 @@ var _ = Describe("manger.Manager", func() {
 
 		})
 
-		It("should return an error it can't create a client.Client", func(done Done) {
+		It("should return an error it can't create a client.Client", func() {
 			m, err := New(cfg, Options{
 				NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 					return nil, errors.New("expected error")
@@ -84,11 +84,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should return an error it can't create a cache.Cache", func(done Done) {
+		It("should return an error it can't create a cache.Cache", func() {
 			m, err := New(cfg, Options{
 				NewCache: func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
 					return nil, fmt.Errorf("expected error")
@@ -97,11 +95,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should create a client defined in by the new client function", func(done Done) {
+		It("should create a client defined in by the new client function", func() {
 			m, err := New(cfg, Options{
 				NewClient: func(cache cache.Cache, config *rest.Config, options client.Options, uncachedObjects ...client.Object) (client.Client, error) {
 					return nil, nil
@@ -110,11 +106,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m).ToNot(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m.GetClient()).To(BeNil())
-
-			close(done)
 		})
 
-		It("should return an error it can't create a recorder.Provider", func(done Done) {
+		It("should return an error it can't create a recorder.Provider", func() {
 			m, err := New(cfg, Options{
 				newRecorderProvider: func(_ *rest.Config, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
 					return nil, fmt.Errorf("expected error")
@@ -123,11 +117,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
-
-			close(done)
 		})
 
-		It("should be able to load Options from cfg.ControllerManagerConfiguration type", func(done Done) {
+		It("should be able to load Options from cfg.ControllerManagerConfiguration type", func() {
 			duration := metav1.Duration{Duration: 48 * time.Hour}
 			port := int(6090)
 			leaderElect := false
@@ -180,11 +172,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m.Port).To(Equal(port))
 			Expect(m.Host).To(Equal("localhost"))
 			Expect(m.CertDir).To(Equal("/certs"))
-
-			close(done)
 		})
 
-		It("should be able to keep Options when cfg.ControllerManagerConfiguration set", func(done Done) {
+		It("should be able to keep Options when cfg.ControllerManagerConfiguration set", func() {
 			optDuration := time.Duration(2)
 			duration := metav1.Duration{Duration: 48 * time.Hour}
 			port := int(6090)
@@ -255,11 +245,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(m.Port).To(Equal(8080))
 			Expect(m.Host).To(Equal("example.com"))
 			Expect(m.CertDir).To(Equal("/pki"))
-
-			close(done)
 		})
 
-		It("should lazily initialize a webhook server if needed", func(done Done) {
+		It("should lazily initialize a webhook server if needed", func() {
 			By("creating a manager with options")
 			m, err := New(cfg, Options{Port: 9440, Host: "foo.com"})
 			Expect(err).NotTo(HaveOccurred())
@@ -270,11 +258,9 @@ var _ = Describe("manger.Manager", func() {
 			Expect(svr).NotTo(BeNil())
 			Expect(svr.Port).To(Equal(9440))
 			Expect(svr.Host).To(Equal("foo.com"))
-
-			close(done)
 		})
 
-		It("should not initialize a webhook server if Options.WebhookServer is set", func(done Done) {
+		It("should not initialize a webhook server if Options.WebhookServer is set", func() {
 			By("creating a manager with options")
 			m, err := New(cfg, Options{Port: 9441, WebhookServer: &webhook.Server{Port: 9440}})
 			Expect(err).NotTo(HaveOccurred())
@@ -284,8 +270,6 @@ var _ = Describe("manger.Manager", func() {
 			svr := m.GetWebhookServer()
 			Expect(svr).NotTo(BeNil())
 			Expect(svr.Port).To(Equal(9440))
-
-			close(done)
 		})
 
 		Context("with leader election enabled", func() {
@@ -599,7 +583,7 @@ var _ = Describe("manger.Manager", func() {
 
 	Describe("Start", func() {
 		var startSuite = func(options Options, callbacks ...func(Manager)) {
-			It("should Start each Component", func(done Done) {
+			It("should Start each Component", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -629,7 +613,6 @@ var _ = Describe("manger.Manager", func() {
 				}()
 
 				wgRunnableStarted.Wait()
-				close(done)
 			})
 
 			It("should not manipulate the provided config", func() {
@@ -651,7 +634,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(m.GetConfig()).To(Equal(originalCfg))
 			})
 
-			It("should stop when context is cancelled", func(done Done) {
+			It("should stop when context is cancelled", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -660,11 +643,9 @@ var _ = Describe("manger.Manager", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 				Expect(m.Start(ctx)).NotTo(HaveOccurred())
-
-				close(done)
 			})
 
-			It("should return an error if it can't start the cache", func(done Done) {
+			It("should return an error if it can't start the cache", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -677,11 +658,9 @@ var _ = Describe("manger.Manager", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 				Expect(m.Start(ctx)).To(MatchError(ContainSubstring("expected error")))
-
-				close(done)
 			})
 
-			It("should start the cache before starting anything else", func(done Done) {
+			It("should start the cache before starting anything else", func() {
 				fakeCache := &startSignalingInformer{Cache: &informertest.FakeInformers{}}
 				options.NewCache = func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
 					return fakeCache, nil
@@ -710,10 +689,9 @@ var _ = Describe("manger.Manager", func() {
 				}()
 
 				<-runnableWasStarted
-				close(done)
 			})
 
-			It("should start additional clusters before anything else", func(done Done) {
+			It("should start additional clusters before anything else", func() {
 				fakeCache := &startSignalingInformer{Cache: &informertest.FakeInformers{}}
 				options.NewCache = func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
 					return fakeCache, nil
@@ -754,10 +732,9 @@ var _ = Describe("manger.Manager", func() {
 				}()
 
 				<-runnableWasStarted
-				close(done)
 			})
 
-			It("should return an error if any Components fail to Start", func(done Done) {
+			It("should return an error if any Components fail to Start", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -786,11 +763,9 @@ var _ = Describe("manger.Manager", func() {
 				err = m.Start(ctx)
 				Expect(err).ToNot(BeNil())
 				Expect(err.Error()).To(Equal("expected error"))
-
-				close(done)
 			})
 
-			It("should wait for runnables to stop", func(done Done) {
+			It("should wait for runnables to stop", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -840,10 +815,9 @@ var _ = Describe("manger.Manager", func() {
 				cancel()
 
 				wgManagerRunning.Wait()
-				close(done)
 			})
 
-			It("should return an error if any Components fail to Start and wait for runnables to stop", func(done Done) {
+			It("should return an error if any Components fail to Start and wait for runnables to stop", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -875,11 +849,9 @@ var _ = Describe("manger.Manager", func() {
 				defer cancel()
 				Expect(m.Start(ctx)).To(HaveOccurred())
 				Expect(runnableDoneCount).To(Equal(2))
-
-				close(done)
 			})
 
-			It("should refuse to add runnable if stop procedure is already engaged", func(done Done) {
+			It("should refuse to add runnable if stop procedure is already engaged", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -907,11 +879,9 @@ var _ = Describe("manger.Manager", func() {
 					defer GinkgoRecover()
 					return nil
 				}))).NotTo(Succeed())
-
-				close(done)
 			})
 
-			It("should return both runnables and stop errors when both error", func(done Done) {
+			It("should return both runnables and stop errors when both error", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -942,11 +912,9 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err.Error()).To(Equal(eMsg))
 				Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 				Expect(errors.Is(err, runnableError{})).To(BeTrue())
-
-				close(done)
 			})
 
-			It("should return only stop errors if runnables dont error", func(done Done) {
+			It("should return only stop errors if runnables dont error", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -982,11 +950,9 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err.Error()).To(Equal("failed waiting for all runnables to end within grace period of 1ns: context deadline exceeded"))
 				Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
 				Expect(errors.Is(err, runnableError{})).ToNot(BeTrue())
-
-				close(done)
 			})
 
-			It("should return only runnables error if stop doesn't error", func(done Done) {
+			It("should return only runnables error if stop doesn't error", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -1002,11 +968,9 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err.Error()).To(Equal("not feeling like that"))
 				Expect(errors.Is(err, context.DeadlineExceeded)).ToNot(BeTrue())
 				Expect(errors.Is(err, runnableError{})).To(BeTrue())
-
-				close(done)
 			})
 
-			It("should not wait for runnables if gracefulShutdownTimeout is 0", func(done Done) {
+			It("should not wait for runnables if gracefulShutdownTimeout is 0", func() {
 				m, err := New(cfg, options)
 				Expect(err).NotTo(HaveOccurred())
 				for _, cb := range callbacks {
@@ -1033,7 +997,6 @@ var _ = Describe("manger.Manager", func() {
 
 				<-managerStopDone
 				<-runnableStopped
-				close(done)
 			})
 
 		}
@@ -1079,7 +1042,7 @@ var _ = Describe("manger.Manager", func() {
 				}
 			})
 
-			It("should stop serving metrics when stop is called", func(done Done) {
+			It("should stop serving metrics when stop is called", func() {
 				opts.MetricsBindAddress = ":0"
 				m, err := New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -1088,7 +1051,6 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
-					close(done)
 				}()
 
 				// Check the metrics started
@@ -1106,7 +1068,7 @@ var _ = Describe("manger.Manager", func() {
 				}).ShouldNot(Succeed())
 			})
 
-			It("should serve metrics endpoint", func(done Done) {
+			It("should serve metrics endpoint", func() {
 				opts.MetricsBindAddress = ":0"
 				m, err := New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -1116,7 +1078,6 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
-					close(done)
 				}()
 
 				metricsEndpoint := fmt.Sprintf("http://%s/metrics", listener.Addr().String())
@@ -1125,7 +1086,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(resp.StatusCode).To(Equal(200))
 			})
 
-			It("should not serve anything other than metrics endpoint by default", func(done Done) {
+			It("should not serve anything other than metrics endpoint by default", func() {
 				opts.MetricsBindAddress = ":0"
 				m, err := New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -1135,7 +1096,6 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
-					close(done)
 				}()
 
 				endpoint := fmt.Sprintf("http://%s/should-not-exist", listener.Addr().String())
@@ -1144,7 +1104,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(resp.StatusCode).To(Equal(404))
 			})
 
-			It("should serve metrics in its registry", func(done Done) {
+			It("should serve metrics in its registry", func() {
 				one := prometheus.NewCounter(prometheus.CounterOpts{
 					Name: "test_one",
 					Help: "test metric for testing",
@@ -1162,7 +1122,6 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
-					close(done)
 				}()
 
 				metricsEndpoint := fmt.Sprintf("http://%s/metrics", listener.Addr().String())
@@ -1183,7 +1142,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(ok).To(BeTrue())
 			})
 
-			It("should serve extra endpoints", func(done Done) {
+			It("should serve extra endpoints", func() {
 				opts.MetricsBindAddress = ":0"
 				m, err := New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
@@ -1204,7 +1163,6 @@ var _ = Describe("manger.Manager", func() {
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
-					close(done)
 				}()
 
 				endpoint := fmt.Sprintf("http://%s/debug", listener.Addr().String())
@@ -1240,7 +1198,7 @@ var _ = Describe("manger.Manager", func() {
 			}
 		})
 
-		It("should stop serving health probes when stop is called", func(done Done) {
+		It("should stop serving health probes when stop is called", func() {
 			opts.HealthProbeBindAddress = ":0"
 			m, err := New(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -1249,7 +1207,6 @@ var _ = Describe("manger.Manager", func() {
 			go func() {
 				defer GinkgoRecover()
 				Expect(m.Start(ctx)).NotTo(HaveOccurred())
-				close(done)
 			}()
 
 			// Check the health probes started
@@ -1267,7 +1224,7 @@ var _ = Describe("manger.Manager", func() {
 			}).ShouldNot(Succeed())
 		})
 
-		It("should serve readiness endpoint", func(done Done) {
+		It("should serve readiness endpoint", func() {
 			opts.HealthProbeBindAddress = ":0"
 			m, err := New(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -1282,7 +1239,6 @@ var _ = Describe("manger.Manager", func() {
 			go func() {
 				defer GinkgoRecover()
 				Expect(m.Start(ctx)).NotTo(HaveOccurred())
-				close(done)
 			}()
 
 			readinessEndpoint := fmt.Sprint("http://", listener.Addr().String(), defaultReadinessEndpoint)
@@ -1318,7 +1274,7 @@ var _ = Describe("manger.Manager", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		})
 
-		It("should serve liveness endpoint", func(done Done) {
+		It("should serve liveness endpoint", func() {
 			opts.HealthProbeBindAddress = ":0"
 			m, err := New(cfg, opts)
 			Expect(err).NotTo(HaveOccurred())
@@ -1333,7 +1289,6 @@ var _ = Describe("manger.Manager", func() {
 			go func() {
 				defer GinkgoRecover()
 				Expect(m.Start(ctx)).NotTo(HaveOccurred())
-				close(done)
 			}()
 
 			livenessEndpoint := fmt.Sprint("http://", listener.Addr().String(), defaultLivenessEndpoint)
@@ -1372,7 +1327,7 @@ var _ = Describe("manger.Manager", func() {
 
 	Describe("Add", func() {
 		It("should immediately start the Component if the Manager has already Started another Component",
-			func(done Done) {
+			func() {
 				m, err := New(cfg, Options{})
 				Expect(err).NotTo(HaveOccurred())
 				mgr, ok := m.(*controllerManager)
@@ -1409,11 +1364,9 @@ var _ = Describe("manger.Manager", func() {
 				}))).To(Succeed())
 				<-c1
 				<-c2
-
-				close(done)
 			})
 
-		It("should immediately start the Component if the Manager has already Started", func(done Done) {
+		It("should immediately start the Component if the Manager has already Started", func() {
 			m, err := New(cfg, Options{})
 			Expect(err).NotTo(HaveOccurred())
 			mgr, ok := m.(*controllerManager)
@@ -1440,8 +1393,6 @@ var _ = Describe("manger.Manager", func() {
 				return nil
 			}))).To(Succeed())
 			<-c1
-
-			close(done)
 		})
 
 		It("should fail if SetFields fails", func() {
@@ -1451,7 +1402,7 @@ var _ = Describe("manger.Manager", func() {
 		})
 	})
 	Describe("SetFields", func() {
-		It("should inject field values", func(done Done) {
+		It("should inject field values", func() {
 			m, err := New(cfg, Options{
 				NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
 					return &informertest.FakeInformers{}, nil
@@ -1543,7 +1494,6 @@ var _ = Describe("manger.Manager", func() {
 				},
 			})
 			Expect(err).To(Equal(expected))
-			close(done)
 		})
 	})
 

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Predicate", func() {
 			},
 		}
 
-		It("should call Create", func(done Done) {
+		It("should call Create", func() {
 			instance := failingFuncs
 			instance.CreateFunc = func(evt event.CreateEvent) bool {
 				defer GinkgoRecover()
@@ -80,10 +80,9 @@ var _ = Describe("Predicate", func() {
 
 			instance.CreateFunc = nil
 			Expect(instance.Create(evt)).To(BeTrue())
-			close(done)
 		})
 
-		It("should call Update", func(done Done) {
+		It("should call Update", func() {
 			newPod := pod.DeepCopy()
 			newPod.Name = "baz2"
 			newPod.Namespace = "biz2"
@@ -111,10 +110,9 @@ var _ = Describe("Predicate", func() {
 
 			instance.UpdateFunc = nil
 			Expect(instance.Update(evt)).To(BeTrue())
-			close(done)
 		})
 
-		It("should call Delete", func(done Done) {
+		It("should call Delete", func() {
 			instance := failingFuncs
 			instance.DeleteFunc = func(evt event.DeleteEvent) bool {
 				defer GinkgoRecover()
@@ -135,10 +133,9 @@ var _ = Describe("Predicate", func() {
 
 			instance.DeleteFunc = nil
 			Expect(instance.Delete(evt)).To(BeTrue())
-			close(done)
 		})
 
-		It("should call Generic", func(done Done) {
+		It("should call Generic", func() {
 			instance := failingFuncs
 			instance.GenericFunc = func(evt event.GenericEvent) bool {
 				defer GinkgoRecover()
@@ -159,7 +156,6 @@ var _ = Describe("Predicate", func() {
 
 			instance.GenericFunc = nil
 			Expect(instance.Generic(evt)).To(BeTrue())
-			close(done)
 		})
 	})
 

--- a/pkg/source/internal/internal_test.go
+++ b/pkg/source/internal/internal_test.go
@@ -91,17 +91,16 @@ var _ = Describe("Internal", func() {
 			newPod.Labels = map[string]string{"foo": "bar"}
 		})
 
-		It("should create a CreateEvent", func(done Done) {
+		It("should create a CreateEvent", func() {
 			funcs.CreateFunc = func(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
 				Expect(evt.Object).To(Equal(pod))
 			}
 			instance.OnAdd(pod)
-			close(done)
 		})
 
-		It("should used Predicates to filter CreateEvents", func(done Done) {
+		It("should used Predicates to filter CreateEvents", func() {
 			instance = internal.EventHandler{
 				Queue:        controllertest.Queue{},
 				EventHandler: setfuncs,
@@ -144,21 +143,17 @@ var _ = Describe("Internal", func() {
 			}
 			instance.OnAdd(pod)
 			Expect(set).To(BeTrue())
-
-			close(done)
 		})
 
-		It("should not call Create EventHandler if the object is not a runtime.Object", func(done Done) {
+		It("should not call Create EventHandler if the object is not a runtime.Object", func() {
 			instance.OnAdd(&metav1.ObjectMeta{})
-			close(done)
 		})
 
-		It("should not call Create EventHandler if the object does not have metadata", func(done Done) {
+		It("should not call Create EventHandler if the object does not have metadata", func() {
 			instance.OnAdd(FooRuntimeObject{})
-			close(done)
 		})
 
-		It("should create an UpdateEvent", func(done Done) {
+		It("should create an UpdateEvent", func() {
 			funcs.UpdateFunc = func(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
@@ -167,10 +162,9 @@ var _ = Describe("Internal", func() {
 				Expect(evt.ObjectNew).To(Equal(newPod))
 			}
 			instance.OnUpdate(pod, newPod)
-			close(done)
 		})
 
-		It("should used Predicates to filter UpdateEvents", func(done Done) {
+		It("should used Predicates to filter UpdateEvents", func() {
 			instance = internal.EventHandler{
 				Queue:        controllertest.Queue{},
 				EventHandler: setfuncs,
@@ -213,23 +207,19 @@ var _ = Describe("Internal", func() {
 			}
 			instance.OnUpdate(pod, newPod)
 			Expect(set).To(BeTrue())
-
-			close(done)
 		})
 
-		It("should not call Update EventHandler if the object is not a runtime.Object", func(done Done) {
+		It("should not call Update EventHandler if the object is not a runtime.Object", func() {
 			instance.OnUpdate(&metav1.ObjectMeta{}, &corev1.Pod{})
 			instance.OnUpdate(&corev1.Pod{}, &metav1.ObjectMeta{})
-			close(done)
 		})
 
-		It("should not call Update EventHandler if the object does not have metadata", func(done Done) {
+		It("should not call Update EventHandler if the object does not have metadata", func() {
 			instance.OnUpdate(FooRuntimeObject{}, &corev1.Pod{})
 			instance.OnUpdate(&corev1.Pod{}, FooRuntimeObject{})
-			close(done)
 		})
 
-		It("should create a DeleteEvent", func(done Done) {
+		It("should create a DeleteEvent", func() {
 			funcs.DeleteFunc = func(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(q).To(Equal(instance.Queue))
@@ -237,10 +227,9 @@ var _ = Describe("Internal", func() {
 				Expect(evt.Object).To(Equal(pod))
 			}
 			instance.OnDelete(pod)
-			close(done)
 		})
 
-		It("should used Predicates to filter DeleteEvents", func(done Done) {
+		It("should used Predicates to filter DeleteEvents", func() {
 			instance = internal.EventHandler{
 				Queue:        controllertest.Queue{},
 				EventHandler: setfuncs,
@@ -283,21 +272,17 @@ var _ = Describe("Internal", func() {
 			}
 			instance.OnDelete(pod)
 			Expect(set).To(BeTrue())
-
-			close(done)
 		})
 
-		It("should not call Delete EventHandler if the object is not a runtime.Object", func(done Done) {
+		It("should not call Delete EventHandler if the object is not a runtime.Object", func() {
 			instance.OnDelete(&metav1.ObjectMeta{})
-			close(done)
 		})
 
-		It("should not call Delete EventHandler if the object does not have metadata", func(done Done) {
+		It("should not call Delete EventHandler if the object does not have metadata", func() {
 			instance.OnDelete(FooRuntimeObject{})
-			close(done)
 		})
 
-		It("should create a DeleteEvent from a tombstone", func(done Done) {
+		It("should create a DeleteEvent from a tombstone", func() {
 
 			tombstone := cache.DeletedFinalStateUnknown{
 				Obj: pod,
@@ -309,19 +294,16 @@ var _ = Describe("Internal", func() {
 			}
 
 			instance.OnDelete(tombstone)
-			close(done)
 		})
 
-		It("should ignore tombstone objects without meta", func(done Done) {
+		It("should ignore tombstone objects without meta", func() {
 			tombstone := cache.DeletedFinalStateUnknown{Obj: Foo{}}
 			instance.OnDelete(tombstone)
-			close(done)
 		})
-		It("should ignore objects without meta", func(done Done) {
+		It("should ignore objects without meta", func() {
 			instance.OnAdd(Foo{})
 			instance.OnUpdate(Foo{}, Foo{})
 			instance.OnDelete(Foo{})
-			close(done)
 		})
 	})
 })

--- a/pkg/source/source_suite_test.go
+++ b/pkg/source/source_suite_test.go
@@ -44,7 +44,7 @@ var icache cache.Cache
 var ctx context.Context
 var cancel context.CancelFunc
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
@@ -64,13 +64,9 @@ var _ = BeforeSuite(func(done Done) {
 		defer GinkgoRecover()
 		Expect(icache.Start(ctx)).NotTo(HaveOccurred())
 	}()
-
-	close(done)
 }, 60)
 
-var _ = AfterSuite(func(done Done) {
+var _ = AfterSuite(func() {
 	cancel()
 	Expect(testenv.Stop()).To(Succeed())
-
-	close(done)
 }, 5)

--- a/pkg/webhook/admission/admission_suite_test.go
+++ b/pkg/webhook/admission/admission_suite_test.go
@@ -33,8 +33,6 @@ func TestAdmissionWebhook(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	close(done)
 }, 60)

--- a/pkg/webhook/authentication/authentication_suite_test.go
+++ b/pkg/webhook/authentication/authentication_suite_test.go
@@ -33,8 +33,6 @@ func TestAuthenticationWebhook(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	close(done)
 }, 60)

--- a/pkg/webhook/conversion/conversion_suite_test.go
+++ b/pkg/webhook/conversion/conversion_suite_test.go
@@ -32,8 +32,6 @@ func TestConversionWebhook(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, suiteName, []Reporter{printer.NewlineReporter{}, printer.NewProwReporter(suiteName)})
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
-
-	close(done)
 })

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Webhook", func() {
 		}
 	})
 	Context("when running a webhook server with a manager", func() {
-		It("should reject create request for webhook that rejects all requests", func(done Done) {
+		It("should reject create request for webhook that rejects all requests", func() {
 			m, err := manager.New(cfg, manager.Options{
 				Port:    testenv.WebhookInstallOptions.LocalServingPort,
 				Host:    testenv.WebhookInstallOptions.LocalServingHost,
@@ -101,9 +101,8 @@ var _ = Describe("Webhook", func() {
 			}, 1*time.Second).Should(BeTrue())
 
 			cancel()
-			close(done)
 		})
-		It("should reject create request for multi-webhook that rejects all requests", func(done Done) {
+		It("should reject create request for multi-webhook that rejects all requests", func() {
 			m, err := manager.New(cfg, manager.Options{
 				Port:    testenv.WebhookInstallOptions.LocalServingPort,
 				Host:    testenv.WebhookInstallOptions.LocalServingHost,
@@ -125,11 +124,10 @@ var _ = Describe("Webhook", func() {
 			}, 1*time.Second).Should(BeTrue())
 
 			cancel()
-			close(done)
 		})
 	})
 	Context("when running a webhook server without a manager", func() {
-		It("should reject create request for webhook that rejects all requests", func(done Done) {
+		It("should reject create request for webhook that rejects all requests", func() {
 			server := webhook.Server{
 				Port:    testenv.WebhookInstallOptions.LocalServingPort,
 				Host:    testenv.WebhookInstallOptions.LocalServingHost,
@@ -149,11 +147,10 @@ var _ = Describe("Webhook", func() {
 			}, 1*time.Second).Should(BeTrue())
 
 			cancel()
-			close(done)
 		})
 	})
 	Context("when running a standalone webhook", func() {
-		It("should reject create request for webhook that rejects all requests", func(done Done) {
+		It("should reject create request for webhook that rejects all requests", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 
 			By("generating the TLS config")
@@ -206,7 +203,6 @@ var _ = Describe("Webhook", func() {
 			}, 1*time.Second).Should(BeTrue())
 
 			cancel()
-			close(done)
 		})
 	})
 })

--- a/pkg/webhook/webhook_suite_test.go
+++ b/pkg/webhook/webhook_suite_test.go
@@ -42,7 +42,7 @@ func TestSource(t *testing.T) {
 var testenv *envtest.Environment
 var cfg *rest.Config
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
@@ -51,7 +51,6 @@ var _ = BeforeSuite(func(done Done) {
 	var err error
 	cfg, err = testenv.Start()
 	Expect(err).NotTo(HaveOccurred())
-	close(done)
 }, 60)
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
Ginkgo has deprecated async tests with channels, and given that we're
not really using those properly or consistently, remove them from
controller runtime and simplify our tests.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
