### PR TITLE
:warning: Inc Generation on fakeClient Update/Patch

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -279,7 +279,19 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
 	}
 	accessor.SetResourceVersion("1")
-	accessor.SetGeneration(1)
+
+	gvk := obj.GetObjectKind().GroupVersionKind()
+	if gvk.Empty() {
+		gvk, err = apiutil.GVKForObject(obj, t.scheme)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isCustomResource(gvk) {
+		accessor.SetGeneration(1)
+	}
+
 	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
 	if err != nil {
 		return err

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"sync"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,8 +45,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/internal/objectutil"
-
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 )
 
 type versionedTracker struct {
@@ -280,6 +279,7 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
 	}
 	accessor.SetResourceVersion("1")
+	accessor.SetGeneration(1)
 	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
 	if err != nil {
 		return err

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1003,9 +1003,9 @@ var _ = Describe("Fake client", func() {
 		var cr *DummyCustomResource
 
 		toUnstructured := func(object interface{}) unstructured.Unstructured {
-			unstructured_, err := runtime.DefaultUnstructuredConverter.ToUnstructured(cr)
+			unstructuredObject, err := runtime.DefaultUnstructuredConverter.ToUnstructured(object)
 			Expect(err).To(BeNil())
-			return unstructured.Unstructured{Object: unstructured_}
+			return unstructured.Unstructured{Object: unstructuredObject}
 		}
 
 		BeforeEach(func() {
@@ -1066,9 +1066,9 @@ var _ = Describe("Fake client", func() {
 		It("should increment the generation for CR non-metadata change using unstructured objects", func() {
 			oldGeneration := cr.Generation
 			cr.Spec.A = 1
-			unstructured_ := toUnstructured(cr)
-			Expect(cl.Update(context.Background(), &unstructured_)).To(BeNil())
-			Expect(unstructured_.GetGeneration()).To(Equal(oldGeneration + 1))
+			unstructuredCR := toUnstructured(cr)
+			Expect(cl.Update(context.Background(), &unstructuredCR)).To(BeNil())
+			Expect(unstructuredCR.GetGeneration()).To(Equal(oldGeneration + 1))
 		})
 
 		It("should not increment generation for CR metadata change using unstructured objects", func() {
@@ -1076,9 +1076,9 @@ var _ = Describe("Fake client", func() {
 			cr.Annotations = map[string]string{
 				"annotation": "value",
 			}
-			unstructured_ := toUnstructured(cr)
-			Expect(cl.Update(context.Background(), &unstructured_)).To(BeNil())
-			Expect(unstructured_.GetGeneration()).To(Equal(oldGeneration))
+			unstructuredCR := toUnstructured(cr)
+			Expect(cl.Update(context.Background(), &unstructuredCR)).To(BeNil())
+			Expect(unstructuredCR.GetGeneration()).To(Equal(oldGeneration))
 		})
 
 		It("should not increment generation for non-CR change using unstructured objects", func() {
@@ -1087,9 +1087,9 @@ var _ = Describe("Fake client", func() {
 				"annotation": "value",
 			}
 			dep.Spec.MinReadySeconds = 10
-			unstructured_ := toUnstructured(cr)
-			Expect(cl.Update(context.Background(), &unstructured_)).To(BeNil())
-			Expect(unstructured_.GetGeneration()).To(Equal(oldGeneration))
+			unstructuredCR := toUnstructured(cr)
+			Expect(cl.Update(context.Background(), &unstructuredCR)).To(BeNil())
+			Expect(unstructuredCR.GetGeneration()).To(Equal(oldGeneration))
 		})
 	})
 

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -33,6 +33,7 @@ WARNING: ⚠️ Current Limitations / Known Issues with the fake Client ⚠️
     e.g. metadata and status in the same reconcile.
   - No OpenAPI validation is performed when creating or updating objects.
   - ObjectMeta's `Generation` and `ResourceVersion` don't behave properly, Patch or Update
-    operations that rely on these fields will fail, or give false positives.
+    operations that rely on these fields will fail, or give false positives. `Generation` will be
+    updated correctly only for custom resources.
 */
 package fake


### PR DESCRIPTION
Closes #1857.

This applies only to custom resources!
The behaviour of the API server regarding generation is polymorphic meaning that any resource type may behave differently. Custom resources have a uniform behaviour (increment on non-metadata change), and so this patch adds logic to `fakeClient` to handle this specific use case.