### PR TITLE
✨Restrict namespace for list/watch based on field selectors

### DIFF
--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -274,8 +274,9 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			ip.selectors[gvk].ApplyToList(&opts)
 			res := listObj.DeepCopyObject()
-			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
-			err := client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			isNamespaceScoped := namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
+			err := client.Get().NamespaceIfScoped(namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
 			return res, err
 		},
 		// Setup the watch function
@@ -283,8 +284,9 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 			ip.selectors[gvk].ApplyToList(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
-			isNamespaceScoped := ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
-			return client.Get().NamespaceIfScoped(ip.namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Watch(ctx)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			isNamespaceScoped := namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
+			return client.Get().NamespaceIfScoped(namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Watch(ctx)
 		},
 	}, nil
 }
@@ -313,8 +315,9 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			ip.selectors[gvk].ApplyToList(&opts)
-			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
-				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			if namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return dynamicClient.Resource(mapping.Resource).Namespace(namespace).List(ctx, opts)
 			}
 			return dynamicClient.Resource(mapping.Resource).List(ctx, opts)
 		},
@@ -323,8 +326,9 @@ func createUnstructuredListWatch(gvk schema.GroupVersionKind, ip *specificInform
 			ip.selectors[gvk].ApplyToList(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
-			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
-				return dynamicClient.Resource(mapping.Resource).Namespace(ip.namespace).Watch(ctx, opts)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			if namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return dynamicClient.Resource(mapping.Resource).Namespace(namespace).Watch(ctx, opts)
 			}
 			return dynamicClient.Resource(mapping.Resource).Watch(ctx, opts)
 		},
@@ -358,8 +362,9 @@ func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersM
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
 			ip.selectors[gvk].ApplyToList(&opts)
-			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
-				return client.Resource(mapping.Resource).Namespace(ip.namespace).List(ctx, opts)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			if namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return client.Resource(mapping.Resource).Namespace(namespace).List(ctx, opts)
 			}
 			return client.Resource(mapping.Resource).List(ctx, opts)
 		},
@@ -368,8 +373,9 @@ func createMetadataListWatch(gvk schema.GroupVersionKind, ip *specificInformersM
 			ip.selectors[gvk].ApplyToList(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
-			if ip.namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
-				return client.Resource(mapping.Resource).Namespace(ip.namespace).Watch(ctx, opts)
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			if namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot {
+				return client.Resource(mapping.Resource).Namespace(namespace).Watch(ctx, opts)
 			}
 			return client.Resource(mapping.Resource).Watch(ctx, opts)
 		},
@@ -385,4 +391,24 @@ func resyncPeriod(resync time.Duration) func() time.Duration {
 		factor := rand.Float64()/5.0 + 0.9 //nolint:gosec
 		return time.Duration(float64(resync.Nanoseconds()) * factor)
 	}
+}
+
+// restrictNamespaceBySelector returns either a global restriction for all ListWatches
+// if not default/empty, or the namespace that a ListWatch for the specific resource
+// is restricted to, based on a specified field selector for metadata.namespace field.
+func restrictNamespaceBySelector(namespaceOpt string, s Selector) string {
+	if namespaceOpt != "" {
+		// namespace is already restricted
+		return namespaceOpt
+	}
+	fieldSelector := s.Field
+	if fieldSelector == nil || fieldSelector.Empty() {
+		return ""
+	}
+	// check whether a selector includes the namespace field
+	value, found := fieldSelector.RequiresExactMatch("metadata.namespace")
+	if found {
+		return value
+	}
+	return ""
 }


### PR DESCRIPTION
Signed-off-by: SHLOMITK@il.ibm.com <shlomitk@il.ibm.com>

Refers to https://github.com/kubernetes-sigs/controller-runtime/issues/244#issuecomment-882808482

This PR creates a namespace-scoped client in ListFunc and WatchFunc if there is a field selector for metadata.namespace and the global namespace is not specified.

