### PR TITLE
🐛 Conversion webhook should not panic when conversion request is nil

### DIFF
--- a/pkg/webhook/conversion/conversion.go
+++ b/pkg/webhook/conversion/conversion.go
@@ -69,6 +69,12 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if convertReview.Request == nil {
+		log.Error(nil, "conversion request is nil")
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+
 	// TODO(droot): may be move the conversion logic to a separate module to
 	// decouple it from the http layer ?
 	resp, err := wh.handleConvertRequest(convertReview.Request)


### PR DESCRIPTION
This PR fixes a panic in the conversion webhook HTTP handler when no conversion request is sent by the client.

To avoid dereferencing a nil pointer when trying to access the UID, I set a default uid to an empty UID.
Let me know if I should return an HTTP Bad Request instead.

EDIT: Bad Request is returned when the conversion request is nil