### PR TITLE
:bug: Panic in `APIServer.Stop` when `Authn == nil`

### DIFF
--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -421,7 +421,10 @@ func (s *APIServer) Stop() error {
 			return err
 		}
 	}
-	return s.Authn.Stop()
+	if s.Authn != nil {
+		return s.Authn.Stop()
+	}
+	return nil
 }
 
 // APIServerDefaultArgs exposes the default args for the APIServer so that you


### PR DESCRIPTION
After a test using this repo which failed with an error like

```
ERROR	controller-runtime.test-env	unable to start the controlplane	{"tries": 4, "error": "timeout waiting for process etcd to start successfully (it may have failed to start, or stopped unexpectedly before becoming ready)"}
sigs.k8s.io/controller-runtime/pkg/envtest.(*Environment).startControlPlane
	~/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/envtest/server.go:330
sigs.k8s.io/controller-runtime/pkg/envtest.(*Environment).Start
	~/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/envtest/server.go:260
…
```

I saw a further error

```
Test Panicked
runtime error: invalid memory address or nil pointer dereference

Full Stack Trace
sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane.(*APIServer).Stop(0x14)
	~/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/testing/controlplane/apiserver.go:425 +0x8f
sigs.k8s.io/controller-runtime/pkg/internal/testing/controlplane.(*ControlPlane).Stop(0xc00001a000)
	~/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/internal/testing/controlplane/plane.go:87 +0x3d
sigs.k8s.io/controller-runtime/pkg/envtest.(*Environment).Stop(0xc00001a000)
	~/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.11.0/pkg/envtest/server.go:194 +0x114
…
```

This seems to be similar to #1724 (merged toward 0.11.0). Maybe related to #1750?

Untested (not known how to reproduce the original error with `etcd`).
