### PR TITLE
✨ Pass webhook logger to handler via context

### DIFF
--- a/examples/builtins/mutatingwebhook.go
+++ b/examples/builtins/mutatingwebhook.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -36,8 +38,10 @@ type podAnnotator struct {
 
 // podAnnotator adds an annotation to every incoming pods.
 func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	pod := &corev1.Pod{}
+	// set up a convenient log object so we don't have to type request over and over again
+	log := logf.FromContext(ctx)
 
+	pod := &corev1.Pod{}
 	err := a.decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
@@ -52,6 +56,7 @@ func (a *podAnnotator) Handle(ctx context.Context, req admission.Request) admiss
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
+	log.Info("Annotating Pod")
 
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }

--- a/examples/builtins/validatingwebhook.go
+++ b/examples/builtins/validatingwebhook.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 
 	corev1 "k8s.io/api/core/v1"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -36,12 +38,16 @@ type podValidator struct {
 
 // podValidator admits a pod if a specific annotation exists.
 func (v *podValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
-	pod := &corev1.Pod{}
+	// set up a convenient log object so we don't have to type request over and over again
+	log := logf.FromContext(ctx)
 
+	pod := &corev1.Pod{}
 	err := v.decoder.Decode(req, pod)
 	if err != nil {
 		return admission.Errored(http.StatusBadRequest, err)
 	}
+
+	log.Info("Validating Pod")
 
 	key := "example-mutating-admission-webhook"
 	anno, found := pod.Annotations[key]

--- a/pkg/webhook/admission/defaulter_test.go
+++ b/pkg/webhook/admission/defaulter_test.go
@@ -10,6 +10,8 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 var _ = Describe("Defaulter Handler", func() {
@@ -17,6 +19,7 @@ var _ = Describe("Defaulter Handler", func() {
 	It("should return ok if received delete verb in defaulter handler", func() {
 		obj := &TestDefaulter{}
 		handler := DefaultingWebhookFor(obj)
+		Expect(inject.LoggerInto(log, handler)).To(BeTrue())
 
 		resp := handler.Handle(context.TODO(), Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{

--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -52,7 +52,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var reviewResponse Response
 	if r.Body == nil {
 		err = errors.New("request body is empty")
-		wh.log.Error(err, "bad request")
+		wh.getLogger(nil).Error(err, "bad request")
 		reviewResponse = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, reviewResponse)
 		return
@@ -60,7 +60,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	defer r.Body.Close()
 	if body, err = io.ReadAll(r.Body); err != nil {
-		wh.log.Error(err, "unable to read the body from the incoming request")
+		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request")
 		reviewResponse = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, reviewResponse)
 		return
@@ -69,7 +69,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// verify the content type is accurate
 	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
 		err = fmt.Errorf("contentType=%s, expected application/json", contentType)
-		wh.log.Error(err, "unable to process a request with an unknown content type", "content type", contentType)
+		wh.getLogger(nil).Error(err, "unable to process a request with an unknown content type", "content type", contentType)
 		reviewResponse = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, reviewResponse)
 		return
@@ -88,12 +88,12 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ar.SetGroupVersionKind(v1.SchemeGroupVersion.WithKind("AdmissionReview"))
 	_, actualAdmRevGVK, err := admissionCodecs.UniversalDeserializer().Decode(body, nil, &ar)
 	if err != nil {
-		wh.log.Error(err, "unable to decode the request")
+		wh.getLogger(nil).Error(err, "unable to decode the request")
 		reviewResponse = Errored(http.StatusBadRequest, err)
 		wh.writeResponse(w, reviewResponse)
 		return
 	}
-	wh.log.V(1).Info("received request", "UID", req.UID, "kind", req.Kind, "resource", req.Resource)
+	wh.getLogger(nil).V(1).Info("received request", "UID", req.UID, "kind", req.Kind, "resource", req.Resource)
 
 	reviewResponse = wh.Handle(ctx, req)
 	wh.writeResponseTyped(w, reviewResponse, actualAdmRevGVK)
@@ -124,7 +124,7 @@ func (wh *Webhook) writeResponseTyped(w io.Writer, response Response, admRevGVK 
 // writeAdmissionResponse writes ar to w.
 func (wh *Webhook) writeAdmissionResponse(w io.Writer, ar v1.AdmissionReview) {
 	if err := json.NewEncoder(w).Encode(ar); err != nil {
-		wh.log.Error(err, "unable to encode and write the response")
+		wh.getLogger(nil).Error(err, "unable to encode and write the response")
 		// Since the `ar v1.AdmissionReview` is a clear and legal object,
 		// it should not have problem to be marshalled into bytes.
 		// The error here is probably caused by the abnormal HTTP connection,
@@ -132,11 +132,11 @@ func (wh *Webhook) writeAdmissionResponse(w io.Writer, ar v1.AdmissionReview) {
 		// to avoid endless circular calling.
 		serverError := Errored(http.StatusInternalServerError, err)
 		if err = json.NewEncoder(w).Encode(v1.AdmissionReview{Response: &serverError.AdmissionResponse}); err != nil {
-			wh.log.Error(err, "still unable to encode and write the InternalServerError response")
+			wh.getLogger(nil).Error(err, "still unable to encode and write the InternalServerError response")
 		}
 	} else {
 		res := ar.Response
-		if log := wh.log; log.V(1).Enabled() {
+		if log := wh.getLogger(nil); log.V(1).Enabled() {
 			if res.Result != nil {
 				log = log.WithValues("code", res.Result.Code, "reason", res.Result.Reason)
 			}

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -200,6 +200,7 @@ func (wh *Webhook) getLogger(req *Request) logr.Logger {
 func DefaultLogConstructor(base logr.Logger, req *Request) logr.Logger {
 	if req != nil {
 		return base.WithValues("object", klog.KRef(req.Namespace, req.Name),
+			"namespace", req.Namespace, "name", req.Name,
 			"resource", req.Resource, "user", req.UserInfo.Username,
 		)
 	}

--- a/pkg/webhook/admission/webhook_test.go
+++ b/pkg/webhook/admission/webhook_test.go
@@ -172,7 +172,7 @@ var _ = Describe("Admission Webhooks", func() {
 		Expect(resp.Allowed).To(BeTrue())
 
 		By("checking that the log message contains the request fields")
-		Eventually(logBuffer).Should(gbytes.Say(`"msg":"Received request","object":{"name":"foo","namespace":"bar"},"resource":{"group":"apps","version":"v1","resource":"deployments"},"user":"tim","requestID":"test123"}`))
+		Eventually(logBuffer).Should(gbytes.Say(`"msg":"Received request","object":{"name":"foo","namespace":"bar"},"namespace":"bar","name":"foo","resource":{"group":"apps","version":"v1","resource":"deployments"},"user":"tim","requestID":"test123"}`))
 	})
 
 	It("should pass a request logger created by LogConstructor via the context", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
`admission.Webhook` now passes a request logger to the handler via the context.
It can be retrieved by handlers via `logf.FromContext(ctx)` and is setup with commonly interesting fields about the request.
The logger and it's fields can be customized by setting `Webhook.LogConstructor`.

This is very similar to how controllers are passing a reconciliation logger to reconcilers and allows for greater harmonization across the entire codebase, i.e. using contextual loggers everywhere instead of manually passing around half-cooked loggers.