### PR TITLE
🌱  Pass Object's GVK version when reconcile.

### DIFF
--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -41,25 +41,34 @@ func (e *EnqueueRequestForObject) Create(evt event.CreateEvent, q workqueue.Rate
 		enqueueLog.Error(nil, "CreateEvent received with no metadata", "event", evt)
 		return
 	}
-	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-		Name:      evt.Object.GetName(),
-		Namespace: evt.Object.GetNamespace(),
-	}})
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Object.GetName(),
+			Namespace: evt.Object.GetNamespace(),
+		},
+		GroupVersionKind: evt.Object.GetObjectKind().GroupVersionKind(),
+	})
 }
 
 // Update implements EventHandler.
 func (e *EnqueueRequestForObject) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
 	switch {
 	case evt.ObjectNew != nil:
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-			Name:      evt.ObjectNew.GetName(),
-			Namespace: evt.ObjectNew.GetNamespace(),
-		}})
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      evt.ObjectNew.GetName(),
+				Namespace: evt.ObjectNew.GetNamespace(),
+			},
+			GroupVersionKind: evt.ObjectNew.GetObjectKind().GroupVersionKind(),
+		})
 	case evt.ObjectOld != nil:
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-			Name:      evt.ObjectOld.GetName(),
-			Namespace: evt.ObjectOld.GetNamespace(),
-		}})
+		q.Add(reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      evt.ObjectOld.GetName(),
+				Namespace: evt.ObjectOld.GetNamespace(),
+			},
+			GroupVersionKind: evt.ObjectOld.GetObjectKind().GroupVersionKind(),
+		})
 	default:
 		enqueueLog.Error(nil, "UpdateEvent received with no metadata", "event", evt)
 	}
@@ -71,10 +80,13 @@ func (e *EnqueueRequestForObject) Delete(evt event.DeleteEvent, q workqueue.Rate
 		enqueueLog.Error(nil, "DeleteEvent received with no metadata", "event", evt)
 		return
 	}
-	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-		Name:      evt.Object.GetName(),
-		Namespace: evt.Object.GetNamespace(),
-	}})
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Object.GetName(),
+			Namespace: evt.Object.GetNamespace(),
+		},
+		GroupVersionKind: evt.Object.GetObjectKind().GroupVersionKind(),
+	})
 }
 
 // Generic implements EventHandler.
@@ -83,8 +95,11 @@ func (e *EnqueueRequestForObject) Generic(evt event.GenericEvent, q workqueue.Ra
 		enqueueLog.Error(nil, "GenericEvent received with no metadata", "event", evt)
 		return
 	}
-	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
-		Name:      evt.Object.GetName(),
-		Namespace: evt.Object.GetNamespace(),
-	}})
+	q.Add(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      evt.Object.GetName(),
+			Namespace: evt.Object.GetNamespace(),
+		},
+		GroupVersionKind: evt.Object.GetObjectKind().GroupVersionKind(),
+	})
 }

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -134,9 +134,16 @@ func (e *EnqueueRequestForOwner) getOwnerReconcileRequest(object metav1.Object, 
 		// object in the event.
 		if ref.Kind == e.groupKind.Kind && refGV.Group == e.groupKind.Group {
 			// Match found - add a Request for the object referred to in the OwnerReference
-			request := reconcile.Request{NamespacedName: types.NamespacedName{
-				Name: ref.Name,
-			}}
+			request := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name: ref.Name,
+				},
+				GroupVersionKind: schema.GroupVersionKind{
+					Group:   refGV.Group,
+					Version: refGV.Version,
+					Kind:    ref.Kind,
+				},
+			}
 
 			// if owner is not namespaced then we should set the namespace to the empty
 			mapping, err := e.mapper.RESTMapping(e.groupKind, refGV.Version)

--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -47,6 +48,7 @@ func (r *Result) IsZero() bool {
 type Request struct {
 	// NamespacedName is the name and namespace of the object to reconcile.
 	types.NamespacedName
+	schema.GroupVersionKind
 }
 
 /*


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

This PR tries to pass the Object's GVK info when reconciling resources in the controller. This would be helpful when the controller is watching multiple resources.

e.g. Suppose we have a CRD `PodHealthySet`, which status contains `ReadyPods` as a counter to record how many `Pod`s are healthy under a specific selector.

In our `PodHealthySet Controller`, we watch `PodHealthySet` and `Pod` resources together.
When Pod healthy status changed, we would like to update `PodHealthySet.Status.ReadyPods`.

If we use `EnqueueRequestsFromMapFunc`, to count `PodHealthySet.Status.ReadyPods`, request chain is

1. Find all matched `PodHealthySet` for a specific `Pod` in `EnqueueRequestsFromMapFunc`, then we enqueue `PodHealthySet` reconcile request.
2. Go through all Pods in `PodHealthySet.Reconcile`, and calculate `ReadyPods`. => This would become slower as more and more `Pod` and `PodHealthySet` objects.

If we support pass object's GVK when reconcile, we could identify reconcile from which kind of object, and then don't need the slow Step 2 above.