### PR TITLE
:book: Add documentation for zap-time-encoding flag

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -257,6 +257,8 @@ func NewRaw(opts ...Opts) *zap.Logger {
 //  zap-log-level:  Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
 //			       or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
 //  zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
+//  zap-time-encoding: Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano').
+//                    Defaults to 'epoch'.
 func (o *Options) BindFlags(fs *flag.FlagSet) {
 	// Set Development mode value
 	fs.BoolVar(&o.Development, "zap-devel", o.Development,


### PR DESCRIPTION
In #1688 the `zap-time-encoding` flag was added. Unfortunately I missed to update the documentation of `Options.BindFlags`, so this flag is not really described in the doc.
This PR addresses it and adds the documenation for the `zap-time-encoding` flag so it shows up in the [go-doc](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log/zap#Options.BindFlags).