### PR TITLE
[WIP] :sparkles: Add GVKCaches and DynamicMultiNamespaceCache

### DIFF
--- a/pkg/cache/dynamic_multi_namespace_cache.go
+++ b/pkg/cache/dynamic_multi_namespace_cache.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DynamicMultiNamespacedCacheBuilder - Builder function to create a new dynamic
+// multi-namespaced cache. Listing for all namespaces from the namespaces that
+// were previously used in gets and namespace-scoped lists.
+//
+// This is useful if you expect your controller a) to have limited list/watch
+// permissions (i.e. not cluster-scoped) and b) to dynamically handle receiving
+// permissions on a new namespace.
+//
+// Note that you may face performance issues when using this with a high number
+// of namespaces.
+func DynamicMultiNamespacedCacheBuilder() NewCacheFunc {
+	return func(config *rest.Config, opts Options) (Cache, error) {
+		opts, err := defaultOpts(config, opts)
+		if err != nil {
+			return nil, err
+		}
+		return &dynamicMultiNamespaceCache{
+			restConfig: config,
+			opts:       opts,
+			cache: &multiNamespaceCache{
+				namespaceToCache: map[string]Cache{},
+				Scheme:           opts.Scheme,
+			},
+		}, nil
+	}
+}
+
+// dynamicMultiNamespaceCache knows how to handle multiple namespaced caches
+// Use this feature when scoping permissions for your
+// operator to a list of namespaces instead of watching every namespace
+// in the cluster.
+type dynamicMultiNamespaceCache struct {
+	restConfig *rest.Config
+	opts       Options
+
+	cache *multiNamespaceCache
+	m     sync.RWMutex
+
+	started bool
+	stopCtx context.Context
+}
+
+var _ Cache = &dynamicMultiNamespaceCache{}
+
+func (c *dynamicMultiNamespaceCache) getOrCreateCache(ctx context.Context, namespace string) (Cache, error) {
+	if cache, ok := c.caches()[namespace]; ok {
+		return cache, nil
+	}
+
+	opts := c.opts
+	opts.Namespace = namespace
+	nsCache, err := New(c.restConfig, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	c.m.Lock()
+	defer c.m.Unlock()
+	if c.started {
+		go nsCache.Start(c.stopCtx)
+		if !nsCache.WaitForCacheSync(ctx) {
+			return nil, fmt.Errorf("failed to sync cache for namespace %q\n", namespace)
+		}
+	}
+	c.cache.namespaceToCache[namespace] = nsCache
+	return nsCache, nil
+}
+
+func (c *dynamicMultiNamespaceCache) caches() map[string]Cache {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	caches := make(map[string]Cache, len(c.cache.namespaceToCache))
+	for k, v := range c.cache.namespaceToCache {
+		caches[k] = v
+	}
+	return caches
+}
+
+// Methods for dynamicMultiNamespaceCache to conform to the Informers interface
+func (c *dynamicMultiNamespaceCache) GetInformer(ctx context.Context, obj client.Object) (Informer, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.cache.GetInformer(ctx, obj)
+}
+
+func (c *dynamicMultiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error) {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.cache.GetInformerForKind(ctx, gvk)
+}
+
+func (c *dynamicMultiNamespaceCache) Start(ctx context.Context) error {
+	func() {
+		c.m.Lock()
+		defer c.m.Unlock()
+
+		// Set the stop channel so it can be passed to informers that are added later
+		c.stopCtx = ctx
+
+		go c.cache.Start(ctx)
+
+		// Set started to true so we immediately start any informers added later.
+		c.started = true
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+func (c *dynamicMultiNamespaceCache) WaitForCacheSync(ctx context.Context) bool {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.cache.WaitForCacheSync(ctx)
+}
+
+func (c *dynamicMultiNamespaceCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	c.m.RLock()
+	defer c.m.RUnlock()
+	return c.cache.IndexField(ctx, obj, field, extractValue)
+}
+
+func (c *dynamicMultiNamespaceCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	cache, err := c.getOrCreateCache(ctx, key.Namespace)
+	if err != nil {
+		return err
+	}
+	return cache.Get(ctx, key, obj)
+}
+
+// List dynamic multi namespace cache will get all the objects in the namespaces that the cache is watching if asked for all namespaces.
+func (c *dynamicMultiNamespaceCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	listOpts := client.ListOptions{}
+	listOpts.ApplyOptions(opts)
+	if listOpts.Namespace != corev1.NamespaceAll {
+		nsCache, err := c.getOrCreateCache(ctx, listOpts.Namespace)
+		if err != nil {
+			return err
+		}
+		nsCache.List(ctx, list, opts...)
+	}
+	return c.cache.List(ctx, list, opts...)
+}

--- a/pkg/cache/gvk_caches.go
+++ b/pkg/cache/gvk_caches.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+type GVKCachesOptions struct {
+	ObjectCacheFuncs map[client.Object]NewCacheFunc
+	DefaultCacheFunc NewCacheFunc
+}
+
+// GVKCachesBuilder - Builder function to create a new composite cache which contains
+// one or more caches based on a mapping of GVKs. Each GVK can be configured to
+// use a separate cache.
+func GVKCachesBuilder(gvkCachesOpts GVKCachesOptions) NewCacheFunc {
+	return func(config *rest.Config, opts Options) (Cache, error) {
+		opts, err := defaultOpts(config, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		if gvkCachesOpts.DefaultCacheFunc == nil {
+			gvkCachesOpts.DefaultCacheFunc = New
+		}
+		defaultCache, err := gvkCachesOpts.DefaultCacheFunc(config, opts)
+		if err != nil {
+			return nil, err
+		}
+
+		gvkToCache := map[schema.GroupVersionKind]Cache{}
+		for obj, newCacheFunc := range gvkCachesOpts.ObjectCacheFuncs {
+			gvk, err := apiutil.GVKForObject(obj, opts.Scheme)
+			if err != nil {
+				return nil, err
+			}
+			gvkToCache[gvk], err = newCacheFunc(config, opts)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		return &gvkCaches{
+			gvkToCache:   gvkToCache,
+			defaultCache: defaultCache,
+			scheme:       opts.Scheme,
+		}, nil
+	}
+}
+
+type gvkCaches struct {
+	gvkToCache   map[schema.GroupVersionKind]Cache
+	defaultCache Cache
+
+	scheme *runtime.Scheme
+}
+
+func (c *gvkCaches) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	if cache, ok := c.gvkToCache[gvk]; ok {
+		return cache.Get(ctx, key, obj)
+	}
+
+	return c.defaultCache.Get(ctx, key, obj)
+}
+
+func (c *gvkCaches) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(list, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasSuffix(gvk.Kind, "List") {
+		return fmt.Errorf("non-list type %T (kind %q) passed as output", list, gvk)
+	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
+
+	if cache, ok := c.gvkToCache[gvk]; ok {
+		return cache.List(ctx, list, opts...)
+	}
+	return c.defaultCache.List(ctx, list, opts...)
+}
+
+func (c *gvkCaches) GetInformer(ctx context.Context, obj client.Object) (Informer, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	if cache, ok := c.gvkToCache[gvk]; ok {
+		return cache.GetInformer(ctx, obj)
+	}
+
+	return c.defaultCache.GetInformer(ctx, obj)
+}
+
+func (c *gvkCaches) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (Informer, error) {
+	if cache, ok := c.gvkToCache[gvk]; ok {
+		return cache.GetInformerForKind(ctx, gvk)
+	}
+
+	return c.defaultCache.GetInformerForKind(ctx, gvk)
+}
+
+func (c *gvkCaches) Start(ctx context.Context) error {
+	for gvk, cache := range c.gvkToCache {
+		go func(gvk schema.GroupVersionKind, cache Cache) {
+			err := cache.Start(ctx)
+			if err != nil {
+				log.Error(err, "gvk cache failed to start", "gvk", gvk)
+			}
+		}(gvk, cache)
+	}
+	go func() {
+		err := c.defaultCache.Start(ctx)
+		if err != nil {
+			log.Error(err, "default cache failed to start")
+		}
+	}()
+	<-ctx.Done()
+	return nil
+}
+
+func (c *gvkCaches) WaitForCacheSync(ctx context.Context) bool {
+	synced := true
+	for _, cache := range c.gvkToCache {
+		if s := cache.WaitForCacheSync(ctx); !s {
+			synced = synced && s
+		}
+	}
+	return synced && c.defaultCache.WaitForCacheSync(ctx)
+}
+
+func (c *gvkCaches) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, c.scheme)
+	if err != nil {
+		return err
+	}
+
+	if cache, ok := c.gvkToCache[gvk]; ok {
+		return cache.IndexField(ctx, obj, field, extractValue)
+	}
+
+	return c.defaultCache.IndexField(ctx, obj, field, extractValue)
+}


### PR DESCRIPTION
Fixes #1590 

We have operators that are moving from namespace scoped to cluster scoped. An operator uses caches for dependent resources, these caches are usually spun up with list/watchers for those resources using controller-runtime pattern at startup.

If the operator is started with access only to the owned CRDs to start and not given all of the required permissions at startup. The caches will not have the dependent resources and when the admin grants permissions later the caches will not be able to react to the change.

The operator would need access to a cache that can handle dynamically changing permissions.