### PR TITLE
🐛  Start the Cache if the Manager has already started

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -211,6 +211,12 @@ func (cm *controllerManager) Add(r Runnable) error {
 		cm.nonLeaderElectionRunnables = append(cm.nonLeaderElectionRunnables, r)
 	} else if hasCache, ok := r.(hasCache); ok {
 		cm.caches = append(cm.caches, hasCache)
+		if cm.started {
+			cm.startRunnable(hasCache)
+			if !hasCache.GetCache().WaitForCacheSync(cm.internalCtx) {
+				return fmt.Errorf("could not sync cache")
+			}
+		}
 	} else {
 		shouldStart = cm.startedLeader
 		cm.leaderElectionRunnables = append(cm.leaderElectionRunnables, r)


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Fixes #1673. 

This is needed to better support multi-cluster controllers where you want to dynamically add Clusters after the Manager has already started and have their caches started and synced. 