### PR TITLE
:seedling: Register kubeconfig flag variable via RegisterFlags func

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -70,6 +70,10 @@ type TypeMeta = metav1.TypeMeta
 type ObjectMeta = metav1.ObjectMeta
 
 var (
+	// RegisterFlags registers flag variables to the given FlagSet if not already registered.
+	// It uses the default command line FlagSet, if none is provided. Currently, it only registers the kubeconfig flag.
+	RegisterFlags = config.RegisterFlags
+
 	// GetConfigOrDie creates a *rest.Config for talking to a Kubernetes apiserver.
 	// If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 	// in cluster and use the cluster provided kubeconfig.

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -50,7 +50,10 @@ func RegisterFlags(fs *flag.FlagSet) {
 	if fs == nil {
 		fs = flag.CommandLine
 	}
-	if fs.Lookup(KubeconfigFlagName) == nil {
+	f := fs.Lookup(KubeconfigFlagName)
+	if f != nil {
+		kubeconfig = f.Value.String()
+	} else {
 		fs.StringVar(&kubeconfig, KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")
 	}
 }

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -29,15 +29,30 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
 )
 
+// KubeconfigFlagName is the name of the kubeconfig flag
+const KubeconfigFlagName = "kubeconfig"
+
 var (
 	kubeconfig string
 	log        = logf.RuntimeLog.WithName("client").WithName("config")
 )
 
+// init registers the "kubeconfig" flag to the default command line FlagSet.
+// TODO: This should be removed, as it potentially leads to redefined flag errors for users, if they already
+// have registered the "kubeconfig" flag to the command line FlagSet in other parts of their code.
 func init() {
-	// TODO: Fix this to allow double vendoring this library but still register flags on behalf of users
-	flag.StringVar(&kubeconfig, "kubeconfig", "",
-		"Paths to a kubeconfig. Only required if out-of-cluster.")
+	RegisterFlags(flag.CommandLine)
+}
+
+// RegisterFlags registers flag variables to the given FlagSet if not already registered.
+// It uses the default command line FlagSet, if none is provided. Currently, it only registers the kubeconfig flag.
+func RegisterFlags(fs *flag.FlagSet) {
+	if fs == nil {
+		fs = flag.CommandLine
+	}
+	if fs.Lookup(KubeconfigFlagName) == nil {
+		fs.StringVar(&kubeconfig, KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+	}
 }
 
 // GetConfig creates a *rest.Config for talking to a Kubernetes API server.

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -50,8 +50,7 @@ func RegisterFlags(fs *flag.FlagSet) {
 	if fs == nil {
 		fs = flag.CommandLine
 	}
-	f := fs.Lookup(KubeconfigFlagName)
-	if f != nil {
+	if f := fs.Lookup(KubeconfigFlagName); f != nil {
 		kubeconfig = f.Value.String()
 	} else {
 		fs.StringVar(&kubeconfig, KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

There have been reported issues (`flag redefined`) because CR registers the `kubeconfig` flag to the default command line FlagSet via init function. See:
* https://github.com/kubernetes-sigs/controller-runtime/issues/1396
* https://github.com/kubernetes-sigs/controller-runtime/issues/878

This PR provides an exported func to register flags that defensively tries to register the kubeconfig flag if not already defined. It does only change the current behaviour by previously checking if has already been defined.

As a follow up the registration via init should probably removed in conjunction with a :warning: release note, as it would be a breaking change for the user.

**NOTE**: I am not entirely sure if this really is the desired way to go and to start a discussion regarding the topic.

<sub>Johannes Frey <[johannes.frey@mercedes-benz.com](mailto:johannes.frey@mercedes-benz.com)>, Mercedes-Benz Tech Innovation GmbH ([Provider Information](https://github.com/mercedes-benz/daimler-foss/blob/master/PROVIDER_INFORMATION.md))</sub>
