### PR TITLE
✨ Improve the fake client builder with WithObjectTracker option

### DIFF
--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/client-go/kubernetes/fake"
 	"time"
+
+	"k8s.io/client-go/kubernetes/fake"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"


### PR DESCRIPTION
This pr improves the fake client with `WithObjectTracker` option.
This is useful when users want to set up unit tests across different fake client.
For example, when users are testing with client-go and kubebuilder, users will create a fake clientSet and a fake client.
Users can get the object tracker from the fake clientSet and set it to the fake controller-runtime client by this new option to let them share the same fake resources.
This will allow users to write more unit tests.