### PR TITLE
🐛 pkg: envtest: komega: fix UpdateStatus & typos in godoc

### DIFF
--- a/pkg/envtest/komega/default.go
+++ b/pkg/envtest/komega/default.go
@@ -61,7 +61,7 @@ func Update(obj client.Object, f func(), opts ...client.UpdateOption) func() err
 // UpdateStatus returns a function that fetches a resource, applies the provided update function and then updates the resource's status.
 // It can be used with gomega.Eventually() like this:
 //   deployment := appsv1.Deployment{ ... }
-//   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
+//   gomega.Eventually(k.UpdateStatus(&deployment, func (o client.Object) {
 //     deployment.Status.AvailableReplicas = 1
 //     return &deployment
 //   })).To(gomega.Scucceed())

--- a/pkg/envtest/komega/default.go
+++ b/pkg/envtest/komega/default.go
@@ -51,7 +51,7 @@ func List(list client.ObjectList, opts ...client.ListOption) func() error {
 //   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
 //     deployment.Spec.Replicas = 3
 //     return &deployment
-//   })).To(gomega.Scucceed())
+//   })).To(gomega.Succeed())
 // By calling the returned function directly it can also be used as gomega.Expect(k.Update(...)()).To(...)
 func Update(obj client.Object, f func(), opts ...client.UpdateOption) func() error {
 	checkDefaultClient()
@@ -64,7 +64,7 @@ func Update(obj client.Object, f func(), opts ...client.UpdateOption) func() err
 //   gomega.Eventually(k.UpdateStatus(&deployment, func (o client.Object) {
 //     deployment.Status.AvailableReplicas = 1
 //     return &deployment
-//   })).To(gomega.Scucceed())
+//   })).To(gomega.Succeed())
 // By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
 func UpdateStatus(obj client.Object, f func(), opts ...client.UpdateOption) func() error {
 	checkDefaultClient()

--- a/pkg/envtest/komega/interfaces.go
+++ b/pkg/envtest/komega/interfaces.go
@@ -45,7 +45,7 @@ type Komega interface {
 	//   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
 	//     deployment.Spec.Replicas = 3
 	//     return &deployment
-	//   })).To(gomega.Scucceed())
+	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.Update(...)()).To(...)
 	Update(client.Object, func(), ...client.UpdateOption) func() error
 
@@ -55,7 +55,7 @@ type Komega interface {
 	//   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
 	//     deployment.Status.AvailableReplicas = 1
 	//     return &deployment
-	//   })).To(gomega.Scucceed())
+	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
 	UpdateStatus(client.Object, func(), ...client.UpdateOption) func() error
 


### PR DESCRIPTION
- It fixes envtest's komega `UpdateStatus()` godoc example to reference the corresponding function call (`UpdateStatus()`) rather than the `Update()` one.
- It fixes some typos in envtest's komega godoc examples by replacing `Scucceed()` with `Succeed()`.