### PR TITLE
:bug: Cleanup if envtest controlplane fails to start

### DIFF
--- a/pkg/internal/testing/controlplane/plane.go
+++ b/pkg/internal/testing/controlplane/plane.go
@@ -47,13 +47,18 @@ type ControlPlane struct {
 }
 
 // Start will start your control plane processes. To stop them, call Stop().
-func (f *ControlPlane) Start() error {
+func (f *ControlPlane) Start() (retErr error) {
 	if f.Etcd == nil {
 		f.Etcd = &Etcd{}
 	}
 	if err := f.Etcd.Start(); err != nil {
 		return err
 	}
+	defer func() {
+		if retErr != nil {
+			_ = f.Etcd.Stop()
+		}
+	}()
 
 	if f.APIServer == nil {
 		f.APIServer = &APIServer{}
@@ -62,6 +67,11 @@ func (f *ControlPlane) Start() error {
 	if err := f.APIServer.Start(); err != nil {
 		return err
 	}
+	defer func() {
+		if retErr != nil {
+			_ = f.APIServer.Stop()
+		}
+	}()
 
 	// provision the default user -- can be removed when the related
 	// methods are removed.  The default user has admin permissions to
@@ -88,6 +98,7 @@ func (f *ControlPlane) Stop() error {
 			errList = append(errList, err)
 		}
 	}
+
 	if f.Etcd != nil {
 		if err := f.Etcd.Stop(); err != nil {
 			errList = append(errList, err)


### PR DESCRIPTION
Currently if the api server fails to start etcd process will be up
the next time ControlPlane.Start() is called, they will both have the
same listening address which will make the new etcd instance fail to
start.

The controlplane object will also be in an incomplete state
so calling ControlPlane.Close() will panic.