### PR TITLE
✨   make it possible to monitor if the webhook server has been started

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -28,10 +28,12 @@ import (
 	"path/filepath"
 	"strconv"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics"
 )
@@ -86,6 +88,10 @@ type Server struct {
 
 	// defaultingOnce ensures that the default fields are only ever set once.
 	defaultingOnce sync.Once
+
+	// started is set to true immediately before the server is started
+	// and thus can be used to check if the server has been started
+	started bool
 
 	// mu protects access to the webhook map & setFields for Start, Register, etc
 	mu sync.Mutex
@@ -272,12 +278,36 @@ func (s *Server) Start(ctx context.Context) error {
 		close(idleConnsClosed)
 	}()
 
+	s.mu.Lock()
+	s.started = true
+	s.mu.Unlock()
 	if err := srv.Serve(listener); err != nil && err != http.ErrServerClosed {
 		return err
 	}
 
 	<-idleConnsClosed
 	return nil
+}
+
+// StartedChecker returns an healthz.Checker which is healthy after the
+// server has been started.
+func (s *Server) StartedChecker() healthz.Checker {
+	return func(req *http.Request) error {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+
+		if !s.started {
+			return fmt.Errorf("webhook server has not been started yet")
+		}
+
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)), 10*time.Second)
+		if err != nil {
+			return fmt.Errorf("webhook server is not reachable: %v", err)
+		}
+		conn.Close()
+
+		return nil
+	}
 }
 
 // InjectFunc injects the field setter into the server.

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -128,6 +128,8 @@ var _ = Describe("Webhook Server", func() {
 		It("should serve a webhook on the requested path", func() {
 			server.Register("/somepath", &testHandler{})
 
+			Expect(server.StartedChecker()(nil)).ToNot(Succeed())
+
 			doneCh := startServer()
 
 			Eventually(func() ([]byte, error) {
@@ -136,6 +138,8 @@ var _ = Describe("Webhook Server", func() {
 				defer resp.Body.Close()
 				return ioutil.ReadAll(resp.Body)
 			}).Should(Equal([]byte("gadzooks!")))
+
+			Expect(server.StartedChecker()(nil)).To(Succeed())
 
 			ctxCancel()
 			Eventually(doneCh, "4s").Should(BeClosed())


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Cherry-pick of #1588