### PR TITLE
🐛  fix bug when set renewDeadline greater than leaseDuration the control…

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -393,7 +393,6 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		livenessEndpointName:          options.LivenessEndpointName,
 		gracefulShutdownTimeout:       *options.GracefulShutdownTimeout,
 		internalProceduresStop:        make(chan struct{}),
-		leaderElectionStopped:         make(chan struct{}),
 		leaderElectionReleaseOnCancel: options.LeaderElectionReleaseOnCancel,
 	}, nil
 }


### PR DESCRIPTION
fix bug when set renewDeadline greater than leaseDuration the controller will hang and no error will be return

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->



Issue: https://github.com/kubernetes-sigs/controller-runtime/issues/1760
