### PR TITLE
✨ [WIP] Improve performance of CreateOrPatch

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -304,7 +304,7 @@ func CreateOrPatch(ctx context.Context, c client.Client, obj client.Object, f Mu
 		result = OperationResultUpdated
 	}
 
-	if (hasBeforeStatus || hasAfterStatus) && !reflect.DeepEqual(beforeStatus, afterStatus) {
+	if hasBeforeStatus && hasAfterStatus && !reflect.DeepEqual(beforeStatus, afterStatus) {
 		// Only issue a Status Patch if the resource has a status and the beforeStatus
 		// and afterStatus copies differ
 		if result == OperationResultUpdated {


### PR DESCRIPTION
When either of the before/after objects has no status data, the
reflect.DeepEqual call becomes redundant because comparing of
existing to non-existing always returns False.

Switch the logical OR condition to AND. That saves us a single
reflect.DeepEqual() call each time we end up with an object without
status after its mutation func was called (or before that).

Signed-off-by: Bogdan Dobrelya <bdobreli@redhat.com>