### PR TITLE
:sparkles: Use `klog` as the controller-runtime default logger

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -38,6 +38,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/klog/v2"
+
 	"github.com/go-logr/logr"
 )
 
@@ -81,7 +83,8 @@ var (
 // set to a NullLogSink.
 var (
 	dlog = NewDelegatingLogSink(NullLogSink{})
-	Log  = logr.New(dlog)
+	// Log uses `klog` as the controller-runtime default logger.
+	Log = klog.NewKlogr()
 )
 
 // FromContext returns a logger with predefined values from a context.Context.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -100,7 +100,8 @@ var _ = Describe("logging", func() {
 	Describe("top-level logger", func() {
 		It("hold newly created loggers until a logger is set", func() {
 			By("grabbing a new sub-logger and logging to it")
-			l1 := Log.WithName("runtimeLog").WithValues("newtag", "newvalue1")
+			lgr := logr.New(dlog)
+			l1 := lgr.WithName("runtimeLog").WithValues("newtag", "newvalue1")
 			l1.Info("before msg")
 
 			By("actually setting the logger")
@@ -108,7 +109,7 @@ var _ = Describe("logging", func() {
 			SetLogger(logr.New(logger))
 
 			By("grabbing another sub-logger and logging to both loggers")
-			l2 := Log.WithName("runtimeLog").WithValues("newtag", "newvalue2")
+			l2 := lgr.WithName("runtimeLog").WithValues("newtag", "newvalue2")
 			l1.Info("after msg 1")
 			l2.Info("after msg 2")
 


### PR DESCRIPTION
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2024

To make the log output consistent with K8s core components (kube-apiserver, kube-controller-manager, etc), and
more human readable.

Test results:
Before this PR, the kubebuilder generated controller-manager log is:
```
1.6656692709539523e+09  INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": "127.0.0.1:8080"}
1.665669270954326e+09   INFO    setup   starting manager
1.6656692709546785e+09  INFO    Starting server {"path": "/metrics", "kind": "metrics", "addr": "127.0.0.1:8080"}
1.6656692709546802e+09  INFO    Starting server {"kind": "health probe", "addr": "[::]:8081"}
```

After this PR, the kubebuilder generated controller-manager log is:
```
I1016 23:41:42.700531   61722 listener.go:44] "controller-runtime/metrics: Metrics server is starting to listen" addr=":8080"
I1016 23:41:42.701073   61722 main.go:115] "setup: starting manager"
I1016 23:41:42.701251   61722 internal.go:362] "Starting server" kind="health probe" addr="[::]:8081"
I1016 23:41:42.701255   61722 internal.go:362] "Starting server" path="/metrics" kind="metrics" addr="[::]:8080"
```