### PR TITLE
Construct the typed clients we need

### DIFF
--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -24,8 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
-	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
 )
@@ -45,7 +44,7 @@ type Provider struct {
 	scheme *runtime.Scheme
 	// logger is the logger to use when logging diagnostic event info
 	logger          logr.Logger
-	evtClient       typedcorev1.EventInterface
+	evtClient       corev1client.EventInterface
 	makeBroadcaster EventBroadcasterProducer
 
 	broadcasterOnce sync.Once
@@ -98,7 +97,7 @@ func (p *Provider) getBroadcaster() record.EventBroadcaster {
 
 	p.broadcasterOnce.Do(func() {
 		broadcaster, stop := p.makeBroadcaster()
-		broadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: p.evtClient})
+		broadcaster.StartRecordingToSink(&corev1client.EventSinkImpl{Interface: p.evtClient})
 		broadcaster.StartEventWatcher(
 			func(e *corev1.Event) {
 				p.logger.V(1).Info(e.Type, "object", e.InvolvedObject, "reason", e.Reason, "message", e.Message)
@@ -112,12 +111,12 @@ func (p *Provider) getBroadcaster() record.EventBroadcaster {
 
 // NewProvider create a new Provider instance.
 func NewProvider(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, makeBroadcaster EventBroadcasterProducer) (*Provider, error) {
-	clientSet, err := kubernetes.NewForConfig(config)
+	corev1Client, err := corev1client.NewForConfig(config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to init clientSet: %w", err)
+		return nil, fmt.Errorf("failed to init client: %w", err)
 	}
 
-	p := &Provider{scheme: scheme, logger: logger, makeBroadcaster: makeBroadcaster, evtClient: clientSet.CoreV1().Events("")}
+	p := &Provider{scheme: scheme, logger: logger, makeBroadcaster: makeBroadcaster, evtClient: corev1Client.Events("")}
 	return p, nil
 }
 

--- a/pkg/internal/recorder/recorder_test.go
+++ b/pkg/internal/recorder/recorder_test.go
@@ -34,13 +34,13 @@ var _ = Describe("recorder.Provider", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return an error if failed to init clientSet.", func() {
+		It("should return an error if failed to init client.", func() {
 			// Invalid the config
 			cfg1 := *cfg
 			cfg1.Host = "invalid host"
 			_, err := recorder.NewProvider(&cfg1, scheme.Scheme, logr.DiscardLogger{}, makeBroadcaster)
 			Expect(err).NotTo(BeNil())
-			Expect(err.Error()).To(ContainSubstring("failed to init clientSet"))
+			Expect(err.Error()).To(ContainSubstring("failed to init client"))
 		})
 	})
 	Describe("GetEventRecorder", func() {


### PR DESCRIPTION
:sparkles: Construct typed clients directly

The pattern of constructing all the clients to get a
kubernetes.Interface, only to extract one or two typed clients has the
side-effect of importing a lot of packages that are otherwise
unneeded.

Avoid doing so by constructing the clients we need.

This isn't sufficient to remove all these extra dependencies (because
of the use of scheme.Scheme as default), but it is a step closer.

<!-- please add a :seedling: (`:seedling:`) to the title of this PR, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->
