### PR TITLE
:sparkles: Fix SetupSignalHandler godoc

### DIFF
--- a/pkg/manager/signals/signal.go
+++ b/pkg/manager/signals/signal.go
@@ -24,8 +24,8 @@ import (
 
 var onlyOneSignalHandler = make(chan struct{})
 
-// SetupSignalHandler registers for SIGTERM and SIGINT. A stop channel is returned
-// which is closed on one of these signals. If a second signal is caught, the program
+// SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+// which is canceled on one of these signals. If a second signal is caught, the program
 // is terminated with exit code 1.
 func SetupSignalHandler() context.Context {
 	close(onlyOneSignalHandler) // panics when called twice


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR is a small follow up to https://github.com/kubernetes-sigs/controller-runtime/pull/1205, which updated `SetupSignalHandler` in `pkg/manager/signals/signal.go` to use a context instead of a stop channel without updating the godoc for that function. 
