### PR TITLE
:bug: Avoid nilref when copying leader election options from custom config

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -494,6 +494,11 @@ func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Opti
 }
 
 func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options {
+	if obj.LeaderElection == nil {
+		// The source does not have any configuration; noop
+		return o
+	}
+
 	if !o.LeaderElection && obj.LeaderElection.LeaderElect != nil {
 		o.LeaderElection = *obj.LeaderElection.LeaderElect
 	}

--- a/pkg/manager/manager_options_test.go
+++ b/pkg/manager/manager_options_test.go
@@ -1,0 +1,54 @@
+package manager
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/config"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	configv1alpha1 "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+)
+
+var _ = Describe("manager.Options", func() {
+	Describe("AndFrom", func() {
+		Describe("reading custom type using OfKind", func() {
+			var (
+				o   Options
+				c   customConfig
+				err error
+			)
+
+			JustBeforeEach(func() {
+				s := runtime.NewScheme()
+				o = Options{Scheme: s}
+				c = customConfig{}
+
+				_, err = o.AndFrom(config.File().AtPath("./testdata/custom-config.yaml").OfKind(&c))
+			})
+
+			It("should not panic or fail", func() {
+				Expect(err).To(Succeed())
+			})
+			It("should set custom properties", func() {
+				Expect(c.CustomValue).To(Equal("foo"))
+			})
+		})
+	})
+})
+
+type customConfig struct {
+	metav1.TypeMeta                                   `json:",inline"`
+	configv1alpha1.ControllerManagerConfigurationSpec `json:",inline"`
+	CustomValue                                       string `json:"customValue"`
+}
+
+func (in *customConfig) DeepCopyObject() runtime.Object {
+	out := &customConfig{}
+	*out = *in
+
+	in.ControllerManagerConfigurationSpec.DeepCopyInto(&out.ControllerManagerConfigurationSpec)
+
+	return out
+}

--- a/pkg/manager/testdata/custom-config.yaml
+++ b/pkg/manager/testdata/custom-config.yaml
@@ -1,0 +1,3 @@
+apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+kind: CustomControllerManagerConfiguration
+customValue: foo


### PR DESCRIPTION
This fixes #1828.