### PR TITLE
:sparkles: Allow configuring a default cache selector

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -90,6 +90,8 @@ type Informer interface {
 type ObjectSelector internal.Selector
 
 // SelectorsByObject associate a client.Object's GVK to a field/label selector.
+// There is also `DefaultSelector` to set a global default (which will be overridden by
+// a more specific setting here, if any).
 type SelectorsByObject map[client.Object]ObjectSelector
 
 // Options are the optional arguments for creating a new InformersMap object.
@@ -117,6 +119,10 @@ type Options struct {
 	// [2] https://pkg.go.dev/k8s.io/apimachinery/pkg/fields#Set
 	SelectorsByObject SelectorsByObject
 
+	// DefaultSelector will be used as selectors for all object types
+	// that do not have a selector in SelectorsByObject defined.
+	DefaultSelector ObjectSelector
+
 	// UnsafeDisableDeepCopyByObject indicates not to deep copy objects during get or
 	// list objects per GVK at the specified object.
 	// Be very careful with this, when enabled you must DeepCopy any object before mutating it,
@@ -132,7 +138,7 @@ func New(config *rest.Config, opts Options) (Cache, error) {
 	if err != nil {
 		return nil, err
 	}
-	selectorsByGVK, err := convertToSelectorsByGVK(opts.SelectorsByObject, opts.Scheme)
+	selectorsByGVK, err := convertToSelectorsByGVK(opts.SelectorsByObject, opts.DefaultSelector, opts.Scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +200,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 	return opts, nil
 }
 
-func convertToSelectorsByGVK(selectorsByObject SelectorsByObject, scheme *runtime.Scheme) (internal.SelectorsByGVK, error) {
+func convertToSelectorsByGVK(selectorsByObject SelectorsByObject, defaultSelector ObjectSelector, scheme *runtime.Scheme) (internal.SelectorsByGVK, error) {
 	selectorsByGVK := internal.SelectorsByGVK{}
 	for object, selector := range selectorsByObject {
 		gvk, err := apiutil.GVKForObject(object, scheme)
@@ -203,6 +209,7 @@ func convertToSelectorsByGVK(selectorsByObject SelectorsByObject, scheme *runtim
 		}
 		selectorsByGVK[gvk] = internal.Selector(selector)
 	}
+	selectorsByGVK[schema.GroupVersionKind{}] = internal.Selector(defaultSelector)
 	return selectorsByGVK, nil
 }
 

--- a/pkg/cache/internal/informers_map.go
+++ b/pkg/cache/internal/informers_map.go
@@ -277,19 +277,19 @@ func createStructuredListWatch(gvk schema.GroupVersionKind, ip *specificInformer
 	// Create a new ListWatch for the obj
 	return &cache.ListWatch{
 		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			ip.selectors[gvk].ApplyToList(&opts)
+			ip.selectors.forGVK(gvk).ApplyToList(&opts)
 			res := listObj.DeepCopyObject()
-			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors.forGVK(gvk))
 			isNamespaceScoped := namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
 			err := client.Get().NamespaceIfScoped(namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Do(ctx).Into(res)
 			return res, err
 		},
 		// Setup the watch function
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			ip.selectors[gvk].ApplyToList(&opts)
+			ip.selectors.forGVK(gvk).ApplyToList(&opts)
 			// Watch needs to be set to true separately
 			opts.Watch = true
-			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors[gvk])
+			namespace := restrictNamespaceBySelector(ip.namespace, ip.selectors.forGVK(gvk))
 			isNamespaceScoped := namespace != "" && mapping.Scope.Name() != meta.RESTScopeNameRoot
 			return client.Get().NamespaceIfScoped(namespace, isNamespaceScoped).Resource(mapping.Resource.Resource).VersionedParams(&opts, ip.paramCodec).Watch(ctx)
 		},

--- a/pkg/cache/internal/selector.go
+++ b/pkg/cache/internal/selector.go
@@ -26,6 +26,17 @@ import (
 // SelectorsByGVK associate a GroupVersionKind to a field/label selector.
 type SelectorsByGVK map[schema.GroupVersionKind]Selector
 
+func (s SelectorsByGVK) forGVK(gvk schema.GroupVersionKind) Selector {
+	if specific, found := s[gvk]; found {
+		return specific
+	}
+	if defaultSelector, found := s[schema.GroupVersionKind{}]; found {
+		return defaultSelector
+	}
+
+	return Selector{}
+}
+
 // Selector specify the label/field selector to fill in ListOptions.
 type Selector struct {
 	Label labels.Selector


### PR DESCRIPTION
It is already possible to configure cache selectors per gvk, but it is
not possible to default this selector for all types. This change adds
that.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->


Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1708