### PR TITLE
📖 nit: fix in client package documentation

### DIFF
--- a/pkg/client/doc.go
+++ b/pkg/client/doc.go
@@ -25,7 +25,7 @@ limitations under the License.
 // The New function can be used to create a new client that talks directly
 // to the API server.
 //
-// A common pattern in Kubernetes to read from a cache and write to the API
+// It is a common pattern in Kubernetes to read from a cache and write to the API
 // server.  This pattern is covered by the DelegatingClient type, which can
 // be used to have a client whose Reader is different from the Writer.
 //


### PR DESCRIPTION
Just a minor nit fix in the documentation. 
This makes the documentation (https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client) more readable. 
