### PR TITLE
:bug: zap-time-encoding test should allow negative tz offset

### DIFF
--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -528,7 +528,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 		It("Should propagate time encoder to logger", func() {
 			// zaps ISO8601TimeEncoder uses 2006-01-02T15:04:05.000Z0700 as pattern for iso8601 encoding
-			iso8601Pattern := `^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(\+[0-9]{4}|Z)`
+			iso8601Pattern := `^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}([-+][0-9]{4}|Z)`
 
 			args := []string{"--zap-time-encoding=iso8601"}
 			fromFlags.BindFlags(&fs)


### PR DESCRIPTION
The regex used to test whether the times were being properly encoded as ISO8601 only permitted either positive tz offsets or Z. This fix adjusts the regex to also allow negative offsets.

Ref: [Wikipedia: ISO 8601 - Time offsets from UTC](https://en.wikipedia.org/wiki/ISO_8601#Time_offsets_from_UTC)

Example of failure when running on my local machine:
```
Zap log level flag options setup
/home/jstrunk/src/controller-runtime/pkg/log/zap/zap_test.go:281
  with zap-time-encoding flag provided
  /home/jstrunk/src/controller-runtime/pkg/log/zap/zap_test.go:487
    Should propagate time encoder to logger [It]
    /home/jstrunk/src/controller-runtime/pkg/log/zap/zap_test.go:529

    Expected
        <string>: 2022-04-05T11:35:03.086-0400
    to match regular expression
        <string>: ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}(\+[0-9]{4}|Z)

    /home/jstrunk/src/controller-runtime/pkg/log/zap/zap_test.go:546
```