### PR TITLE
✨Switch from rsa to ecdsa in tinyca

### DIFF
--- a/pkg/internal/testing/certs/tinyca.go
+++ b/pkg/internal/testing/certs/tinyca.go
@@ -24,8 +24,9 @@ package certs
 
 import (
 	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	crand "crypto/rand"
-	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -38,8 +39,8 @@ import (
 )
 
 var (
-	rsaKeySize = 2048 // a decent number, as of 2019
-	bigOne     = big.NewInt(1)
+	ellipticCurve = elliptic.P256()
+	bigOne        = big.NewInt(1)
 )
 
 // CertPair is a private key and certificate for use for client auth, as a CA, or serving.
@@ -86,7 +87,7 @@ type TinyCA struct {
 // newPrivateKey generates a new private key of a relatively sane size (see
 // rsaKeySize).
 func newPrivateKey() (crypto.Signer, error) {
-	return rsa.GenerateKey(crand.Reader, rsaKeySize)
+	return ecdsa.GenerateKey(ellipticCurve, crand.Reader)
 }
 
 // NewTinyCA creates a new a tiny CA utility for provisioning serving certs and client certs FOR TESTING ONLY.


### PR DESCRIPTION
Generating new RSA private keys each time a envtest environment is started, causes a lot of unnecessary cpu overhead.
This causes my tests to take longer to complete.
Instead, if we use ECC, key generation is much faster (see benchmark below for confirmation).

```go
package main

import (
	"crypto/ecdsa"
	"crypto/elliptic"
	"crypto/rand"
	"crypto/rsa"
	"testing"
)

var (
	rsaKeySize    = 2048
	ellipticCurve = elliptic.P256()
)

func BenchmarkEcdsa(b *testing.B) {
	for n := 0; n < b.N; n++ {
		ecdsa.GenerateKey(ellipticCurve, rand.Reader)
	}
}

func BenchmarkRsa(b *testing.B) {
	for n := 0; n < b.N; n++ {
		rsa.GenerateKey(rand.Reader, rsaKeySize)
	}
}
```
```console
$ go test -bench=.
goos: linux
goarch: amd64
pkg: sigs.k8s.io/controller-runtime/temp
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkEcdsa-12          74070             16064 ns/op
BenchmarkRsa-12               10         172068810 ns/op
PASS
ok      sigs.k8s.io/controller-runtime/temp     3.185s
```