### PR TITLE
⚠️ Do not mutate the global warning handler

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -88,13 +88,12 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		// is log.KubeAPIWarningLogger with deduplication enabled.
 		// See log.KubeAPIWarningLoggerOptions for considerations
 		// regarding deduplication.
-		rest.SetDefaultWarningHandler(
-			log.NewKubeAPIWarningLogger(
-				logger,
-				log.KubeAPIWarningLoggerOptions{
-					Deduplicate: !options.Opts.AllowDuplicateLogs,
-				},
-			),
+		config = rest.CopyConfig(config)
+		config.WarningHandler = log.NewKubeAPIWarningLogger(
+			logger,
+			log.KubeAPIWarningLoggerOptions{
+				Deduplicate: !options.Opts.AllowDuplicateLogs,
+			},
 		)
 	}
 


### PR DESCRIPTION
Only configure the local warning handler. Please see the issue for details.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/1928.