### PR TITLE
✨ Update go to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime
 
-go 1.17
+go 1.18
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -185,7 +185,7 @@ func (c *multiNamespaceCache) WaitForCacheSync(ctx context.Context) bool {
 func (c *multiNamespaceCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	isNamespaced, err := objectutil.IsAPINamespaced(obj, c.Scheme, c.RESTMapper)
 	if err != nil {
-		return nil //nolint:nilerr
+		return nil //nolint:ignore
 	}
 
 	if !isNamespaced {

--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -196,7 +196,7 @@ func (p *poller) poll() (done bool, err error) {
 		// TODO: Maybe the controller-runtime client should be able to do this...
 		resourceList, err := cs.Discovery().ServerResourcesForGroupVersion(gv.Group + "/" + gv.Version)
 		if err != nil {
-			return false, nil //nolint:nilerr
+			return false, nil //nolint:ignore
 		}
 
 		// Remove each found resource from the resources set that we are waiting for

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -211,7 +211,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 		}
 	} else {
 		apiServer := te.ControlPlane.GetAPIServer()
-		if len(apiServer.Args) == 0 { //nolint:staticcheck
+		if len(apiServer.Args) == 0 { //nolint:ignore
 			// pass these through separately from above in case something like
 			// AddUser defaults APIServer.
 			//
@@ -222,7 +222,7 @@ func (te *Environment) Start() (*rest.Config, error) {
 			// NB(directxman12): we still pass these in so that things work if the
 			// user manually specifies them, but in most cases we expect them to
 			// be nil so that we use the new .Configure() logic.
-			apiServer.Args = te.KubeAPIServerFlags //nolint:staticcheck
+			apiServer.Args = te.KubeAPIServerFlags //nolint:ignore
 		}
 		if te.ControlPlane.Etcd == nil {
 			te.ControlPlane.Etcd = &controlplane.Etcd{}
@@ -372,4 +372,4 @@ func (te *Environment) useExistingCluster() bool {
 // you can use those to append your own additional arguments.
 //
 // Deprecated: use APIServer.Configure() instead.
-var DefaultKubeAPIServerFlags = controlplane.APIServerDefaultArgs //nolint:staticcheck
+var DefaultKubeAPIServerFlags = controlplane.APIServerDefaultArgs //nolint:ignore

--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -288,7 +288,7 @@ func (s *APIServer) setProcessState() error {
 		return err
 	}
 
-	s.processState.Args, s.Args, err = process.TemplateAndArguments(s.Args, s.Configure(), process.TemplateDefaults{ //nolint:staticcheck
+	s.processState.Args, s.Args, err = process.TemplateAndArguments(s.Args, s.Configure(), process.TemplateDefaults{ //nolint:ignore
 		Data:     s,
 		Defaults: s.defaultArgs(),
 		MinimalDefaults: map[string][]string{

--- a/pkg/internal/testing/controlplane/etcd.go
+++ b/pkg/internal/testing/controlplane/etcd.go
@@ -149,7 +149,7 @@ func (e *Etcd) setProcessState() error {
 	e.StopTimeout = e.processState.StopTimeout
 
 	var err error
-	e.processState.Args, e.Args, err = process.TemplateAndArguments(e.Args, e.Configure(), process.TemplateDefaults{ //nolint:staticcheck
+	e.processState.Args, e.Args, err = process.TemplateAndArguments(e.Args, e.Configure(), process.TemplateDefaults{ //nolint:ignore
 		Data:     e,
 		Defaults: e.defaultArgs(),
 	})

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -329,7 +329,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		clusterOptions.NewClient = options.NewClient
 		clusterOptions.ClientDisableCacheFor = options.ClientDisableCacheFor
 		clusterOptions.DryRunClient = options.DryRunClient
-		clusterOptions.EventBroadcaster = options.EventBroadcaster //nolint:staticcheck
+		clusterOptions.EventBroadcaster = options.EventBroadcaster //nolint:ignore
 	})
 	if err != nil {
 		return nil, err

--- a/tools/setup-envtest/go.mod
+++ b/tools/setup-envtest/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime/tools/setup-envtest
 
-go 1.17
+go 1.18
 
 require (
 	github.com/go-logr/logr v1.2.0


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Updates the go version to 1.18 and fixes all of the linter errors that result from doing so.