### PR TITLE
📖  README pkg overview doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ see how it can be used.
 
 Documentation:
 
-- [Package overview](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg)
+- [Package overview](https://pkg.go.dev/sigs.k8s.io/controller-runtime#section-directories)
 - [Basic controller using builder](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/builder#example-Builder)
 - [Creating a manager](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/manager#example-New)
 - [Creating a controller](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#example-New)


### PR DESCRIPTION
This PR addresses #1642 and offers an alternative link to substitute for the broken package overview link. 
The offered doesn't seem to be exactly equivalent to the previous link in the overview, but it's the best substitute I was able to find at the https://pkg.go.dev/ site.