### PR TITLE
🐛 fix List method for metadataClient

### DIFF
--- a/pkg/client/metadata_client.go
+++ b/pkg/client/metadata_client.go
@@ -145,7 +145,8 @@ func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...List
 		return fmt.Errorf("metadata client did not understand object: %T", obj)
 	}
 
-	gvk := metadata.GroupVersionKind()
+	listGVK := metadata.GroupVersionKind()
+	gvk := listGVK
 	if strings.HasSuffix(gvk.Kind, "List") {
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
@@ -163,7 +164,7 @@ func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...List
 		return err
 	}
 	*metadata = *res
-	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
+	metadata.SetGroupVersionKind(listGVK) // restore the GVK, which isn't set on metadata
 	return nil
 }
 

--- a/pkg/client/metadata_client_test.go
+++ b/pkg/client/metadata_client_test.go
@@ -1,0 +1,64 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakemetadata "k8s.io/client-go/metadata/fake"
+)
+
+var (
+	testScheme *runtime.Scheme
+	testMapper meta.RESTMapper
+)
+
+func init() {
+	testScheme = runtime.NewScheme()
+	_ = appsv1.AddToScheme(testScheme)
+	_ = metav1.AddMetaToScheme(testScheme)
+
+	testMapper = testrestmapper.TestOnlyStaticRESTMapper(testScheme)
+}
+
+func newPartialObjectMetadata(apiVersion, kind, namespace, name string) *metav1.PartialObjectMetadata {
+	return &metav1.PartialObjectMetadata{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: apiVersion,
+			Kind:       kind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+	}
+}
+
+func TestMetadataClient_list(t *testing.T) {
+	client := fakemetadata.NewSimpleMetadataClient(testScheme,
+		newPartialObjectMetadata(appsv1.SchemeGroupVersion.String(), "Deployment", "default", "deploy1"),
+	)
+	metadataClient := metadataClient{client: client, restMapper: testMapper}
+
+	listGVK := appsv1.SchemeGroupVersion.WithKind("DeploymentList")
+	list := &metav1.PartialObjectMetadataList{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: listGVK.GroupVersion().String(),
+			Kind:       listGVK.Kind,
+		},
+	}
+
+	if err := metadataClient.List(context.TODO(), list); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Errorf("expected items length is 1, got: %v", len(list.Items))
+	}
+	if list.GroupVersionKind() != listGVK {
+		t.Errorf("expected %v, got %v", listGVK, list.GroupVersionKind())
+	}
+}


### PR DESCRIPTION
Signed-off-by: Iceber Gu <wei.cai-nat@daocloud.io>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
I think the `List` method should not modify the `GVK` of the `obj`