### PR TITLE
📖 Advertise struct pointer requirement for Create

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -60,7 +60,8 @@ type Reader interface {
 
 // Writer knows how to create, delete, and update Kubernetes objects.
 type Writer interface {
-	// Create saves the object obj in the Kubernetes cluster.
+	// Create saves the object obj in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
 	Create(ctx context.Context, obj Object, opts ...CreateOption) error
 
 	// Delete deletes the given obj from Kubernetes cluster.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Make it explicit in the function comments that the "obj" argument of the Client interface's Create method must be a struct pointer, because implementers will store in it the object returned by the K8s API server.

The added statement was already present on `Update` and `Patch` methods, but not on `Create`.

**Note**:This comment will end up in the godoc of the package, but I couldn't find the godocs in the repo, so I don't know how to update the godocs.