### PR TITLE
✨  export queue's length of Controller

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -79,6 +79,11 @@ type Controller interface {
 
 	// GetLogger returns this controller logger prefilled with basic information.
 	GetLogger() logr.Logger
+
+	// Len returns the current queue length, for informational purposes only. You
+	// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+	// value, that can't be synchronized properly.
+	Len() int
 }
 
 // New returns a new Controller registered with the Manager.  The Manager will ensure that shared Caches have

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -267,6 +267,15 @@ func (c *Controller) processNextWorkItem(ctx context.Context) bool {
 	return true
 }
 
+// Len returns the current queue length, for informational purposes only. You
+// shouldn't e.g. gate a call to Add() or Get() on Len() being a particular
+// value, that can't be synchronized properly.
+func (c *Controller) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.Queue.Len()
+}
+
 const (
 	labelError        = "error"
 	labelRequeueAfter = "requeue_after"


### PR DESCRIPTION
Signed-off-by: zounengren <zouyee1989@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
fix https://github.com/kubernetes-sigs/controller-runtime/issues/1733