### PR TITLE
🐛 Fix broken kind logging

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -315,13 +315,13 @@ func (blder *Builder) doController(r reconcile.Reconciler) error {
 			"controllerKind", gvk.Kind,
 		)
 
-		lowerCamelCaseKind := strings.ToLower(gvk.Kind[:1]) + gvk.Kind[1:]
+		kind := gvk.Kind
 
 		ctrlOptions.LogConstructor = func(req *reconcile.Request) logr.Logger {
 			log := log
 			if req != nil {
 				log = log.WithValues(
-					lowerCamelCaseKind, klog.KRef(req.Namespace, req.Name),
+					kind, klog.KRef(req.Namespace, req.Name),
 					"namespace", req.Namespace, "name", req.Name,
 				)
 			}


### PR DESCRIPTION
If gvk.Kind is "APIService", I expect "apiService", but the current
code produces and logs "aPIService".  Because it is not easy to do
this kind of thing, it is better to log the kind as is.

Fixes #1945
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
