### PR TITLE
:book: Fix documentation typo

### DIFF
--- a/TMP-LOGGING.md
+++ b/TMP-LOGGING.md
@@ -21,7 +21,7 @@ log.Printf("starting reconciliation for pod %s/%s", podNamespace, podName)
 In controller-runtime, we'd instead write:
 
 ```go
-logger.Info("starting reconciliation", "pod", req.NamespacedNamed)
+logger.Info("starting reconciliation", "pod", req.NamespacedName)
 ```
 
 or even write


### PR DESCRIPTION
Rename `req.NamespaceNamed` to `req.Namespacename`

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
