### PR TITLE
:running: Update golangci-lint to 1.45.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.40.1
+          version: v1.45.2
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,6 +121,11 @@ issues:
   - linters:
     - gocritic
     text: "singleCaseSwitch: should rewrite switch statement to if statement"
+  # It considers all file access to a filename that comes from a variable problematic,
+  # which is naiv at best.
+  - linters:
+    - gosec
+    text: "G304: Potential file inclusion via variable"
 
 run:
   timeout: 10m

--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -167,7 +167,7 @@ func writeCerts(certPath, keyPath, ip string) error {
 		return err
 	}
 
-	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600) //nolint:gosec
+	keyOut, err := os.OpenFile(keyPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1110,7 +1110,7 @@ var _ = Describe("Client", func() {
 				By("initially creating two Deployments")
 
 				dep2 := dep.DeepCopy()
-				dep2.Name = dep2.Name + "-2"
+				dep2.Name += "-2"
 
 				dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1209,7 +1209,7 @@ var _ = Describe("Client", func() {
 				By("initially creating two Deployments")
 
 				dep2 := dep.DeepCopy()
-				dep2.Name = dep2.Name + "-2"
+				dep2.Name += "-2"
 
 				dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -1295,7 +1295,7 @@ var _ = Describe("Client", func() {
 				By("initially creating two Deployments")
 
 				dep2 := dep.DeepCopy()
-				dep2.Name = dep2.Name + "-2"
+				dep2.Name += "-2"
 
 				dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -352,9 +352,7 @@ func (c *fakeClient) Watch(ctx context.Context, list client.ObjectList, opts ...
 		return nil, err
 	}
 
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	listOpts := client.ListOptions{}
 	listOpts.ApplyOptions(opts)
@@ -371,9 +369,7 @@ func (c *fakeClient) List(ctx context.Context, obj client.ObjectList, opts ...cl
 
 	originalKind := gvk.Kind
 
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	if _, isUnstructuredList := obj.(*unstructured.UnstructuredList); isUnstructuredList && !c.scheme.Recognizes(gvk) {
 		// We need to register the ListKind with UnstructuredList:

--- a/pkg/client/metadata_client.go
+++ b/pkg/client/metadata_client.go
@@ -146,9 +146,7 @@ func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...List
 	}
 
 	gvk := metadata.GroupVersionKind()
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	listOpts := ListOptions{}
 	listOpts.ApplyOptions(opts)

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -95,8 +95,7 @@ func (uc *unstructuredClient) Update(ctx context.Context, obj Object, opts ...Up
 
 // Delete implements client.Client.
 func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if !ok {
+	if _, ok := obj.(*unstructured.Unstructured); !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
@@ -118,8 +117,7 @@ func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...De
 
 // DeleteAllOf implements client.Client.
 func (uc *unstructuredClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if !ok {
+	if _, ok := obj.(*unstructured.Unstructured); !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
@@ -141,8 +139,7 @@ func (uc *unstructuredClient) DeleteAllOf(ctx context.Context, obj Object, opts 
 
 // Patch implements client.Client.
 func (uc *unstructuredClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if !ok {
+	if _, ok := obj.(*unstructured.Unstructured); !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
@@ -201,9 +198,7 @@ func (uc *unstructuredClient) List(ctx context.Context, obj ObjectList, opts ...
 	}
 
 	gvk := u.GroupVersionKind()
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	listOpts := ListOptions{}
 	listOpts.ApplyOptions(opts)
@@ -222,8 +217,7 @@ func (uc *unstructuredClient) List(ctx context.Context, obj ObjectList, opts ...
 }
 
 func (uc *unstructuredClient) UpdateStatus(ctx context.Context, obj Object, opts ...UpdateOption) error {
-	_, ok := obj.(*unstructured.Unstructured)
-	if !ok {
+	if _, ok := obj.(*unstructured.Unstructured); !ok {
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 

--- a/pkg/client/watch.go
+++ b/pkg/client/watch.go
@@ -69,9 +69,7 @@ func (w *watchingClient) listOpts(opts ...ListOption) ListOptions {
 
 func (w *watchingClient) metadataWatch(ctx context.Context, obj *metav1.PartialObjectMetadataList, opts ...ListOption) (watch.Interface, error) {
 	gvk := obj.GroupVersionKind()
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	listOpts := w.listOpts(opts...)
 
@@ -85,9 +83,7 @@ func (w *watchingClient) metadataWatch(ctx context.Context, obj *metav1.PartialO
 
 func (w *watchingClient) unstructuredWatch(ctx context.Context, obj *unstructured.UnstructuredList, opts ...ListOption) (watch.Interface, error) {
 	gvk := obj.GroupVersionKind()
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	r, err := w.client.unstructuredClient.cache.getResource(obj)
 	if err != nil {

--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -426,7 +426,7 @@ func readCRDs(basePath string, files []os.FileInfo) ([]*apiextensionsv1.CustomRe
 
 // readDocuments reads documents from file.
 func readDocuments(fp string) ([][]byte, error) {
-	b, err := ioutil.ReadFile(fp) //nolint:gosec
+	b, err := ioutil.ReadFile(fp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/internal/flock/flock_unix.go
+++ b/pkg/internal/flock/flock_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || openbsd || netbsd || dragonfly
 // +build linux darwin freebsd openbsd netbsd dragonfly
 
 /*

--- a/pkg/manager/signals/signal_posix.go
+++ b/pkg/manager/signals/signal_posix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 /*

--- a/tools/setup-envtest/workflows/workflows_test.go
+++ b/tools/setup-envtest/workflows/workflows_test.go
@@ -369,7 +369,7 @@ var _ = Describe("Workflows", func() {
 		})
 
 		It("should remove matching versions from the store & keep non-matching ones", func() {
-			entries, err := env.FS.ReadDir(filepath.Join(".teststore/k8s"))
+			entries, err := env.FS.ReadDir(".teststore/k8s")
 			Expect(err).NotTo(HaveOccurred(), "should be able to read the store")
 			Expect(entries).To(ConsistOf(
 				WithTransform(fs.FileInfo.Name, Equal("1.16.2-ifonlysingularitywasstillathing-amd64")),


### PR DESCRIPTION
The current version fails on files that are unchanged, e.G. here: https://github.com/kubernetes-sigs/controller-runtime/pull/1864/files#diff-5d81d5921628c398d14ca10b459beaf11485365684008a771587421685f30dd2

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
