### PR TITLE
⚠ Zap log: Default to RFC3339 time encoding

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -168,7 +168,7 @@ type Options struct {
 	// underlying Zap logger.
 	ZapOpts []zap.Option
 	// TimeEncoder specifies the encoder for the timestamps in log messages.
-	// Defaults to EpochTimeEncoder as this is the default in Zap currently.
+	// Defaults to RFC3339TimeEncoder.
 	TimeEncoder zapcore.TimeEncoder
 }
 
@@ -217,7 +217,7 @@ func (o *Options) addDefaults() {
 	}
 
 	if o.TimeEncoder == nil {
-		o.TimeEncoder = zapcore.EpochTimeEncoder
+		o.TimeEncoder = zapcore.RFC3339TimeEncoder
 	}
 	f := func(ecfg *zapcore.EncoderConfig) {
 		ecfg.EncodeTime = o.TimeEncoder

--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -502,7 +502,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 			Expect(optVal.Pointer()).To(Equal(expVal.Pointer()))
 		})
 
-		It("Should default to 'epoch' time encoding", func() {
+		It("Should default to 'rfc3339' time encoding", func() {
 			args := []string{""}
 			fromFlags.BindFlags(&fs)
 			err := fs.Parse(args)
@@ -513,7 +513,7 @@ var _ = Describe("Zap log level flag options setup", func() {
 			opt.addDefaults()
 
 			optVal := reflect.ValueOf(opt.TimeEncoder)
-			expVal := reflect.ValueOf(zapcore.EpochTimeEncoder)
+			expVal := reflect.ValueOf(zapcore.RFC3339TimeEncoder)
 
 			Expect(optVal.Pointer()).To(Equal(expVal.Pointer()))
 		})


### PR DESCRIPTION
The zap logger currently defaults to epoch time encoding which is pretty much imposisble to parse for humands. Default to RFC339 instead, as that is well-parseable by both humans and machines.

Fixes #2024 

/assign @vincepri @joelanford @sbueringer @camilamacedo86 

Ccing a larger group, as changing defaults has the potential of breaking things in a way where ppl will only notice after a rollout (e.G. if their log parsing assumes the epoch time format), so I want to be sure that everyone agrees this is a good idea.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
