### PR TITLE
:bug: fix loading CRDs from multiple directories in envtests

### DIFF
--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -278,12 +278,6 @@ func CreateCRDs(config *rest.Config, crds []*apiextensionsv1.CustomResourceDefin
 
 // renderCRDs iterate through options.Paths and extract all CRD files.
 func renderCRDs(options *CRDInstallOptions) ([]*apiextensionsv1.CustomResourceDefinition, error) {
-	var (
-		err   error
-		info  os.FileInfo
-		files []string
-	)
-
 	type GVKN struct {
 		GVK  schema.GroupVersionKind
 		Name string
@@ -292,7 +286,12 @@ func renderCRDs(options *CRDInstallOptions) ([]*apiextensionsv1.CustomResourceDe
 	crds := map[GVKN]*apiextensionsv1.CustomResourceDefinition{}
 
 	for _, path := range options.Paths {
-		var filePath = path
+		var (
+			err      error
+			info     os.FileInfo
+			files    []string
+			filePath = path
+		)
 
 		// Return the error if ErrorIfPathMissing exists
 		if info, err = os.Stat(path); os.IsNotExist(err) {

--- a/pkg/envtest/crd_test.go
+++ b/pkg/envtest/crd_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package envtest
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var _ = Describe("Test", func() {
+	Describe("readCRDFiles", func() {
+		It("should not mix up files from different directories", func() {
+			opt := CRDInstallOptions{
+				Paths: []string{
+					"testdata/crds",
+					"testdata/crdv1_original",
+				},
+			}
+			err := readCRDFiles(&opt)
+			Expect(err).NotTo(HaveOccurred())
+
+			expectedCRDs := sets.NewString(
+				"frigates.ship.example.com",
+				"configs.foo.example.com",
+				"drivers.crew.example.com",
+			)
+
+			foundCRDs := sets.NewString()
+			for _, crd := range opt.CRDs {
+				foundCRDs.Insert(crd.Name)
+			}
+
+			Expect(expectedCRDs).To(Equal(foundCRDs))
+		})
+	})
+})


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
In #1888 I accidentally changed the semantics of `files`, which was previously always overridden with the result from `ioutil.ReadDir`, but is now only ever `append()`ed to. This causes problems when reading CRDs from multiple directories.

This PR changes the scope for the variables to fix that bug. So sorry to have broken the 0.12 release :(