### PR TITLE
🐛 Inject func in `predicate.{And,Or}`

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 var log = logf.RuntimeLog.WithName("predicate").WithName("eventFilters")
@@ -239,6 +240,15 @@ type and struct {
 	predicates []Predicate
 }
 
+func (a and) InjectFunc(f inject.Func) error {
+	for _, p := range a.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (a and) Create(e event.CreateEvent) bool {
 	for _, p := range a.predicates {
 		if !p.Create(e) {
@@ -282,6 +292,15 @@ func Or(predicates ...Predicate) Predicate {
 
 type or struct {
 	predicates []Predicate
+}
+
+func (o or) InjectFunc(f inject.Func) error {
+	for _, p := range o.predicates {
+		if err := f(p); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (o or) Create(e event.CreateEvent) bool {


### PR DESCRIPTION
Pass down injector in `predicate.{And,Or}` to sub-predicates.

I'm aware, that the injection mechanisms are deprecated.
However, it comes as a surprise to users that `And,Or` don't pass down the injector. Hence, I'm opening this PR to discuss fixing this unexpected behavior.