### PR TITLE
✨ Introduce pprof server to manager

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -105,6 +106,9 @@ type controllerManager struct {
 
 	// Healthz probe handler
 	healthzHandler *healthz.Handler
+
+	// pprofListener is used to serve pprof
+	pprofListener net.Listener
 
 	// controllerConfig are the global controller options.
 	controllerConfig config.Controller
@@ -343,6 +347,24 @@ func (cm *controllerManager) serveHealthProbes() {
 	go cm.httpServe("health probe", cm.logger, server, cm.healthProbeListener)
 }
 
+func (cm *controllerManager) addPprofServer() error {
+	mux := http.NewServeMux()
+	srv := httpserver.New(mux)
+
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+
+	return cm.add(&server{
+		Kind:     "pprof",
+		Log:      cm.logger,
+		Server:   srv,
+		Listener: cm.pprofListener,
+	})
+}
+
 func (cm *controllerManager) httpServe(kind string, log logr.Logger, server *http.Server, ln net.Listener) {
 	log = log.WithValues("kind", kind, "addr", ln.Addr())
 
@@ -438,6 +460,13 @@ func (cm *controllerManager) Start(ctx context.Context) (err error) {
 	// Serve health probes.
 	if cm.healthProbeListener != nil {
 		cm.serveHealthProbes()
+	}
+
+	// Add pprof server
+	if cm.pprofListener != nil {
+		if err := cm.addPprofServer(); err != nil {
+			return fmt.Errorf("failed to add pprof server: %w", err)
+		}
 	}
 
 	// First start any webhook servers, which includes conversion, validation, and defaulting

--- a/pkg/manager/server.go
+++ b/pkg/manager/server.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+// server is a general purpose HTTP server Runnable for a manager
+// to serve some internal handlers such as health probes, metrics and profiling.
+type server struct {
+	Kind     string
+	Log      logr.Logger
+	Server   *http.Server
+	Listener net.Listener
+}
+
+func (s *server) Start(ctx context.Context) error {
+	log := s.Log.WithValues("kind", s.Kind, "addr", s.Listener.Addr())
+
+	serverShutdown := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		log.Info("shutting down server")
+		if err := s.Server.Shutdown(context.Background()); err != nil {
+			log.Error(err, "error shutting down server")
+		}
+		close(serverShutdown)
+	}()
+
+	log.Info("starting server")
+	if err := s.Server.Serve(s.Listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	<-serverShutdown
+	return nil
+}
+
+func (s *server) NeedLeaderElection() bool {
+	return false
+}


### PR DESCRIPTION
This PR introduces a configurable standalone server for serving pprof to manager, just like the health and metrics server.

fixes #1779 

Additional thoughts:
I've been aware of `metricsExtraHandlers` introduced in #824 which might be an alternative for end users to serve pprof, but I don't think it's quite appropriate to do so, mainly for these two reasons:
1. pprof is a language built-in feature which is widely used, so it's more appropriate to make its server built-in in the library rather than let end users construct and run themselves in every controller.
2. `metricsExtraHandlers` bind all handlers to metrics listener which is not that general and flexible, it cannot meet cases that user want to expose metrics and pprof by different listeners (common use case: a 0.0.0.0: listener for serving metrics and a 127.0.0.1: listener for serving pprof).