### PR TITLE
✨ Provide access to admission.Request in custom validator/defaulter

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -19,7 +19,6 @@ package admission
 import (
 	"context"
 	"encoding/json"
-
 	"errors"
 	"net/http"
 
@@ -60,6 +59,8 @@ func (h *defaulterForType) Handle(ctx context.Context, req Request) Response {
 	if h.object == nil {
 		panic("object should never be nil")
 	}
+
+	ctx = NewContextWithRequest(ctx, req)
 
 	// Get the object in the request
 	obj := h.object.DeepCopyObject()

--- a/pkg/webhook/admission/validator_custom.go
+++ b/pkg/webhook/admission/validator_custom.go
@@ -64,6 +64,8 @@ func (h *validatorForType) Handle(ctx context.Context, req Request) Response {
 		panic("object should never be nil")
 	}
 
+	ctx = NewContextWithRequest(ctx, req)
+
 	// Get the object in the request
 	obj := h.object.DeepCopyObject()
 

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -253,3 +253,21 @@ func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, err
 	}
 	return metrics.InstrumentedHook(opts.MetricsPath, hook), nil
 }
+
+// requestContextKey is how we find the admission.Request in a context.Context.
+type requestContextKey struct{}
+
+// RequestFromContext returns an admission.Request from ctx.
+func RequestFromContext(ctx context.Context) (Request, error) {
+	if v, ok := ctx.Value(requestContextKey{}).(Request); ok {
+		return v, nil
+	}
+
+	return Request{}, errors.New("admission.Request not found in context")
+}
+
+// NewContextWithRequest returns a new Context, derived from ctx, which carries the
+// provided admission.Request.
+func NewContextWithRequest(ctx context.Context, req Request) context.Context {
+	return context.WithValue(ctx, requestContextKey{}, req)
+}

--- a/pkg/webhook/admission/webhook_test.go
+++ b/pkg/webhook/admission/webhook_test.go
@@ -194,6 +194,21 @@ var _ = Describe("Admission Webhooks", func() {
 	})
 })
 
+var _ = Describe("Should be able to write/read admission.Request to/from context", func() {
+	ctx := context.Background()
+	testRequest := Request{
+		admissionv1.AdmissionRequest{
+			UID: "test-uid",
+		},
+	}
+
+	ctx = NewContextWithRequest(ctx, testRequest)
+
+	gotRequest, err := RequestFromContext(ctx)
+	Expect(err).To(Not(HaveOccurred()))
+	Expect(gotRequest).To(Equal(testRequest))
+})
+
 type stringInjector interface {
 	InjectString(s string) error
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR provides access to the admisison.Request in custom validator and defaulter.

Fixes #1949 
