### PR TITLE
Try a temporary directory if the user cache fails

### DIFF
--- a/pkg/internal/testing/addr/manager.go
+++ b/pkg/internal/testing/addr/manager.go
@@ -43,11 +43,17 @@ var (
 
 func init() {
 	baseDir, err := os.UserCacheDir()
-	if err != nil {
-		baseDir = os.TempDir()
+	if err == nil {
+		cacheDir = filepath.Join(baseDir, "kubebuilder-envtest")
+		err = os.MkdirAll(cacheDir, 0o750)
 	}
-	cacheDir = filepath.Join(baseDir, "kubebuilder-envtest")
-	if err := os.MkdirAll(cacheDir, 0750); err != nil {
+	if err != nil {
+		// Either we didn't get a cache directory, or we can't use it
+		baseDir = os.TempDir()
+		cacheDir = filepath.Join(baseDir, "kubebuilder-envtest")
+		err = os.MkdirAll(cacheDir, 0o750)
+	}
+	if err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
Since commit 58c17f6 ("addr.Suggest should lock a file instead of
memory"), pkg/internal/testing/addr/manager.go’s init() function tries
to create a directory using either os.UserCacheDir() or os.TempDir(),
whichever succeeds first. In many build environments, $HOME is
non-empty but points to an unusable directory; in such cases,
os.UserCacheDir() returns an unusable directory, which causes init()
to panic.

This changes init() to first try os.UserCacheDir(), including creating
the desired directory; if that fails, the whole operation is tried
again with os.TempDir().

Fixes: #1799
Signed-off-by: Stephen Kitt <skitt@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
