### PR TITLE
✨return a bool from AddFinalizer and RemoveFinalizer

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -349,26 +349,31 @@ func mutate(f MutateFn, key client.ObjectKey, obj client.Object) error {
 type MutateFn func() error
 
 // AddFinalizer accepts an Object and adds the provided finalizer if not present.
-func AddFinalizer(o client.Object, finalizer string) {
+// It returns an indication of whether it updated the object's list of finalizers.
+func AddFinalizer(o client.Object, finalizer string) (finalizersUpdated bool) {
 	f := o.GetFinalizers()
 	for _, e := range f {
 		if e == finalizer {
-			return
+			return false
 		}
 	}
 	o.SetFinalizers(append(f, finalizer))
+	return true
 }
 
 // RemoveFinalizer accepts an Object and removes the provided finalizer if present.
-func RemoveFinalizer(o client.Object, finalizer string) {
+// It returns an indication of whether it updated the object's list of finalizers.
+func RemoveFinalizer(o client.Object, finalizer string) (finalizersUpdated bool) {
 	f := o.GetFinalizers()
 	for i := 0; i < len(f); i++ {
 		if f[i] == finalizer {
 			f = append(f[:i], f[i+1:]...)
 			i--
+			finalizersUpdated = true
 		}
 	}
 	o.SetFinalizers(f)
+	return
 }
 
 // ContainsFinalizer checks an Object that the provided finalizer is present.


### PR DESCRIPTION
When a finalizer is added or removed to an object, typically a client requests the object be updated on the server.  Instead of making an update request unconditionally, it may be desirable to do so only when the object is modified, as an optimization.  Since the add and remove finalizer routines do not return an indication whether a finalizer was add or removed respectively, a caller needs to determine this information some other way.

One way is to call `ContainsFinalizer` before calling `AddFinalizer` or `RemoveFinalizer`.  But the time complexity of each of those routines is linear, resulting in two linear time functions when a finalizer is added or removed.

Another solution is to save the length of a the finalizer slice before calling add or remove finalizer and checking if the length is different upon return.  This improves over the previous solution presuming `len()` of a slice is a constant time complexity operation.

This solution provided in this pull request simplifies further by not requiring the add or remove finalizer caller save slice length prior to call.  Instead, the caller can simply call add or remove finalizer and if it returns true, then make the object update request.