### PR TITLE
[WIP] 🌱 Enable per-reconcile logger customization

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -154,6 +154,13 @@ func (blder *Builder) WithLogger(log logr.Logger) *Builder {
 	return blder
 }
 
+// WithLoggerCustomizer sets a LoggerCustomizer which allows per-reconcile customization
+// of the logger.
+func (blder *Builder) WithLoggerCustomizer(loggerCustomizer func(logr.Logger, reconcile.Request) logr.Logger) *Builder {
+	blder.ctrlOptions.LoggerCustomizer = loggerCustomizer
+	return blder
+}
+
 // Named sets the name of the controller to the given name.  The name shows up
 // in metrics, among other things, and thus should be a prometheus compatible name
 // (underscores and alphanumeric characters only).

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -50,6 +50,9 @@ type Options struct {
 	// request via the context field.
 	Log logr.Logger
 
+	// LoggerCustomizer customizes the logger for individual reconciliations.
+	LoggerCustomizer func(logr.Logger, reconcile.Request) logr.Logger
+
 	// CacheSyncTimeout refers to the time limit set to wait for syncing caches.
 	// Defaults to 2 minutes if not set.
 	CacheSyncTimeout time.Duration
@@ -137,6 +140,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		SetFields:               mgr.SetFields,
 		Name:                    name,
 		Log:                     options.Log.WithName("controller").WithName(name).WithValues("controller", name),
+		LoggerCustomizer:        options.LoggerCustomizer,
 		RecoverPanic:            options.RecoverPanic,
 	}, nil
 }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
For more details please see #1811

PR is currently [WIP] as it's only meant to illustrate a possible solution for #1811.

