### PR TITLE
🐛 Remove no-op clientgo reflector metrics

### DIFF
--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	reflectormetrics "k8s.io/client-go/tools/cache"
 	clientmetrics "k8s.io/client-go/tools/metrics"
 )
 
@@ -35,19 +34,6 @@ const (
 	RestClientSubsystem = "rest_client"
 	LatencyKey          = "request_latency_seconds"
 	ResultKey           = "requests_total"
-)
-
-// Metrics subsystem and all keys used by the reflectors.
-const (
-	ReflectorSubsystem     = "reflector"
-	ListsTotalKey          = "lists_total"
-	ListsDurationKey       = "list_duration_seconds"
-	ItemsPerListKey        = "items_per_list"
-	WatchesTotalKey        = "watches_total"
-	ShortWatchesTotalKey   = "short_watches_total"
-	WatchDurationKey       = "watch_duration_seconds"
-	ItemsPerWatchKey       = "items_per_watch"
-	LastResourceVersionKey = "last_resource_version"
 )
 
 var (
@@ -81,64 +67,10 @@ var (
 		Name:      ResultKey,
 		Help:      "Number of HTTP requests, partitioned by status code, method, and host.",
 	}, []string{"code", "method", "host"})
-
-	// reflector metrics.
-
-	// TODO(directxman12): update these to be histograms once the metrics overhaul KEP
-	// PRs start landing.
-
-	listsTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      ListsTotalKey,
-		Help:      "Total number of API lists done by the reflectors",
-	}, []string{"name"})
-
-	listsDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      ListsDurationKey,
-		Help:      "How long an API list takes to return and decode for the reflectors",
-	}, []string{"name"})
-
-	itemsPerList = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      ItemsPerListKey,
-		Help:      "How many items an API list returns to the reflectors",
-	}, []string{"name"})
-
-	watchesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      WatchesTotalKey,
-		Help:      "Total number of API watches done by the reflectors",
-	}, []string{"name"})
-
-	shortWatchesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      ShortWatchesTotalKey,
-		Help:      "Total number of short API watches done by the reflectors",
-	}, []string{"name"})
-
-	watchDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      WatchDurationKey,
-		Help:      "How long an API watch takes to return and decode for the reflectors",
-	}, []string{"name"})
-
-	itemsPerWatch = prometheus.NewSummaryVec(prometheus.SummaryOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      ItemsPerWatchKey,
-		Help:      "How many items an API watch returns to the reflectors",
-	}, []string{"name"})
-
-	lastResourceVersion = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Subsystem: ReflectorSubsystem,
-		Name:      LastResourceVersionKey,
-		Help:      "Last resource version seen for the reflectors",
-	}, []string{"name"})
 )
 
 func init() {
 	registerClientMetrics()
-	registerReflectorMetrics()
 }
 
 // registerClientMetrics sets up the client latency metrics from client-go.
@@ -150,20 +82,6 @@ func registerClientMetrics() {
 	clientmetrics.Register(clientmetrics.RegisterOpts{
 		RequestResult: &resultAdapter{metric: requestResult},
 	})
-}
-
-// registerReflectorMetrics sets up reflector (reconcile) loop metrics.
-func registerReflectorMetrics() {
-	Registry.MustRegister(listsTotal)
-	Registry.MustRegister(listsDuration)
-	Registry.MustRegister(itemsPerList)
-	Registry.MustRegister(watchesTotal)
-	Registry.MustRegister(shortWatchesTotal)
-	Registry.MustRegister(watchDuration)
-	Registry.MustRegister(itemsPerWatch)
-	Registry.MustRegister(lastResourceVersion)
-
-	reflectormetrics.SetReflectorMetricsProvider(reflectorMetricsProvider{})
 }
 
 // this section contains adapters, implementations, and other sundry organic, artisanally
@@ -190,42 +108,4 @@ type resultAdapter struct {
 
 func (r *resultAdapter) Increment(_ context.Context, code, method, host string) {
 	r.metric.WithLabelValues(code, method, host).Inc()
-}
-
-// Reflector metrics provider (method #2 for client-go metrics),
-// copied (more-or-less directly) from k8s.io/kubernetes setup code
-// (which isn't anywhere in an easily-importable place).
-
-type reflectorMetricsProvider struct{}
-
-func (reflectorMetricsProvider) NewListsMetric(name string) reflectormetrics.CounterMetric {
-	return listsTotal.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewListDurationMetric(name string) reflectormetrics.SummaryMetric {
-	return listsDuration.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewItemsInListMetric(name string) reflectormetrics.SummaryMetric {
-	return itemsPerList.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewWatchesMetric(name string) reflectormetrics.CounterMetric {
-	return watchesTotal.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewShortWatchesMetric(name string) reflectormetrics.CounterMetric {
-	return shortWatchesTotal.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewWatchDurationMetric(name string) reflectormetrics.SummaryMetric {
-	return watchDuration.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewItemsInWatchMetric(name string) reflectormetrics.SummaryMetric {
-	return itemsPerWatch.WithLabelValues(name)
-}
-
-func (reflectorMetricsProvider) NewLastResourceVersionMetric(name string) reflectormetrics.GaugeMetric {
-	return lastResourceVersion.WithLabelValues(name)
 }


### PR DESCRIPTION
**Deescription**
This PR removes the no-op reflector metrics to avoid confusion like #817.

This PR is seperated from the orignal PR #1901 where previous discussions can be found.

**Notes**
Why we are removing the no-op reflector metrics? 
- These metrics have no longer been exported since  k8s 1.14; see: https://github.com/kubernetes/kubernetes/pull/74636
- They are not these same metrics exported by default documented here: https://book.kubebuilder.io/reference/metrics-reference.html