### PR TITLE
:sparkles: [WIP]  handle "no kind is registered for the type" errors

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -182,11 +182,19 @@ func (c *client) RESTMapper() meta.RESTMapper {
 func (c *client) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
 	switch obj.(type) {
 	case *unstructured.Unstructured:
-		return c.unstructuredClient.Create(ctx, obj, opts...)
+		err := c.unstructuredClient.Create(ctx, obj, opts...)
+		if err != nil && runtime.IsNotRegisteredError(err) {
+			return fmt.Errorf("custom IsNotRegisteredError:%w", err)
+		}
+		return err
 	case *metav1.PartialObjectMetadata:
 		return fmt.Errorf("cannot create using only metadata")
 	default:
-		return c.typedClient.Create(ctx, obj, opts...)
+		err := c.typedClient.Create(ctx, obj, opts...)
+		if err != nil && runtime.IsNotRegisteredError(err) {
+			return fmt.Errorf("custom IsNotRegisteredError:%w", err)
+		}
+		return err
 	}
 }
 


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
When a kind is not registered in the scheme, it returns a typed error.
This PR handles that error and returns a more user friendly error message.

Fixes: #492 

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>