### PR TITLE
🐛 avoid panic in envtest by checking before dereferencing

### DIFF
--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -414,10 +414,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 // Stop stops this process gracefully, waits for its termination, and cleans up
 // the CertDir if necessary.
 func (s *APIServer) Stop() error {
-	if s.processState.DirNeedsCleaning {
-		s.CertDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
-	}
 	if s.processState != nil {
+		if s.processState.DirNeedsCleaning {
+			s.CertDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
+		}
 		if err := s.processState.Stop(); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- please add a :bug: (`:bug:`) to the title of this PR, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

<!-- What issue does this fix (e.g. Fixes #XYZ) -->

Move an unchecked pointer dereference into a checked block so the code doesn't panic when calling `Stop` on an `APIServer` instance that failed to start.






