### PR TITLE
:sparkles: Allow webhooks to register custom validators/defaulter types

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"encoding/json"
+
+	"errors"
+	"net/http"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// CustomDefaulter defines functions for setting defaults on resources.
+type CustomDefaulter interface {
+	Default(ctx context.Context, obj runtime.Object) error
+}
+
+// WithCustomDefaulter creates a new Webhook for a CustomDefaulter interface.
+func WithCustomDefaulter(obj runtime.Object, defaulter CustomDefaulter) *Webhook {
+	return &Webhook{
+		Handler: &defaulterForType{object: obj, defaulter: defaulter},
+	}
+}
+
+type defaulterForType struct {
+	defaulter CustomDefaulter
+	object    runtime.Object
+	decoder   *Decoder
+}
+
+var _ DecoderInjector = &defaulterForType{}
+
+func (h *defaulterForType) InjectDecoder(d *Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *defaulterForType) Handle(ctx context.Context, req Request) Response {
+	if h.defaulter == nil {
+		panic("defaulter should never be nil")
+	}
+	if h.object == nil {
+		panic("object should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.object.DeepCopyObject()
+	if err := h.decoder.Decode(req, obj); err != nil {
+		return Errored(http.StatusBadRequest, err)
+	}
+
+	// Default the object
+	if err := h.defaulter.Default(ctx, obj); err != nil {
+		var apiStatus apierrors.APIStatus
+		if errors.As(err, &apiStatus) {
+			return validationResponseFromStatus(false, apiStatus.Status())
+		}
+		return Denied(err.Error())
+	}
+
+	// Create the patch
+	marshalled, err := json.Marshal(obj)
+	if err != nil {
+		return Errored(http.StatusInternalServerError, err)
+	}
+	return PatchResponseFromRaw(req.Object.Raw, marshalled)
+}

--- a/pkg/webhook/admission/validator_custom.go
+++ b/pkg/webhook/admission/validator_custom.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package admission
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+
+	v1 "k8s.io/api/admission/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// CustomValidator defines functions for validating an operation.
+type CustomValidator interface {
+	ValidateCreate(ctx context.Context, obj runtime.Object) error
+	ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) error
+	ValidateDelete(ctx context.Context, obj runtime.Object) error
+}
+
+// WithCustomValidator creates a new Webhook for validating the provided type.
+func WithCustomValidator(obj runtime.Object, validator CustomValidator) *Webhook {
+	return &Webhook{
+		Handler: &validatorForType{object: obj, validator: validator},
+	}
+}
+
+type validatorForType struct {
+	validator CustomValidator
+	object    runtime.Object
+	decoder   *Decoder
+}
+
+var _ DecoderInjector = &validatorForType{}
+
+// InjectDecoder injects the decoder into a validatingHandler.
+func (h *validatorForType) InjectDecoder(d *Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+// Handle handles admission requests.
+func (h *validatorForType) Handle(ctx context.Context, req Request) Response {
+	if h.validator == nil {
+		panic("validator should never be nil")
+	}
+	if h.object == nil {
+		panic("object should never be nil")
+	}
+
+	// Get the object in the request
+	obj := h.object.DeepCopyObject()
+
+	var err error
+	switch req.Operation {
+	case v1.Create:
+		if err := h.decoder.Decode(req, obj); err != nil {
+			return Errored(http.StatusBadRequest, err)
+		}
+
+		err = h.validator.ValidateCreate(ctx, obj)
+	case v1.Update:
+		oldObj := obj.DeepCopyObject()
+		if err := h.decoder.DecodeRaw(req.Object, obj); err != nil {
+			return Errored(http.StatusBadRequest, err)
+		}
+		if err := h.decoder.DecodeRaw(req.OldObject, oldObj); err != nil {
+			return Errored(http.StatusBadRequest, err)
+		}
+
+		err = h.validator.ValidateUpdate(ctx, oldObj, obj)
+	case v1.Delete:
+		// In reference to PR: https://github.com/kubernetes/kubernetes/pull/76346
+		// OldObject contains the object being deleted
+		if err := h.decoder.DecodeRaw(req.OldObject, obj); err != nil {
+			return Errored(http.StatusBadRequest, err)
+		}
+
+		err = h.validator.ValidateDelete(ctx, obj)
+	default:
+		return Errored(http.StatusBadRequest, fmt.Errorf("unknown operation request %q", req.Operation))
+	}
+
+	// Check the error message first.
+	if err != nil {
+		var apiStatus apierrors.APIStatus
+		if errors.As(err, &apiStatus) {
+			return validationResponseFromStatus(false, apiStatus.Status())
+		}
+		return Denied(err.Error())
+	}
+
+	// Return allowed if everything succeeded.
+	return Allowed("")
+}

--- a/pkg/webhook/alias.go
+++ b/pkg/webhook/alias.go
@@ -29,6 +29,12 @@ type Defaulter = admission.Defaulter
 // Validator defines functions for validating an operation.
 type Validator = admission.Validator
 
+// CustomDefaulter defines functions for setting defaults on resources.
+type CustomDefaulter = admission.CustomDefaulter
+
+// CustomValidator defines functions for validating an operation.
+type CustomValidator = admission.CustomValidator
+
 // AdmissionRequest defines the input for an admission handler.
 // It contains information to identify the object in
 // question (group, version, kind, resource, subresource,


### PR DESCRIPTION
This changeset allows our webhook builder to take in a handler any other
struct other than a runtime.Object.

Today having an object as the primary source of truth for both
Defaulting and Validators makes API types carry a lot of information and
business logic alongside their definitions.

Moreover, lots of folks in the past have asked for ways to have an
external type to handle these operations and use a controller runtime
client for validations.

This change brings a new way to register webhooks, which admission.For
handler any type (struct) can be a defaulting or validating handler for
a runtime Object.

Signed-off-by: Vince Prignano <vincepri@vmware.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
