### PR TITLE
:bug: don't override global log in builder

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -309,7 +309,7 @@ func (blder *Builder) doController(r reconcile.Reconciler) error {
 
 	// Setup the logger.
 	if ctrlOptions.LogConstructor == nil {
-		log = blder.mgr.GetLogger().WithValues(
+		log := blder.mgr.GetLogger().WithValues(
 			"controller", controllerName,
 			"controllerGroup", gvk.Group,
 			"controllerKind", gvk.Kind,


### PR DESCRIPTION
The recent change
https://github.com/kubernetes-sigs/controller-runtime/commit/598978c592839b5a602af3706fce8751d2d2532c#diff-e77b9468ab935d5ea4d5cdae3b994114bada17df0001570e4b1436419afd50ccR312
introduced a bug by overriding `log` with the log created by a builder,
resulting in all logs produced by `controller-runtime` having
`controller`, `controllerGroup` and `controllerKind` set to the last
created controller.
