### PR TITLE
:sparkles: Allow TLS to be entirely configured on webhook server

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -76,6 +76,9 @@ type Server struct {
 	// "", "1.0", "1.1", "1.2" and "1.3" only ("" is equivalent to "1.0" for backwards compatibility)
 	TLSMinVersion string
 
+	// TLSOpts is used to allow configuring the TLS config used for the server
+	TLSOpts []func(*tls.Config)
+
 	// WebhookMux is the multiplexer that handles different webhooks.
 	WebhookMux *http.ServeMux
 
@@ -252,6 +255,11 @@ func (s *Server) Start(ctx context.Context) error {
 
 		cfg.ClientCAs = certPool
 		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+	}
+
+	// fallback TLS config ready, will now mutate if passer wants full control over it
+	for _, op := range s.TLSOpts {
+		op(cfg)
 	}
 
 	listener, err := tls.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)), cfg)


### PR DESCRIPTION
Some operators might want to respect cluster-wide TLS ciphers for example,
which means that these will eventually have to be passed down to the webhook server.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1754