### PR TITLE
🐛 Fix object overwrite on patch for fake client

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -284,6 +285,7 @@ func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 		return err
 	}
 	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
 	_, _, err = decoder.Decode(j, nil, obj)
 	return err
 }
@@ -346,6 +348,7 @@ func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...cl
 		return err
 	}
 	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
 	_, _, err = decoder.Decode(j, nil, obj)
 	if err != nil {
 		return err
@@ -549,6 +552,7 @@ func (c *fakeClient) Patch(ctx context.Context, obj client.Object, patch client.
 		return err
 	}
 	decoder := scheme.Codecs.UniversalDecoder()
+	zero(obj)
 	_, _, err = decoder.Decode(j, nil, obj)
 	return err
 }
@@ -694,4 +698,13 @@ func allowsCreateOnUpdate(gvk schema.GroupVersionKind) bool {
 	}
 
 	return false
+}
+
+// zero zeros the value of a pointer.
+func zero(x interface{}) {
+	if x == nil {
+		return
+	}
+	res := reflect.ValueOf(x).Elem()
+	res.Set(reflect.Zero(res.Type()))
 }


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Previously the fake client tried to decode the new object after patching to the object outside, which will cause some fields that should be removed in this patch remain in the object.

It should overwrite the object using reflect set, just like [the way in cache get](https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/cache/internal/cache_reader.go#L99).