### PR TITLE
📖 Explain what may happen when using OnlyMetadata and Get on the concrete type instead of PartialMetadataObject

### DIFF
--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -107,6 +107,20 @@ var (
 	// metav1.PartialObjectMetadata to the client when fetching objects in your
 	// reconciler, otherwise you'll end up with a duplicate structured or
 	// unstructured cache.
+	//
+	// When watching a resource with OnlyMetadata, for example the v1.Pod, you
+	// should not Get and List using the v1.Pod type. Instead, you should use
+	// the special metav1.PartialObjectMetadata type:
+	//
+	//   pod := &v1.Pod{}                             // ❌
+	//   mgr.GetClient().Get(ctx, nsAndName, pod)     // ❌
+	//
+	//   pod := &metav1.PartialObjectMetadata{}       // ✅
+	//   mgr.GetClient().Get(ctx, nsAndName, pod)     // ✅
+	//
+	// In the first case, controller-runtime will create another cache for the
+	// concrete type on top of the metadata cache; this increases memory
+	// consumption and leads to race conditions as caches are not in sync.
 	OnlyMetadata = projectAs(projectAsMetadata)
 
 	_ ForOption     = OnlyMetadata

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -110,13 +110,22 @@ var (
 	//
 	// When watching a resource with OnlyMetadata, for example the v1.Pod, you
 	// should not Get and List using the v1.Pod type. Instead, you should use
-	// the special metav1.PartialObjectMetadata type:
+	// the special metav1.PartialObjectMetadata type.
 	//
-	//   pod := &v1.Pod{}                             // ❌
-	//   mgr.GetClient().Get(ctx, nsAndName, pod)     // ❌
+	// ❌ Incorrect:
 	//
-	//   pod := &metav1.PartialObjectMetadata{}       // ✅
-	//   mgr.GetClient().Get(ctx, nsAndName, pod)     // ✅
+	//   pod := &v1.Pod{}
+	//   mgr.GetClient().Get(ctx, nsAndName, pod)
+	//
+	// ✅ Correct:
+	//
+	//   pod := &metav1.PartialObjectMetadata{}
+	//   pod.SetGroupVersionKind(schema.GroupVersionKind{
+	//       Group:   "",
+	//       Version: "v1",
+	//       Kind:    "Pod",
+	//   })
+	//   mgr.GetClient().Get(ctx, nsAndName, pod)
 	//
 	// In the first case, controller-runtime will create another cache for the
 	// concrete type on top of the metadata cache; this increases memory


### PR DESCRIPTION
In #1660, we found that it is too easy for users to duplicate cache projections, for example by creating a watch with `OnlyMetadata`, which creates a metadata cache, and then using the concrete type to get the watched object, which automatically creates a cache of the concrete projection.

Duplicating the cached projections is probably never what the user wanted to do, and leads to:
- Increased memory usage,
- Race conditions since caches aren't synchronized.

At first, I wanted to follow the suggestion in https://github.com/kubernetes-sigs/controller-runtime/issues/1660#issuecomment-918242097:

> We could add a check for this into pkg/cache and error out if someone requests something that we already have in a different projection

I then realized that I don't really know how to make this change.

Can I suggest starting with a quick warning that people would see when looking at  `OnlyMetadata`? In this PR, I added the warning.

To sum up my goal in this PR, I wish to document the following:

1. The three following Get calls will create three different caches:

	```go
	// Concrete client:
	pod := &v1.Pod{}
	mgr.GetClient().Get(ctx, nsAndName, pod)
	
	// Unstructured client:
	pod := &unstructured.Unstructured{}
	mgr.GetClient().Get(ctx, nsAndName, pod)

	// Metadata-only client:
	pod := &metav1.PartialObjectMetadata{}
	mgr.GetClient().Get(ctx, nsAndName, pod)
	```

2. Caches are not synchronized, meaning that you may end up with data races when using two different cache projections.
3. Using OnlyMetadata option should not be used with the concrete nor the unstructured clients.