### PR TITLE
🌱 grammar: removed doubles of the word "the"

### DIFF
--- a/TMP-LOGGING.md
+++ b/TMP-LOGGING.md
@@ -51,7 +51,7 @@ You can configure the logging implementation using
 `"sigs.k8s.io/controller-runtime/pkg/log".SetLogger`.  That
 package also contains the convenience functions for setting up Zap.
 
-You can get a handle to the the "root" logger using
+You can get a handle to the "root" logger using
 `"sigs.k8s.io/controller-runtime/pkg/log".Log`, and can then call
 `WithName` to create individual named loggers.  You can call `WithName`
 repeatedly to chain names together:

--- a/pkg/builder/options.go
+++ b/pkg/builder/options.go
@@ -101,9 +101,9 @@ func (p projectAs) ApplyToWatches(opts *WatchesInput) {
 
 var (
 	// OnlyMetadata tells the controller to *only* cache metadata, and to watch
-	// the the API server in metadata-only form.  This is useful when watching
+	// the API server in metadata-only form.  This is useful when watching
 	// lots of objects, really big objects, or objects for which you only know
-	// the the GVK, but not the structure.  You'll need to pass
+	// the GVK, but not the structure.  You'll need to pass
 	// metav1.PartialObjectMetadata to the client when fetching objects in your
 	// reconciler, otherwise you'll end up with a duplicate structured or
 	// unstructured cache.

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -101,7 +101,7 @@ func newConsoleEncoder(opts ...EncoderConfigOption) zapcore.Encoder {
 	return zapcore.NewConsoleEncoder(encoderConfig)
 }
 
-// Level sets Options.Level, which configures the the minimum enabled logging level e.g Debug, Info.
+// Level sets Options.Level, which configures the minimum enabled logging level e.g Debug, Info.
 // A zap log level should be multiplied by -1 to get the logr verbosity.
 // For example, to get logr verbosity of 3, pass zapcore.Level(-3) to this Opts.
 // See https://pkg.go.dev/github.com/go-logr/zapr for how zap level relates to logr verbosity.

--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -91,7 +91,7 @@ Then, you have a few options for managing your binaries:
   `--use-env` makes the command unconditionally use the value of
   KUBEBUILDER_ASSETS as long as it contains the required binaries, and
   `-i` indicates that we only ever want to work with installed binaries
-  (no reaching out the the remote GCS storage).
+  (no reaching out the remote GCS storage).
 
   As noted about, you can use `ENVTEST_INSTALLED_ONLY=true` to switch `-i`
   on by default, and you can use `ENVTEST_USE_ENV=true` to switch

--- a/tools/setup-envtest/main.go
+++ b/tools/setup-envtest/main.go
@@ -192,7 +192,7 @@ Versions:
 	Z may also be '*' or 'x' to match a wildcard.
 	You may also just write X.Y, which means X.Y.*.
 
-	A version may be prefixed with '~' to match the the most recent Z release
+	A version may be prefixed with '~' to match the most recent Z release
 	in the given Y release ( [X.Y.Z, X.Y+1.0) ).
 
 	Finally, you may suffix the version with '!' to force checking the

--- a/tools/setup-envtest/workflows/workflows.go
+++ b/tools/setup-envtest/workflows/workflows.go
@@ -25,7 +25,7 @@ func (f Use) Do(env *envp.Env) {
 	ctx := logr.NewContext(context.TODO(), env.Log.WithName("use"))
 	env.EnsureBaseDirs(ctx)
 	if f.UseEnv {
-		// the the env var unconditionally
+		// the env var unconditionally
 		if env.PathMatches(f.AssetsPath) {
 			env.PrintInfo(f.PrintFormat)
 			return


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

A minor grammar fix that removes doubles of the word "the".