### PR TITLE
✨ Enable metrics of clientgo leader election

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -144,6 +144,9 @@ type controllerManager struct {
 	// webhookServer if unset, and Add() it to controllerManager.
 	webhookServerOnce sync.Once
 
+	// leaderElectionID is the name of the resource that leader election
+	// will use for holding the leader lock.
+	leaderElectionID string
 	// leaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership.
 	leaseDuration time.Duration
@@ -637,6 +640,7 @@ func (cm *controllerManager) startLeaderElection(ctx context.Context) (err error
 			},
 		},
 		ReleaseOnCancel: cm.leaderElectionReleaseOnCancel,
+		Name:            cm.leaderElectionID,
 	})
 	if err != nil {
 		return err

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -439,6 +439,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		certDir:                       options.CertDir,
 		tlsOpts:                       options.TLSOpts,
 		webhookServer:                 options.WebhookServer,
+		leaderElectionID:              options.LeaderElectionID,
 		leaseDuration:                 *options.LeaseDuration,
 		renewDeadline:                 *options.RenewDeadline,
 		retryPeriod:                   *options.RetryPeriod,

--- a/pkg/metrics/leaderelection.go
+++ b/pkg/metrics/leaderelection.go
@@ -1,0 +1,40 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/client-go/tools/leaderelection"
+)
+
+// This file is copied and adapted from k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
+// which registers metrics to the k8s legacy Registry. We require very
+// similar functionality, but must register metrics to a different Registry.
+
+var (
+	leaderGauge = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "leader_election_master_status",
+		Help: "Gauge of if the reporting system is master of the relevant lease, 0 indicates backup, 1 indicates master. 'name' is the string used to identify the lease. Please make sure to group by name.",
+	}, []string{"name"})
+)
+
+func init() {
+	Registry.MustRegister(leaderGauge)
+	leaderelection.SetProvider(leaderelectionMetricsProvider{})
+}
+
+type leaderelectionMetricsProvider struct{}
+
+func (leaderelectionMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {
+	return &switchAdapter{gauge: leaderGauge}
+}
+
+type switchAdapter struct {
+	gauge *prometheus.GaugeVec
+}
+
+func (s *switchAdapter) On(name string) {
+	s.gauge.WithLabelValues(name).Set(1.0)
+}
+
+func (s *switchAdapter) Off(name string) {
+	s.gauge.WithLabelValues(name).Set(0.0)
+}

--- a/pkg/metrics/workqueue.go
+++ b/pkg/metrics/workqueue.go
@@ -21,8 +21,8 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
-// This file is copied and adapted from k8s.io/kubernetes/pkg/util/workqueue/prometheus
-// which registers metrics to the default prometheus Registry. We require very
+// This file is copied and adapted from k8s.io/component-base/metrics/prometheus/workqueue
+// which registers metrics to the k8s legacy Registry. We require very
 // similar functionality, but must register metrics to a different Registry.
 
 // Metrics subsystem and all keys used by the workqueue.


### PR DESCRIPTION
This PR enables metrics of clientgo leader election ( "k8s.io/client-go/tools/leaderelection" )