### PR TITLE
✨ Allow TLSMinVersion to be set in Manager configuration

### DIFF
--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -139,6 +139,10 @@ type ControllerWebhook struct {
 	// must be named tls.key and tls.crt, respectively.
 	// +optional
 	CertDir string `json:"certDir,omitempty"`
+
+	// TLSMinVersion is the minimum version of TLS for the webhook server
+	// Defaults to TLS 1.0 if not set.
+	TLSMinVersion string `json:"tlsMinVersion,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -144,6 +144,8 @@ type controllerManager struct {
 	// if not set, webhook server would look up the server key and certificate in
 	// {TempDir}/k8s-webhook-server/serving-certs
 	certDir string
+	// tlsMinVersion is the minimum TLS version that the webhook server will use
+	tlsMinVersion string
 
 	webhookServer *webhook.Server
 	// webhookServerOnce will be called in GetWebhookServer() to optionally initialize
@@ -338,9 +340,10 @@ func (cm *controllerManager) GetWebhookServer() *webhook.Server {
 	cm.webhookServerOnce.Do(func() {
 		if cm.webhookServer == nil {
 			cm.webhookServer = &webhook.Server{
-				Port:    cm.port,
-				Host:    cm.host,
-				CertDir: cm.certDir,
+				Port:          cm.port,
+				Host:          cm.host,
+				CertDir:       cm.certDir,
+				TLSMinVersion: cm.tlsMinVersion,
 			}
 		}
 		if err := cm.Add(cm.webhookServer); err != nil {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -222,6 +222,10 @@ type Options struct {
 	// It is used to set webhook.Server.CertDir if WebhookServer is not set.
 	CertDir string
 
+	// TLSMinVersion is the minimum version of TLS used
+	// If not set the webhook server will default to TLS 1.0
+	TLSMinVersion string
+
 	// WebhookServer is an externally configured webhook.Server. By default,
 	// a Manager will create a default server using Port, Host, and CertDir;
 	// if this is set, the Manager will use this server instead.
@@ -377,6 +381,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		port:                          options.Port,
 		host:                          options.Host,
 		certDir:                       options.CertDir,
+		tlsMinVersion:                 options.TLSMinVersion,
 		webhookServer:                 options.WebhookServer,
 		leaseDuration:                 *options.LeaseDuration,
 		renewDeadline:                 *options.RenewDeadline,
@@ -443,6 +448,10 @@ func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options,
 
 	if o.CertDir == "" && newObj.Webhook.CertDir != "" {
 		o.CertDir = newObj.Webhook.CertDir
+	}
+
+	if o.TLSMinVersion == "" && newObj.Webhook.TLSMinVersion != "" {
+		o.TLSMinVersion = newObj.Webhook.TLSMinVersion
 	}
 
 	if newObj.Controller != nil {


### PR DESCRIPTION
Routines like GetWebhookServer need to have configuration exposed
to be able to set TLS minimum version