### PR TITLE
:warning: GIT-1918: enable leader election callback options

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -90,6 +90,9 @@ issues:
     - revive
     text: "exported: exported method .*\\.(Reconcile|SetupWithManager|SetupWebhookWithManager) should have comment or be unexported"
   - linters:
+    - revive
+    text: "exported: type name .*\\.(ManagerWithLeaderCallbacks) .*"
+  - linters:
     - errcheck
     text: Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
   # With Go 1.16, the new embed directive can be used with an un-named import,

--- a/alias.go
+++ b/alias.go
@@ -106,6 +106,9 @@ var (
 	// NewManager returns a new Manager for creating Controllers.
 	NewManager = manager.New
 
+	// NewManagerWithLeaderCallback returns a new ManagerWithLeaderCallback for creating controllers with leader callbacks.
+	NewManagerWithLeaderCallback = manager.NewWithLeaderElectionCallback
+
 	// CreateOrUpdate creates or updates the given object obj in the Kubernetes
 	// cluster. The object's desired state should be reconciled with the existing
 	// state using the passed in ReconcileFn. obj must be a struct pointer so that


### PR DESCRIPTION
Closes #1918 

This PR does the following. 

1. In order to retain the backward compatibility, this introduces a new interface named `ManagerWithLeaderCallbacks` that supports configuring the leader callbacks via the manager
2. A manager.Options that can be used to configure the global callbacks un-conditionally if required
3. Modify the leader election workflow to enable `OnNewLeader` callbacks
4. Introduce a new `NewManagerWithLeaderCallback` alias for creating a new Manager with callback support 