### PR TITLE
:book: Fix comment on ListOptions

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -318,7 +318,7 @@ func (p PropagationPolicy) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
 // pre-parsed selectors (since generally, selectors will be executed
 // against the cache).
 type ListOptions struct {
-	// LabelSelector filters results by label.  Use SetLabelSelector to
+	// LabelSelector filters results by label. Use labels.Parse() to
 	// set from raw string form.
 	LabelSelector labels.Selector
 	// FieldSelector filters results by a particular field.  In order


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Since forever the ListOptions had the comment to use SetLabelSelector(), but I could not find any revision (going back to 0.2.x) that ever offered such a function. Therefore I updated the comment to hint to the upstream parsing function.

Fixes #1878