### PR TITLE
🐛  prometheus/client_golang 0.11.0 -> 0.11.1 - fix DoS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/zapr v1.2.0
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.17.0
-	github.com/prometheus/client_golang v1.11.0
+	github.com/prometheus/client_golang v1.11.1
 	github.com/prometheus/client_model v0.2.0
 	go.uber.org/goleak v1.1.12
 	go.uber.org/zap v1.19.1

--- a/go.sum
+++ b/go.sum
@@ -376,8 +376,9 @@ github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXP
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
+github.com/prometheus/client_golang v1.11.1 h1:+4eQaD7vAZ6DsfsxB15hbE0odUjGI5ARs9yskGu1v4s=
+github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=


### PR DESCRIPTION
This PR fixes https://github.com/golang/vulndb/issues/322 by replacing the vulnerable module with a non-vulnerable release.

```
 Medium severity vulnerability found in github.com/prometheus/client_golang/prometheus/promhttp
  Description: Denial of Service (DoS)
  Info: https://snyk.io/vuln/SNYK-GOLANG-GITHUBCOMPROMETHEUSCLIENTGOLANGPROMETHEUSPROMHTTP-2401819
  Introduced through: sigs.k8s.io/controller-runtime@0.11.1, sigs.k8s.io/controller-runtime/pkg/webhook@0.11.1
  From: sigs.k8s.io/controller-runtime@0.11.1 > sigs.k8s.io/controller-runtime/pkg/manager@0.11.1 > github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  From: sigs.k8s.io/controller-runtime/pkg/webhook@0.11.1 > sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics@0.11.1 > github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  From: sigs.k8s.io/controller-runtime@0.11.1 > sigs.k8s.io/controller-runtime/pkg/manager@0.11.1 > sigs.k8s.io/controller-runtime/pkg/webhook@0.11.1 > sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics@0.11.1 > github.com/prometheus/client_golang/prometheus/promhttp@1.11.0
  Fixed in: 1.11.1
```