### PR TITLE
:book: Update doc.go

### DIFF
--- a/pkg/builder/doc.go
+++ b/pkg/builder/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package builder provides wraps other controller-runtime libraries and exposes simple
+// Package builder wraps other controller-runtime libraries and exposes simple
 // patterns for building common Controllers.
 //
 // Projects built with the builder package can trivially be rebased on top of the underlying


### PR DESCRIPTION
Rewording.

This corrects the info about builder package. It is needed to remove unnecessary word which causes confusion.