### PR TITLE
:sparkles: Allow to provide a custom lock interface to manager

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -193,6 +193,12 @@ type Options struct {
 	// LeaseDuration time first.
 	LeaderElectionReleaseOnCancel bool
 
+	// LeaderElectionResourceLockInterface allows to provide a custom resourcelock.Interface that was created outside
+	// of the controller-runtime. If this value is set the options LeaderElectionID, LeaderElectionNamespace,
+	// LeaderElectionResourceLock, LeaseDuration, RenewDeadline and RetryPeriod will be ignored. This can be useful if you
+	// want to use a locking mechanism that is currently not supported, like a MultiLock across two Kubernetes clusters.
+	LeaderElectionResourceLockInterface resourcelock.Interface
+
 	// LeaseDuration is the duration that non-leader candidates will
 	// wait to force acquire leadership. This is measured against time of
 	// last observed ack. Default is 15 seconds.
@@ -377,14 +383,19 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		}
 	}
 
-	resourceLock, err := options.newResourceLock(leaderConfig, leaderRecorderProvider, leaderelection.Options{
-		LeaderElection:             options.LeaderElection,
-		LeaderElectionResourceLock: options.LeaderElectionResourceLock,
-		LeaderElectionID:           options.LeaderElectionID,
-		LeaderElectionNamespace:    options.LeaderElectionNamespace,
-	})
-	if err != nil {
-		return nil, err
+	var resourceLock resourcelock.Interface
+	if options.LeaderElectionResourceLockInterface != nil && options.LeaderElection {
+		resourceLock = options.LeaderElectionResourceLockInterface
+	} else {
+		resourceLock, err = options.newResourceLock(leaderConfig, leaderRecorderProvider, leaderelection.Options{
+			LeaderElection:             options.LeaderElection,
+			LeaderElectionResourceLock: options.LeaderElectionResourceLock,
+			LeaderElectionID:           options.LeaderElectionID,
+			LeaderElectionNamespace:    options.LeaderElectionNamespace,
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Create the metrics listener. This will throw an error if the metrics bind

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -511,6 +511,25 @@ var _ = Describe("manger.Manager", func() {
 				Expect(err).To(BeNil())
 				Expect(record.HolderIdentity).To(BeEmpty())
 			})
+			When("using a custom LeaderElectionResourceLockInterface", func() {
+				It("should use the custom LeaderElectionResourceLockInterface", func() {
+					rl, err := fakeleaderelection.NewResourceLock(nil, nil, leaderelection.Options{})
+					Expect(err).NotTo(HaveOccurred())
+
+					m, err := New(cfg, Options{
+						LeaderElection:                      true,
+						LeaderElectionResourceLockInterface: rl,
+						newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
+							return nil, fmt.Errorf("this should not be called")
+						},
+					})
+					Expect(m).ToNot(BeNil())
+					Expect(err).ToNot(HaveOccurred())
+					cm, ok := m.(*controllerManager)
+					Expect(ok).To(BeTrue())
+					Expect(cm.resourceLock).To(Equal(rl))
+				})
+			})
 		})
 
 		It("should create a listener for the metrics if a valid address is provided", func() {


### PR DESCRIPTION
Fixes: https://github.com/kubernetes-sigs/controller-runtime/issues/2026 

This allows a more flexible configuration of the controller-runtime leader election if needed. Those changes allow to provide a custom `resourcelock.Interface` that will be used for leader election.