### PR TITLE
:seedling: do not use io/ioutil anymore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -64,6 +64,10 @@ linters-settings:
     go: "1.18"
   stylecheck:
     go: "1.18"
+  depguard:
+    include-go-root: true
+    packages:
+      - io/ioutil # https://go.dev/doc/go1.16#ioutil
 
 issues:
   max-same-issues: 0

--- a/examples/scratch-env/main.go
+++ b/examples/scratch-env/main.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	goflag "flag"
-	"io/ioutil"
 	"os"
 
 	flag "github.com/spf13/pflag"
@@ -83,7 +82,7 @@ func runMain() int {
 	}
 
 	// TODO(directxman12): add support for writing to a new context in an existing file
-	kubeconfigFile, err := ioutil.TempFile("", "scratch-env-kubeconfig-")
+	kubeconfigFile, err := os.CreateTemp("", "scratch-env-kubeconfig-")
 	if err != nil {
 		log.Error(err, "unable to create kubeconfig file, continuing on without it")
 		return 1

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,7 +44,7 @@ var _ = Describe("Config", func() {
 	BeforeEach(func() {
 		// create temporary directory for test case
 		var err error
-		dir, err = ioutil.TempDir("", "cr-test")
+		dir, err = os.MkdirTemp("", "cr-test")
 		Expect(err).NotTo(HaveOccurred())
 
 		// override $HOME/.kube/config
@@ -192,7 +191,7 @@ func setConfigs(tc testCase, dir string) {
 
 func createFiles(files map[string]string, dir string) error {
 	for path, data := range files {
-		if err := ioutil.WriteFile(filepath.Join(dir, path), []byte(data), 0644); err != nil { //nolint:gosec
+		if err := os.WriteFile(filepath.Join(dir, path), []byte(data), 0644); err != nil { //nolint:gosec
 			return err
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -18,7 +18,7 @@ package config
 
 import (
 	"fmt"
-	ioutil "io/ioutil"
+	"os"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -96,7 +96,7 @@ func (d *DeferredFileLoader) loadFile() {
 		return
 	}
 
-	content, err := ioutil.ReadFile(d.path)
+	content, err := os.ReadFile(d.path)
 	if err != nil {
 		d.err = fmt.Errorf("could not read file at %s", d.path)
 		return

--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -19,7 +19,6 @@ package controlplane
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -385,10 +384,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil { //nolint:gosec
 		return err
 	}
-	if err := ioutil.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil { //nolint:gosec
 		return err
 	}
 
@@ -405,10 +404,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := ioutil.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0640); err != nil { //nolint:gosec
 		return err
 	}
-	return ioutil.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0640) //nolint:gosec
+	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0640) //nolint:gosec
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/pkg/internal/testing/controlplane/auth.go
+++ b/pkg/internal/testing/controlplane/auth.go
@@ -18,7 +18,7 @@ package controlplane
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"k8s.io/client-go/rest"
@@ -128,7 +128,7 @@ func (c *CertAuthn) Start() error {
 		return fmt.Errorf("start called before configure")
 	}
 	caCrt := c.ca.CA.CertBytes()
-	if err := ioutil.WriteFile(c.caCrtPath(), caCrt, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(c.caCrtPath(), caCrt, 0640); err != nil { //nolint:gosec
 		return fmt.Errorf("unable to save the client certificate CA to %s: %w", c.caCrtPath(), err)
 	}
 

--- a/pkg/internal/testing/controlplane/kubectl_test.go
+++ b/pkg/internal/testing/controlplane/kubectl_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controlplane_test
 
 import (
-	"io/ioutil"
+	"io"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -36,7 +36,7 @@ var _ = Describe("Kubectl", func() {
 		stdout, stderr, err := k.Run(args...)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stdout).To(ContainSubstring("something"))
-		bytes, err := ioutil.ReadAll(stderr)
+		bytes, err := io.ReadAll(stderr)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(bytes).To(BeEmpty())
 	})

--- a/pkg/internal/testing/process/process.go
+++ b/pkg/internal/testing/process/process.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -109,7 +108,7 @@ func (ps *State) Init(name string) error {
 	}
 
 	if ps.Dir == "" {
-		newDir, err := ioutil.TempDir("", "k8s_test_framework_")
+		newDir, err := os.MkdirTemp("", "k8s_test_framework_")
 		if err != nil {
 			return err
 		}

--- a/pkg/internal/testing/process/process_test.go
+++ b/pkg/internal/testing/process/process_test.go
@@ -18,7 +18,6 @@ package process_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -297,7 +296,7 @@ var _ = Describe("Stop method", func() {
 			var err error
 
 			Expect(processState.Start(nil, nil)).To(Succeed())
-			processState.Dir, err = ioutil.TempDir("", "k8s_test_framework_")
+			processState.Dir, err = os.MkdirTemp("", "k8s_test_framework_")
 			Expect(err).NotTo(HaveOccurred())
 			processState.DirNeedsCleaning = true
 			processState.StopTimeout = 400 * time.Millisecond

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -19,7 +19,6 @@ package leaderelection
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -120,7 +119,7 @@ func getInClusterNamespace() (string, error) {
 	}
 
 	// Load the namespace file and return its content
-	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
+	namespace, err := os.ReadFile(inClusterNamespacePath)
 	if err != nil {
 		return "", fmt.Errorf("error reading namespace file: %w", err)
 	}

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"path"
@@ -1186,7 +1186,7 @@ var _ = Describe("manger.Manager", func() {
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(200))
 
-				data, err := ioutil.ReadAll(resp.Body)
+				data, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(data)).To(ContainSubstring("%s\n%s\n%s\n",
 					`# HELP test_one test metric for testing`,
@@ -1229,7 +1229,7 @@ var _ = Describe("manger.Manager", func() {
 				defer resp.Body.Close()
 				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 
-				body, err := ioutil.ReadAll(resp.Body)
+				body, err := io.ReadAll(resp.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(body)).To(Equal("Some debug info"))
 			})

--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	v1 "k8s.io/api/admission/v1"
@@ -60,7 +59,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	if body, err = ioutil.ReadAll(r.Body); err != nil {
+	if body, err = io.ReadAll(r.Body); err != nil {
 		wh.log.Error(err, "unable to read the body from the incoming request")
 		reviewResponse = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, reviewResponse)

--- a/pkg/webhook/authentication/http.go
+++ b/pkg/webhook/authentication/http.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -60,7 +59,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	if body, err = ioutil.ReadAll(r.Body); err != nil {
+	if body, err = io.ReadAll(r.Body); err != nil {
 		wh.log.Error(err, "unable to read the body from the incoming request")
 		reviewResponse = Errored(err)
 		wh.writeResponse(w, reviewResponse)

--- a/pkg/webhook/conversion/conversion_test.go
+++ b/pkg/webhook/conversion/conversion_test.go
@@ -19,7 +19,7 @@ package conversion
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -70,7 +70,7 @@ var _ = Describe("Conversion Webhook", func() {
 
 		convReview := &apix.ConversionReview{}
 		req := &http.Request{
-			Body: ioutil.NopCloser(bytes.NewReader(payload.Bytes())),
+			Body: io.NopCloser(bytes.NewReader(payload.Bytes())),
 		}
 		webhook.ServeHTTP(respRecorder, req)
 		Expect(json.NewDecoder(respRecorder.Result().Body).Decode(convReview)).To(Succeed())

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -241,7 +240,7 @@ func (s *Server) Start(ctx context.Context) error {
 	// load CA to verify client certificate
 	if s.ClientCAName != "" {
 		certPool := x509.NewCertPool()
-		clientCABytes, err := ioutil.ReadFile(filepath.Join(s.CertDir, s.ClientCAName))
+		clientCABytes, err := os.ReadFile(filepath.Join(s.CertDir, s.ClientCAName))
 		if err != nil {
 			return fmt.Errorf("failed to read client CA cert: %w", err)
 		}

--- a/pkg/webhook/server_test.go
+++ b/pkg/webhook/server_test.go
@@ -19,7 +19,7 @@ package webhook_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 
@@ -136,7 +136,7 @@ var _ = Describe("Webhook Server", func() {
 				resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
 				Expect(err).NotTo(HaveOccurred())
 				defer resp.Body.Close()
-				return ioutil.ReadAll(resp.Body)
+				return io.ReadAll(resp.Body)
 			}).Should(Equal([]byte("gadzooks!")))
 
 			Expect(server.StartedChecker()(nil)).To(Succeed())
@@ -176,7 +176,7 @@ var _ = Describe("Webhook Server", func() {
 			Expect(err).NotTo(HaveOccurred())
 			defer resp.Body.Close()
 
-			Expect(ioutil.ReadAll(resp.Body)).To(Equal([]byte("gadzooks!")))
+			Expect(io.ReadAll(resp.Body)).To(Equal([]byte("gadzooks!")))
 		})
 
 		It("should inject dependencies, if an inject func has been provided already", func() {
@@ -201,7 +201,7 @@ var _ = Describe("Webhook Server", func() {
 			resp, err := client.Get(fmt.Sprintf("https://%s/somepath", testHostPort))
 			Expect(err).NotTo(HaveOccurred())
 			defer resp.Body.Close()
-			return ioutil.ReadAll(resp.Body)
+			return io.ReadAll(resp.Body)
 		}).Should(Equal([]byte("gadzooks!")))
 
 		ctxCancel()


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Go 1.16 deprecated the usage of `io/ioutil` and this PR performs the necessary changes to get rid of that package. Go 1.17 is the minimum supported version of controller-runtime since #1714 (November 2021).

/kind cleanup

Fixes #1518