### PR TITLE
:seedling: Allow Specification of the Log Timestamp Format

### DIFF
--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -128,3 +128,41 @@ func (ev *stackTraceFlag) String() string {
 func (ev *stackTraceFlag) Type() string {
 	return "level"
 }
+
+type timeEncodingFlag struct {
+	setFunc func(zapcore.TimeEncoder)
+	value   string
+}
+
+var _ flag.Value = &timeEncodingFlag{}
+
+func (ev *timeEncodingFlag) String() string {
+	return ev.value
+}
+
+func (ev *timeEncodingFlag) Type() string {
+	return "time-encoding"
+}
+
+func (ev *timeEncodingFlag) Set(flagValue string) error {
+	val := strings.ToLower(flagValue)
+	switch val {
+	case "rfc3339nano":
+		ev.setFunc(zapcore.RFC3339NanoTimeEncoder)
+	case "rfc3339":
+		ev.setFunc(zapcore.RFC3339TimeEncoder)
+	case "iso8601":
+		ev.setFunc(zapcore.ISO8601TimeEncoder)
+	case "millis":
+		ev.setFunc(zapcore.EpochMillisTimeEncoder)
+	case "nanos":
+		ev.setFunc(zapcore.EpochNanosTimeEncoder)
+	case "epoch":
+		ev.setFunc(zapcore.EpochTimeEncoder)
+	default:
+		return fmt.Errorf("invalid time-encoding value \"%s\"", flagValue)
+	}
+
+	ev.value = flagValue
+	return nil
+}


### PR DESCRIPTION
Currently the user doesn't have an option to specify the encoding of the log timestamps via a command line flag. So by default all log timestamps are in `epoch` format, which makes them hard to read/interpret imho.

This PR addresses it and adds the `zap-time-encoding` flag, which allows to specify the required format for log timestamp encoding and accepts the following values:

* `epoch`: floating-point number of seconds since the Unix epoch
* `nanos`: integer of nanoseconds since the Unix epoch
* `millis`: floating-point number of milliseconds since the Unix epoch
* `iso8601`: ISO8601-formatted string with millisecond precision
* `rfc3339`: RFC3339-formatted string or
* `rfc3339nano`: RFC3339-formatted string with nanosecond precision.
