### PR TITLE
🐛 Trim List if List GVK is provided

### DIFF
--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -96,11 +96,11 @@ func (ip *informerCache) objectTypeForListObject(list client.ObjectList) (*schem
 		return nil, nil, err
 	}
 
-	if !strings.HasSuffix(gvk.Kind, "List") {
-		return nil, nil, fmt.Errorf("non-list type %T (kind %q) passed as output", list, gvk)
-	}
 	// we need the non-list GVK, so chop off the "List" from the end of the kind
-	gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	if strings.HasSuffix(gvk.Kind, "List") && apimeta.IsListType(list) {
+		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
+	}
+
 	_, isUnstructured := list.(*unstructured.UnstructuredList)
 	var cacheTypeObj runtime.Object
 	if isUnstructured {


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
`List` suffix is not required for listing `UnstrcuturedList` objects in some parts of the client. This makes it so for the cached client.

https://github.com/kubernetes-sigs/controller-runtime/blob/b8db76e66383819c94f530bd4b8dea60025b716f/pkg/client/client_cache.go#L57-L60

