### PR TITLE
:bug: Unconditionally set NegotiatedSerializer

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -158,14 +158,12 @@ func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConf
 		protobufSchemeLock.RUnlock()
 	}
 
-	if cfg.NegotiatedSerializer == nil {
-		if isUnstructured {
-			// If the object is unstructured, we need to preserve the GVK information.
-			// Use our own custom serializer.
-			cfg.NegotiatedSerializer = serializerWithDecodedGVK{serializer.WithoutConversionCodecFactory{CodecFactory: codecs}}
-		} else {
-			cfg.NegotiatedSerializer = serializerWithTargetZeroingDecode{NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: codecs}}
-		}
+	if isUnstructured {
+		// If the object is unstructured, we need to preserve the GVK information.
+		// Use our own custom serializer.
+		cfg.NegotiatedSerializer = serializerWithDecodedGVK{serializer.WithoutConversionCodecFactory{CodecFactory: codecs}}
+	} else {
+		cfg.NegotiatedSerializer = serializerWithTargetZeroingDecode{NegotiatedSerializer: serializer.WithoutConversionCodecFactory{CodecFactory: codecs}}
 	}
 
 	return cfg


### PR DESCRIPTION
We currently only set the NegotiatedSerializer when there is none set
yet. Unfortunately, various things will break if someone sets their own
in the rest config, hence always set it.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1654
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
