### PR TITLE
:sparkles: chore: Fix bad urls

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 <!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
-<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
+<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
 
 <!-- What does this do, and why do we need it? -->

--- a/FAQ.md
+++ b/FAQ.md
@@ -55,7 +55,7 @@ to test against a real API server.  In our experience, tests using fake
 clients gradually re-implement poorly-written impressions of a real API
 server, which leads to hard-to-maintain, complex test code.
 
-### Q: How should I write tests?  Any suggestions for getting started? 
+### Q: How should I write tests?  Any suggestions for getting started?
 
 - Use the aforementioned
   [envtest.Environment](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest#Environment)

--- a/example_test.go
+++ b/example_test.go
@@ -63,7 +63,7 @@ func Example() {
 // This example creates a simple application Controller that is configured for ReplicaSets and Pods.
 // This application controller will be running leader election with the provided configuration in the manager options.
 // If leader election configuration is not provided, controller runs leader election with default values.
-// Default values taken from: https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go
+// Default values taken from: https://github.com/kubernetes/component-base/blob/master/config/v1alpha1/defaults.go
 //	defaultLeaseDuration = 15 * time.Second
 //	defaultRenewDeadline = 10 * time.Second
 //	defaultRetryPeriod   = 2 * time.Second

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	// Values taken from: https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go
+	// Values taken from: https://github.com/kubernetes/component-base/blob/master/config/v1alpha1/defaults.go
 	defaultLeaseDuration          = 15 * time.Second
 	defaultRenewDeadline          = 10 * time.Second
 	defaultRetryPeriod            = 2 * time.Second


### PR DESCRIPTION
Link https://github.com/kubernetes/apiserver/blob/master/pkg/apis/config/v1alpha1/defaults.go is out of date since k8s.io/{apiserver,apimachinery}/pkg/apis/config is moved to  k8s.io/component-base/config.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
