### PR TITLE
:bug: skip mutation handler when received deletion verb

### DIFF
--- a/pkg/webhook/admission/defaulter_test.go
+++ b/pkg/webhook/admission/defaulter_test.go
@@ -1,0 +1,68 @@
+package admission
+
+import (
+	"context"
+	"net/http"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("Defaulter Handler", func() {
+
+	It("should return ok if received delete verb in defaulter handler", func() {
+		obj := &TestDefaulter{}
+		handler := DefaultingWebhookFor(obj)
+
+		resp := handler.Handle(context.TODO(), Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				OldObject: runtime.RawExtension{
+					Raw: []byte("{}"),
+				},
+			},
+		})
+		Expect(resp.Allowed).Should(BeTrue())
+		Expect(resp.Result.Code).Should(Equal(int32(http.StatusOK)))
+	})
+
+})
+
+// TestDefaulter.
+var _ runtime.Object = &TestDefaulter{}
+
+type TestDefaulter struct {
+	Replica int `json:"replica,omitempty"`
+}
+
+var testDefaulterGVK = schema.GroupVersionKind{Group: "foo.test.org", Version: "v1", Kind: "TestDefaulter"}
+
+func (d *TestDefaulter) GetObjectKind() schema.ObjectKind { return d }
+func (d *TestDefaulter) DeepCopyObject() runtime.Object {
+	return &TestDefaulter{
+		Replica: d.Replica,
+	}
+}
+
+func (d *TestDefaulter) GroupVersionKind() schema.GroupVersionKind {
+	return testDefaulterGVK
+}
+
+func (d *TestDefaulter) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
+
+var _ runtime.Object = &TestDefaulterList{}
+
+type TestDefaulterList struct{}
+
+func (*TestDefaulterList) GetObjectKind() schema.ObjectKind { return nil }
+func (*TestDefaulterList) DeepCopyObject() runtime.Object   { return nil }
+
+func (d *TestDefaulter) Default() {
+	if d.Replica < 2 {
+		d.Replica = 2
+	}
+}


### PR DESCRIPTION
Signed-off-by: AnyISalIn <anyisalin@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

We should always return zero patches when receiving a DELETE operation in the mutation handle.

Reference Issues:
  https://github.com/kubernetes-sigs/controller-runtime/issues/1762
  https://github.com/kubernetes-sigs/controller-runtime/issues/1278
