### PR TITLE
✨ Allow specifying custom TLS Config for webhooks

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -299,7 +299,12 @@ func (te *Environment) Start() (*rest.Config, error) {
 	te.CRDs = crds
 
 	log.V(1).Info("installing webhooks")
-	if err := te.WebhookInstallOptions.Install(te.Config); err != nil {
+	if te.WebhookInstallOptions.CustomTLSConfig != nil {
+		err = te.WebhookInstallOptions.InstallWithCustomTLS(te.Config)
+	} else {
+		err = te.WebhookInstallOptions.Install(te.Config)
+	}
+	if err != nil {
 		return nil, fmt.Errorf("unable to install webhooks onto control plane: %w", err)
 	}
 	return te.Config, nil

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -18,6 +18,7 @@ package envtest
 
 import (
 	"context"
+	"crypto/tls"
 	"path/filepath"
 	"time"
 
@@ -107,6 +108,76 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(installOptions.MutatingWebhooks)).To(Equal(2))
 			Expect(len(installOptions.ValidatingWebhooks)).To(Equal(2))
+		})
+	})
+
+	Describe("Webhook With Custom TLS", func() {
+		It("should reject requests due to bad certificate", func(done Done) {
+			err := env.WebhookInstallOptions.setupCA()
+			dir := env.WebhookInstallOptions.LocalServingCertDir
+			certFile := filepath.Join(dir, "tls.crt")
+			keyFile := filepath.Join(dir, "tls.key")
+			Expect(err).NotTo(HaveOccurred())
+			sCert, err := tls.LoadX509KeyPair(certFile, keyFile)
+			Expect(err).NotTo(HaveOccurred())
+			m, err := manager.New(env.Config, manager.Options{
+				Port: env.WebhookInstallOptions.LocalServingPort,
+				Host: env.WebhookInstallOptions.LocalServingHost,
+				// CertDir: env.WebhookInstallOptions.LocalServingCertDir,
+				WebhookTLSConfig: &tls.Config{
+					NextProtos:   []string{"h2"},
+					Certificates: []tls.Certificate{sCert},
+					ClientAuth:   tls.NoClientCert,
+					MinVersion:   tls.VersionTLS13,
+				},
+			}) // we need manager here just to leverage manager.SetFields
+			Expect(err).NotTo(HaveOccurred())
+			server := m.GetWebhookServer()
+			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go func() {
+				_ = server.Start(ctx)
+			}()
+
+			c, err := client.New(env.Config, client.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			obj := &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deployment",
+					Namespace: "default",
+				},
+				Spec: appsv1.DeploymentSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"foo": "bar"},
+					},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{
+								{
+									Name:  "nginx",
+									Image: "nginx",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			Eventually(func() bool {
+				err = c.Create(context.TODO(), obj)
+				// Bad Certificate shows up as InternalError
+				return apierrors.ReasonForError(err) == metav1.StatusReason("InternalError")
+			}, 1*time.Second).Should(BeTrue())
+
+			close(done)
 		})
 	})
 })

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
@@ -229,6 +230,11 @@ type Options struct {
 
 	// Functions to all for a user to customize the values that will be injected.
 
+	// WebhookTLSConfig is a *tls.Config object that will be used in place of
+	// the one normally created by reading certs in the CertDir.  If both
+	// CertDir and this are specified CertDir will be ignored
+	WebhookTLSConfig *tls.Config
+
 	// NewCache is the function that will create the cache to be used
 	// by the manager. If not set this will use the default new cache function.
 	NewCache cache.NewCacheFunc
@@ -377,6 +383,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		port:                          options.Port,
 		host:                          options.Host,
 		certDir:                       options.CertDir,
+		webhookTLSConfig:              options.WebhookTLSConfig,
 		webhookServer:                 options.WebhookServer,
 		leaseDuration:                 *options.LeaseDuration,
 		renewDeadline:                 *options.RenewDeadline,


### PR DESCRIPTION
* This implements a Manager option WebhookTLSConfig which allows for
  specifying a custom TLS configuration when running webhooks using
  controller-runtime
* Added CustomTLSConfig attribute to WebhookInstallOptions
* Added test to show this config overrides the config generated by
  CertDir