### PR TITLE
🐛 fix the typo of certwatcher example test

### DIFF
--- a/pkg/certwatcher/example_test.go
+++ b/pkg/certwatcher/example_test.go
@@ -32,7 +32,7 @@ func Example() {
 	// Setup Context
 	ctx := ctrl.SetupSignalHandler()
 
-	// Initialize a new cert watcher with cert/key pari
+	// Initialize a new cert watcher with cert/key pair
 	watcher, err := certwatcher.New("ssl/tls.crt", "ssl/tls.key")
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Fix the typo that is in certwatcher package example.