### PR TITLE
🐛 Fix log depth for DelegatingLogSink

### DIFF
--- a/examples/scratch-env/main.go
+++ b/examples/scratch-env/main.go
@@ -21,10 +21,11 @@ import (
 	"os"
 
 	flag "github.com/spf13/pflag"
+	"go.uber.org/zap"
 
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 var (
@@ -35,8 +36,9 @@ var (
 
 // have a separate function so we can return an exit code w/o skipping defers
 func runMain() int {
-	loggerOpts := &zap.Options{
+	loggerOpts := &logzap.Options{
 		Development: true, // a sane default
+		ZapOpts:     []zap.Option{zap.AddCaller()},
 	}
 	{
 		var goFlagSet goflag.FlagSet
@@ -44,7 +46,8 @@ func runMain() int {
 		flag.CommandLine.AddGoFlagSet(&goFlagSet)
 	}
 	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(loggerOpts)))
+	ctrl.SetLogger(logzap.New(logzap.UseFlagOptions(loggerOpts)))
+	ctrl.Log.Info("Starting...")
 
 	log := ctrl.Log.WithName("main")
 

--- a/pkg/log/deleg.go
+++ b/pkg/log/deleg.go
@@ -73,6 +73,9 @@ func (p *loggerPromise) Fulfill(parentLogSink logr.LogSink) {
 
 	p.logger.lock.Lock()
 	p.logger.logger = sink
+	if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+		p.logger.logger = withCallDepth.WithCallDepth(1)
+	}
 	p.logger.promise = nil
 	p.logger.lock.Unlock()
 
@@ -141,7 +144,11 @@ func (l *DelegatingLogSink) WithName(name string) logr.LogSink {
 	defer l.lock.RUnlock()
 
 	if l.promise == nil {
-		return l.logger.WithName(name)
+		sink := l.logger.WithName(name)
+		if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+			sink = withCallDepth.WithCallDepth(-1)
+		}
+		return sink
 	}
 
 	res := &DelegatingLogSink{logger: l.logger}
@@ -157,7 +164,11 @@ func (l *DelegatingLogSink) WithValues(tags ...interface{}) logr.LogSink {
 	defer l.lock.RUnlock()
 
 	if l.promise == nil {
-		return l.logger.WithValues(tags...)
+		sink := l.logger.WithValues(tags...)
+		if withCallDepth, ok := sink.(logr.CallDepthLogSink); ok {
+			sink = withCallDepth.WithCallDepth(-1)
+		}
+		return sink
 	}
 
 	res := &DelegatingLogSink{logger: l.logger}

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -244,7 +244,7 @@ func NewRaw(opts ...Opts) *zap.Logger {
 	// this basically mimics New<type>Config, but with a custom sink
 	sink := zapcore.AddSync(o.DestWriter)
 
-	o.ZapOpts = append(o.ZapOpts, zap.AddCallerSkip(1), zap.ErrorOutput(sink))
+	o.ZapOpts = append(o.ZapOpts, zap.ErrorOutput(sink))
 	log := zap.New(zapcore.NewCore(&KubeAwareEncoder{Encoder: o.Encoder, Verbose: o.Development}, sink, o.Level))
 	log = log.WithOptions(o.ZapOpts...)
 	return log


### PR DESCRIPTION
Fixes #1737

Adds a depth of 1 to the DelegatingLogSink sink, instead of a global depth to the zapr sink.

This global depth is problematic because it doesn't apply to loggers obtained with `WithName` or `WithValues`.

**Notes for reviewer**

To see this fix in action (and the bug before this fix), go to `examples/scratch-env/main.go` and set Development mode to false.