### PR TITLE
:bug: Cache sync cancelled should not error with timeout

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -175,6 +175,9 @@ func (ks *Kind) WaitForSync(ctx context.Context) error {
 		return err
 	case <-ctx.Done():
 		ks.startCancel()
+		if ctx.Err() == context.Canceled {
+			return nil
+		}
 		return errors.New("timed out waiting for cache to be synced")
 	}
 }


### PR DESCRIPTION
This fixes the false cache sync timeout error reported if context cancelled right after cache sync has started. This situation seems to happen quite frequently on rolling updates when leader election enabled.

Fixes #1786

I am not too familiar with the controller-runtime codebase, so please let me know if you think more could be done to better support context cancellation.