### PR TITLE
🐛  client/config: use filepath.Join for loadingRules.Precedence

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/user"
-	"path"
+	"path/filepath"
 
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -125,7 +125,7 @@ func loadConfig(context string) (*rest.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("could not get current user: %v", err)
 		}
-		loadingRules.Precedence = append(loadingRules.Precedence, path.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
+		loadingRules.Precedence = append(loadingRules.Precedence, filepath.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
 	}
 
 	return loadConfigWithContext("", loadingRules, context)


### PR DESCRIPTION
client/config: use filepath.Join for loadingRules.Precedence.
It's not url path, actually file path.