### PR TITLE
:seedling: add preWatch options for leader-elections runnables to reduce failover time when leader changes

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -358,3 +358,19 @@ func (c *Controller) InjectFunc(f inject.Func) error {
 func (c *Controller) updateMetrics(reconcileTime time.Duration) {
 	ctrlmetrics.ReconcileTime.WithLabelValues(c.Name).Observe(reconcileTime.Seconds())
 }
+
+// implements PreWatch interface.
+func (c *Controller) PreWatch() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, watch := range c.startWatches {
+		preWatchSource, ok := watch.src.(source.PreWatch)
+		if !ok {
+			continue
+		}
+		if err := preWatchSource.PreWatch(); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

### What does this do, and why do we need it? 
As we know leader-elections runnables only have one working instance, when the leader instance changes, the new leader should watch all resources; 

The problem is that watching resources takes long time in the big clusters, and this will have a affect for components who cares about the failover time。

This PR is used to provide a preWatch option for leader-election runnables to preWatch kubernetes resources (it does not handle resource events) for instances which does not acquire leader,  when the instance become leader, it starts to process events;
