### PR TITLE
🌱 Disable fsync on etcd envtest

### DIFF
--- a/hack/test-all.sh
+++ b/hack/test-all.sh
@@ -20,18 +20,6 @@ source $(dirname ${BASH_SOURCE})/common.sh
 
 header_text "running go test"
 
-# On MacOS there is a strange race condition
-# between port allocation of envtest suites when go test
-# runs all the tests in parallel without any limits (spins up around 10+ environments).
-#
-# To avoid flakes, set we're setting the go-test parallel flag to
-# to limit the number of parallel executions.
-#
-# TODO(community): Investigate this behavior further.
-if [[ "${OSTYPE}" == "darwin"* ]]; then
-  P_FLAG="-p=1"
-fi
-
 go test -race ${P_FLAG} ${MOD_OPT} ./...
 
 if [[ -n ${ARTIFACTS:-} ]]; then

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -207,7 +207,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f M
 		return OperationResultCreated, nil
 	}
 
-	existing := obj.DeepCopyObject() //nolint:ifshort
+	existing := obj.DeepCopyObject() //nolint
 	if err := mutate(f, key, obj); err != nil {
 		return OperationResultNone, err
 	}

--- a/pkg/internal/testing/controlplane/etcd.go
+++ b/pkg/internal/testing/controlplane/etcd.go
@@ -157,6 +157,11 @@ func (e *Etcd) defaultArgs() map[string][]string {
 		args["advertise-client-urls"] = []string{e.URL.String()}
 		args["listen-client-urls"] = []string{e.URL.String()}
 	}
+
+	// Add unsafe no fsync, available from etcd 3.5
+	if ok, _ := e.processState.CheckFlag("unsafe-no-fsync"); ok {
+		args["unsafe-no-fsync"] = []string{"true"}
+	}
 	return args
 }
 


### PR DESCRIPTION
etcd 3.5 now supports disabling fsync; this change adds the new flag if
it's available which helps speed up envtest execution

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
