### PR TITLE
🌱  Manager should use the global logger, reduce log names verbosity

### DIFF
--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -76,7 +76,7 @@ func (p *loggerPromise) V(l *DelegatingLogger, level int) *loggerPromise {
 
 // Fulfill instantiates the Logger with the provided logger.
 func (p *loggerPromise) Fulfill(parentLogger logr.Logger) {
-	var logger = parentLogger
+	logger := logr.WithCallDepth(parentLogger, 1)
 	if p.name != nil {
 		logger = logger.WithName(*p.name)
 	}

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -37,9 +37,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
@@ -572,7 +572,7 @@ func setOptionsDefaults(options Options) Options {
 	}
 
 	if options.Logger == nil {
-		options.Logger = logf.RuntimeLog.WithName("manager")
+		options.Logger = log.Log
 	}
 
 	return options

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -45,10 +45,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
-	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 	fakeleaderelection "sigs.k8s.io/controller-runtime/pkg/leaderelection/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
@@ -1444,7 +1444,7 @@ var _ = Describe("manger.Manager", func() {
 				},
 				log: func(logger logr.Logger) error {
 					defer GinkgoRecover()
-					Expect(logger).To(Equal(logf.RuntimeLog.WithName("manager")))
+					Expect(logger).To(Equal(log.Log))
 					return nil
 				},
 			})


### PR DESCRIPTION
Currently a controller using the default logger has very verbose names
such as "controller-runtime/manager/controller/<name>", this changeset
reduces the verbosity of each log line to mostly have controller/<name>.

Signed-off-by: Stefan Büringer buringerst@vmware.com

Cherry-pick of: #1647

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
