### PR TITLE
:book: fix docs: typo in OpenAPI

### DIFF
--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -31,7 +31,7 @@ WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
 - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
 - There is some support for sub resources which can cause issues with tests if you're trying to update
   e.g. metadata and status in the same reconcile.
-- No OpeanAPI validation is performed when creating or updating objects.
+- No OpanAPI validation is performed when creating or updating objects.
 - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
 operations that rely on these fields will fail, or give false positives.
 

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -31,7 +31,7 @@ WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
 - This client does not have a way to inject specific errors to test handled vs. unhandled errors.
 - There is some support for sub resources which can cause issues with tests if you're trying to update
   e.g. metadata and status in the same reconcile.
-- No OpanAPI validation is performed when creating or updating objects.
+- No OpenAPI validation is performed when creating or updating objects.
 - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
 operations that rely on these fields will fail, or give false positives.
 


### PR DESCRIPTION
There was a typo in docs of `pkg/client/fake/doc.go`:
s/OpeanAPI/OpenAPI/