### PR TITLE
:book: update links to godoc.org to use pkg.go.dev

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -30,13 +30,13 @@ on your situation.
   take this approach: the StatefulSet controller appends a specific number
   to each pod that it creates, while the Deployment controller hashes the
   pod template spec and appends that.
-  
+
 - In the few cases when you cannot take advantage of deterministic names
   (e.g. when using generateName), it may be useful in to track which
   actions you took, and assume that they need to be repeated if they don't
   occur after a given time (e.g. using a requeue result).  This is what
   the ReplicaSet controller does.
-  
+
 In general, write your controller with the assumption that information
 will eventually be correct, but may be slightly out of date. Make sure
 that your reconcile function enforces the entire state of the world each
@@ -48,9 +48,9 @@ generally cover most circumstances.
 ### Q: Where's the fake client?  How do I use it?
 
 **A**: The fake client
-[exists](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/client/fake),
+[exists](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake),
 but we generally recommend using
-[envtest.Environment](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest#Environment)
+[envtest.Environment](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest#Environment)
 to test against a real API server.  In our experience, tests using fake
 clients gradually re-implement poorly-written impressions of a real API
 server, which leads to hard-to-maintain, complex test code.
@@ -58,7 +58,7 @@ server, which leads to hard-to-maintain, complex test code.
 ### Q: How should I write tests?  Any suggestions for getting started?
 
 - Use the aforementioned
-  [envtest.Environment](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/envtest#Environment)
+  [envtest.Environment](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest#Environment)
   to spin up a real API server instead of trying to mock one out.
 
 - Structure your tests to check that the state of the world is as you
@@ -77,5 +77,5 @@ mapping between Go types and group-version-kinds in Kubernetes. In
 general, your application should have its own Scheme containing the types
 from the API groups that it needs (be they Kubernetes types or your own).
 See the [scheme builder
-docs](https://godoc.org/sigs.k8s.io/controller-runtime/pkg/scheme) for
+docs](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/scheme) for
 more information.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/controller-runtime)](https://goreportcard.com/report/sigs.k8s.io/controller-runtime)
-[![godoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime?status.svg)](https://pkg.go.dev/sigs.k8s.io/controller-runtime)
+[![godoc](https://pkg.go.dev/badge/sigs.k8s.io/controller-runtime)](https://pkg.go.dev/sigs.k8s.io/controller-runtime)
 
 # Kubernetes controller-runtime Project
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Go Report Card](https://goreportcard.com/badge/sigs.k8s.io/controller-runtime)](https://goreportcard.com/report/sigs.k8s.io/controller-runtime)
-[![godoc](https://godoc.org/sigs.k8s.io/controller-runtime?status.svg)](https://godoc.org/sigs.k8s.io/controller-runtime)
+[![godoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime?status.svg)](https://pkg.go.dev/sigs.k8s.io/controller-runtime)
 
 # Kubernetes controller-runtime Project
 

--- a/designs/README.md
+++ b/designs/README.md
@@ -2,7 +2,7 @@ Designs
 =======
 
 These are design documents for changes to Controller Runtime They exist
-to help document the design processes that go into writing Controller 
+to help document the design processes that go into writing Controller
 Runtime, but may not be up-to-date (more below).
 
 Not all changes to Controller Runtime need a design document -- only major
@@ -17,7 +17,7 @@ proof-of-concept process can help iron out wrinkles and can help with the
 ## Out-of-Date Designs
 
 **Controller Runtime documentation
-[GoDoc](https://godoc.org/sigs.k8s.io/controller-runtime) should be
+[GoDoc](https://pkg.go.dev/sigs.k8s.io/controller-runtime) should be
 considered the canonical, update-to-date reference and architectural
 documentation** for Controller Runtime.
 

--- a/designs/component-config.md
+++ b/designs/component-config.md
@@ -37,7 +37,7 @@ Currently controllers that use `controller-runtime` need to configure the `ctrl.
 
 ## Motivation
 
-This change is important because: 
+This change is important because:
 - it will help make it easier for controllers to be configured by other machine processes
 - it will reduce the required flags required to start a controller
 - allow for configuration types which aren't natively supported by flags
@@ -65,7 +65,7 @@ This change is important because:
 
 ## Proposal
 
-The `ctrl.Manager` _SHOULD_ support loading configurations from `ComponentConfig` like objects. 
+The `ctrl.Manager` _SHOULD_ support loading configurations from `ComponentConfig` like objects.
 An interface for that object with getters for the specific configuration parameters is created to bridge existing patterns.
 
 Without breaking the current `ctrl.NewManager` which uses an exported `ctrl.Options{}` the `manager.go` can expose a new func, `NewFromComponentConfig()` this would be able to loop through the getters to populate an internal `ctrl.Options{}` and pass that into `New()`.
@@ -101,7 +101,7 @@ type ManagerConfiguration interface {
 func NewFromComponentConfig(config *rest.Config, scheme *runtime.Scheme, filename string, managerconfig ManagerConfiguration) (Manager, error) {
 	codecs := serializer.NewCodecFactory(scheme)
     if err := decodeComponentConfigFileInto(codecs, filename, managerconfig); err != nil {
-		
+
 	}
 	options := Options{}
 
@@ -139,7 +139,7 @@ import (
 
 // ControllerManagerConfiguration defines the embedded RuntimeConfiguration for controller-runtime clients.
 type ControllerManagerConfiguration struct {
-	Namespace string `json:"namespace,omitempty"` 
+	Namespace string `json:"namespace,omitempty"`
 
 	SyncPeriod *time.Duration `json:"syncPeriod,omitempty"`
 
@@ -168,7 +168,7 @@ type ControllerManagerConfigurationHealth struct {
 
 #### Default ComponentConfig Type
 
-To enable `controller-runtime` to have a default `ComponentConfig` struct which can be used instead of requiring each controller or extension to build it's own `ComponentConfig` type, we can create a `DefaultControllerConfiguration` type which can exist in `pkg/api/config/v1alpha1/types.go`. This will allow the controller authors to use this before needing to implement their own type with additional configs.
+To enable `controller-runtime` to have a default `ComponentConfig` struct which can be used instead of requiring each controller or extension to build its own `ComponentConfig` type, we can create a `DefaultControllerConfiguration` type which can exist in `pkg/api/config/v1alpha1/types.go`. This will allow the controller authors to use this before needing to implement their own type with additional configs.
 
 ```golang
 // pkg/api/config/v1alpha1/types.go
@@ -212,12 +212,12 @@ if err != nil {
 }
 ```
 
-The above example uses `configname` which is the name of the file to load the configuration from and uses `scheme` to get the specific serializer, eg `serializer.NewCodecFactory(scheme)`. This will allow the configuration to be unmarshalled into the `runtime.Object` type and passed into the 
+The above example uses `configname` which is the name of the file to load the configuration from and uses `scheme` to get the specific serializer, eg `serializer.NewCodecFactory(scheme)`. This will allow the configuration to be unmarshalled into the `runtime.Object` type and passed into the
 `ctrl.NewManagerFromComponentConfig()` as a `ManagerConfiguration` interface.
 
 #### Using Flags w/ ComponentConfig
 
-Since this design still requires setting up the initial `ComponentConfig` type and passing in a pointer to `ctrl.NewFromComponentConfig()` if you want to allow for the use of flags, your controller can use any of the different flagging interfaces. eg [`flag`](https://golang.org/pkg/flag/), [`pflag`](https://godoc.org/github.com/spf13/pflag), [`flagnum`](https://godoc.org/github.com/luci/luci-go/common/flag/flagenum) and set values on the `ComponentConfig` type prior to passing the pointer into the `ctrl.NewFromComponentConfig()`, example below.
+Since this design still requires setting up the initial `ComponentConfig` type and passing in a pointer to `ctrl.NewFromComponentConfig()` if you want to allow for the use of flags, your controller can use any of the different flagging interfaces. eg [`flag`](https://golang.org/pkg/flag/), [`pflag`](https://pkg.go.dev/github.com/spf13/pflag), [`flagnum`](https://pkg.go.dev/github.com/luci/luci-go/common/flag/flagenum) and set values on the `ComponentConfig` type prior to passing the pointer into the `ctrl.NewFromComponentConfig()`, example below.
 
 ```golang
 leaderElect := true
@@ -247,7 +247,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	configv1alpha1 "sigs.k8s.io/controller-runtime/pkg/apis/config/v1alpha1"
-) 
+)
 
 type ControllerNameConfigurationSpec struct {
 	configv1alpha1.ControllerManagerConfiguration `json:",inline"`

--- a/doc.go
+++ b/doc.go
@@ -107,7 +107,7 @@ limitations under the License.
 //
 // Logging (pkg/log) in controller-runtime is done via structured logs, using a
 // log set of interfaces called logr
-// (https://godoc.org/github.com/go-logr/logr).  While controller-runtime
+// (https://pkg.go.dev/github.com/go-logr/logr).  While controller-runtime
 // provides easy setup for using Zap (https://go.uber.org/zap, pkg/log/zap),
 // you can provide any implementation of logr as the base logger for
 // controller-runtime.

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -227,7 +227,7 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 
 // convertFromUnstructuredIfNecessary will convert *unstructured.Unstructured for a GVK that is recocnized
 // by the schema into the whatever the schema produces with New() for said GVK.
-// This is required because the tracker unconditionally saves on manipulations, but it's List() implementation
+// This is required because the tracker unconditionally saves on manipulations, but its List() implementation
 // tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
 // we save as the very same type, otherwise subsequent List requests will fail.
 func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -345,7 +345,7 @@ func mutate(f MutateFn, key client.ObjectKey, obj client.Object) error {
 	return nil
 }
 
-// MutateFn is a function which mutates the existing object into it's desired state.
+// MutateFn is a function which mutates the existing object into its desired state.
 type MutateFn func() error
 
 // AddFinalizer accepts an Object and adds the provided finalizer if not present.

--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -177,7 +177,7 @@ func (l *DelegatingLogSink) Fulfill(actual logr.LogSink) {
 }
 
 // NewDelegatingLogSink constructs a new DelegatingLogSink which uses
-// the given logger before it's promise is fulfilled.
+// the given logger before its promise is fulfilled.
 func NewDelegatingLogSink(initial logr.LogSink) *DelegatingLogSink {
 	l := &DelegatingLogSink{
 		logger:  initial,

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -29,7 +29,7 @@ limitations under the License.
 //
 // All logging in controller-runtime is structured, using a set of interfaces
 // defined by a package called logr
-// (https://godoc.org/github.com/go-logr/logr).  The sub-package zap provides
+// (https://pkg.go.dev/github.com/go-logr/logr).  The sub-package zap provides
 // helpers for setting up logr backed by Zap (go.uber.org/zap).
 package log
 

--- a/pkg/log/warning_handler.go
+++ b/pkg/log/warning_handler.go
@@ -47,7 +47,7 @@ type KubeAPIWarningLogger struct {
 }
 
 // HandleWarningHeader handles logging for responses from API server that are
-// warnings with code being 299 and uses a logr.Logger for it's logging purposes.
+// warnings with code being 299 and uses a logr.Logger for its logging purposes.
 func (l *KubeAPIWarningLogger) HandleWarningHeader(code int, agent string, message string) {
 	if code != 299 || len(message) == 0 {
 		return

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -138,7 +138,7 @@ type Options struct {
 	// console when Development is true and JSON otherwise
 	Encoder zapcore.Encoder
 	// EncoderConfigOptions can modify the EncoderConfig needed to initialize an Encoder.
-	// See https://godoc.org/go.uber.org/zap/zapcore#EncoderConfig for the list of options
+	// See https://pkg.go.dev/go.uber.org/zap/zapcore#EncoderConfig for the list of options
 	// that can be configured.
 	// Note that the EncoderConfigOptions are not applied when the Encoder option is already set.
 	EncoderConfigOptions []EncoderConfigOption

--- a/tools/setup-envtest/store/store.go
+++ b/tools/setup-envtest/store/store.go
@@ -229,7 +229,7 @@ func (s *Store) Remove(ctx context.Context, matching Filter) ([]Item, error) {
 func (s *Store) Path(item Item) (string, error) {
 	path := s.unpackedPath(item.dirName())
 	// NB(directxman12): we need root's realpath because RealPath only
-	// looks at it's own path, and so thus doesn't prepend the underlying
+	// looks at its own path, and so thus doesn't prepend the underlying
 	// root's base path.
 	//
 	// Technically, if we're fed something that's double wrapped as root,


### PR DESCRIPTION
Links to godoc.org seem to unconditionally and permanently redirect to pkg.go.dev nowadays:

```bash
$ curl -I https://godoc.org/github.com/go-logr/logr
HTTP/2 301
date: Mon, 27 Dec 2021 18:53:05 GMT
content-type: text/html; charset=utf-8
location: https://pkg.go.dev/github.com/go-logr/logr?utm_source=godoc
x-cloud-trace-context: 22d12027c3a1e74c4ccb40ccfc47d4cb/10602237531594422575;o=1
via: 1.1 google
```

This PR therefore changes the links to pkg.go.dev. I also noticed one typo and then looked and found a couple of other places where `it's` and `its` were mixed up.