### PR TITLE
⚠ leaderelection: use 'leases' as default resource lock object

### DIFF
--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -27,6 +27,7 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
 )
 
@@ -39,7 +40,7 @@ type Options struct {
 	LeaderElection bool
 
 	// LeaderElectionResourceLock determines which resource lock to use for leader election,
-	// defaults to "configmapsleases".
+	// defaults to "leases".
 	LeaderElectionResourceLock string
 
 	// LeaderElectionNamespace determines the namespace in which the leader
@@ -57,11 +58,12 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 		return nil, nil
 	}
 
-	// Default resource lock to "configmapsleases". We must keep this default until we are sure all controller-runtime
-	// users have upgraded from the original default ConfigMap lock to a controller-runtime version that has this new
-	// default. Many users of controller-runtime skip versions, so we should be extremely conservative here.
+	// Default resource lock to "leases". The previous default (from v0.7.0 to v0.11.x) was configmapsleases, which was
+	// used to migrate from configmaps to leases. Since the default was "configmapsleases" for over a year, spanning
+	// five minor releases, any actively maintained operators are very likely to have a released version that uses
+	// "configmapsleases". Therefore defaulting to "leases" should be safe.
 	if options.LeaderElectionResourceLock == "" {
-		options.LeaderElectionResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		options.LeaderElectionResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	// LeaderElectionID must be provided to prevent clashes


### PR DESCRIPTION
Update the default resource lock from `configmapsleases` to `leases`.

The previous default (since v0.7.0) was `configmapsleases`, which is the migration step from `configmaps` to `leases`. Since the default was `configmapsleases` for over a year, spanning five minor releases, any actively maintained operators are very likely to have a released version that uses `configmapsleases`. Therefore defaulting to `leases` now should be safe.

Any operators currently on a version <0.7.0 should migrate from `configmaps` to `leases` via `configmapsleases`.
- If an operator is currently on version <v0.7.0, it is hardcoded to using `configmaps`
- If an operator is currently in the range v0.7.0 to a version prior to this PR merging, it is configurable, but defaulted to `configmapsleases`.
- If an operator is using a version of controller-runtime containing this PR, it is configurable but defaulted to `leases`.

Operators currently using `configmaps` should:
1. Release a version (A) of their operator that uses controller-runtime v0.7.0+ (if jumping directly to a version of controller-runtime containing this PR, you should explicitly set `configmapsleases` when configuring leader election in this version)
2. Release a subsequent version (B) of their operator that uses a version of controller-runtime containing this PR (or if not bumping, you should explicitly set `leases` when configuring leader election in this version)
3. Ensure operators upgrade through A before getting to B.

See https://github.com/kubernetes/kubernetes/issues/107454 (This PR moves controller-runtime from step x+1 to x+2)

Signed-off-by: Joe Lanford <joe.lanford@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
