### PR TITLE
🐛 Fix the internal cache object selector

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -86,8 +86,11 @@ type Informer interface {
 	HasSynced() bool
 }
 
+// ObjectSelector is an alias name of internal.Selector.
+type ObjectSelector internal.Selector
+
 // SelectorsByObject associate a client.Object's GVK to a field/label selector.
-type SelectorsByObject map[client.Object]internal.Selector
+type SelectorsByObject map[client.Object]ObjectSelector
 
 // Options are the optional arguments for creating a new InformersMap object.
 type Options struct {
@@ -198,7 +201,7 @@ func convertToSelectorsByGVK(selectorsByObject SelectorsByObject, scheme *runtim
 		if err != nil {
 			return nil, err
 		}
-		selectorsByGVK[gvk] = selector
+		selectorsByGVK[gvk] = internal.Selector(selector)
 	}
 	return selectorsByGVK, nil
 }


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Currently the value of `SelectorsByObject` is `internal.Selector`, which is unaccessible from outside projects. I add an alias name to make it able to be used externally.

fixes #1697 
