### PR TITLE
🌱 Expose Indexer from Informer

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -84,6 +84,8 @@ type Informer interface {
 	AddIndexers(indexers toolscache.Indexers) error
 	// HasSynced return true if the informers underlying store has synced.
 	HasSynced() bool
+	// GetIndexer returns the Indexer backed by this informer
+	GetIndexer() toolscache.Indexer
 }
 
 // ObjectSelector is an alias name of internal.Selector.

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -329,3 +329,7 @@ func (i *multiNamespaceInformer) HasSynced() bool {
 	}
 	return true
 }
+
+func (i *multiNamespaceInformer) GetIndexer() toolscache.Indexer {
+	panic("GetIndexer is not supported for multiNamespaceInformer")
+}


### PR DESCRIPTION
This allows users to use the Lister implementations from client-go

Signed-off-by: Tamal Saha <tamal@appscode.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
We are looking to use controller-runtime more and more with our sample-controller style code. As  part of that we still need to use the `Lister`. To create a Lister, we need access to the underlying `Indexer` which is not exposed via the `Informer` interface. This pr just exposed that.