### PR TITLE
:sparkles: Implement IgnoreAlreadyExists

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -3403,6 +3403,32 @@ var _ = Describe("IgnoreNotFound", func() {
 	})
 })
 
+var _ = Describe("IgnoreAlreadyExists", func() {
+	It("should return nil on a 'AlreadyExists' error", func() {
+		By("creating a AlreadyExists error")
+		err := apierrors.NewAlreadyExists(schema.GroupResource{}, "")
+
+		By("returning no error")
+		Expect(client.IgnoreAlreadyExists(err)).To(Succeed())
+	})
+
+	It("should return the error on a status other than already exists", func() {
+		By("creating a BadRequest error")
+		err := apierrors.NewBadRequest("")
+
+		By("returning an error")
+		Expect(client.IgnoreAlreadyExists(err)).To(HaveOccurred())
+	})
+
+	It("should return the error on a non-status error", func() {
+		By("creating an fmt error")
+		err := fmt.Errorf("arbitrary error")
+
+		By("returning an error")
+		Expect(client.IgnoreAlreadyExists(err)).To(HaveOccurred())
+	})
+})
+
 type fakeReader struct {
 	Called int
 }

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -143,3 +143,13 @@ func IgnoreNotFound(err error) error {
 	}
 	return err
 }
+
+// IgnoreAlreadyExists returns nil on AlreadyExists errors.
+// All other values that are not AlreadyExists errors or nil are returned unmodified.
+func IgnoreAlreadyExists(err error) error {
+	if apierrors.IsAlreadyExists(err) {
+		return nil
+	}
+
+	return err
+}


### PR DESCRIPTION
closes https://github.com/kubernetes-sigs/controller-runtime/issues/1964

This PR adds a function to ignore `AlreadyExists` errors.