### PR TITLE
:warning:  make fake client delete operations honor dry run opt

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -473,6 +473,12 @@ func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...clie
 	delOptions := client.DeleteOptions{}
 	delOptions.ApplyOptions(opts)
 
+	for _, dryRunOpt := range delOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
+
 	// Check the ResourceVersion if that Precondition was specified.
 	if delOptions.Preconditions != nil && delOptions.Preconditions.ResourceVersion != nil {
 		name := accessor.GetName()
@@ -506,6 +512,12 @@ func (c *fakeClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ..
 
 	dcOptions := client.DeleteAllOfOptions{}
 	dcOptions.ApplyOptions(opts)
+
+	for _, dryRunOpt := range dcOptions.DryRun {
+		if dryRunOpt == metav1.DryRunAll {
+			return nil
+		}
+	}
 
 	gvr, _ := meta.UnsafeGuessKindToResource(gvk)
 	o, err := c.tracker.List(gvr, gvk, dcOptions.Namespace)

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -830,6 +830,27 @@ var _ = Describe("Fake client", func() {
 				Expect(obj).To(Equal(cm))
 				Expect(obj.ObjectMeta.ResourceVersion).To(Equal(trackerAddResourceVersion))
 			})
+
+			It("Should not Delete the object", func() {
+				By("Deleting a configmap with DryRun with Delete()")
+				err := cl.Delete(context.Background(), cm, client.DryRunAll)
+				Expect(err).To(BeNil())
+
+				By("Deleting a configmap with DryRun with DeleteAllOf()")
+				err = cl.DeleteAllOf(context.Background(), cm, client.DryRunAll)
+				Expect(err).To(BeNil())
+
+				By("Getting the configmap")
+				namespacedName := types.NamespacedName{
+					Name:      "test-cm",
+					Namespace: "ns2",
+				}
+				obj := &corev1.ConfigMap{}
+				err = cl.Get(context.Background(), namespacedName, obj)
+				Expect(err).To(BeNil())
+				Expect(obj).To(Equal(cm))
+				Expect(obj.ObjectMeta.ResourceVersion).To(Equal(trackerAddResourceVersion))
+			})
 		})
 
 		It("should be able to Patch", func() {


### PR DESCRIPTION
Signed-off-by: Bryce Palmer <bpalmer@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This adds functionality to the `fakeClient` to honor dry run options when using the `Delete` or `DeleteAllOf` functions. This functionality was already present for `Create`, `Update`, and `Patch` but was missing from `Delete` and `DeleteAllOf`

This is marked as a breaking change due to this comment left on Slack by @alvaroaleman : https://kubernetes.slack.com/archives/C02MRBMN00Z/p1650560938460609?thread_ts=1650560794.722809&cid=C02MRBMN00Z

fixes #1871 
