### PR TITLE
:sparkles: feat: add NOT predicate

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -50,6 +50,7 @@ var _ Predicate = GenerationChangedPredicate{}
 var _ Predicate = AnnotationChangedPredicate{}
 var _ Predicate = or{}
 var _ Predicate = and{}
+var _ Predicate = not{}
 
 // Funcs is a function that implements Predicate.
 type Funcs struct {
@@ -338,6 +339,35 @@ func (o or) Generic(e event.GenericEvent) bool {
 		}
 	}
 	return false
+}
+
+// Not returns a predicate that implements a logical NOT of the predicate passed to it.
+func Not(predicate Predicate) Predicate {
+	return not{predicate}
+}
+
+type not struct {
+	predicate Predicate
+}
+
+func (n not) InjectFunc(f inject.Func) error {
+	return f(n.predicate)
+}
+
+func (n not) Create(e event.CreateEvent) bool {
+	return !n.predicate.Create(e)
+}
+
+func (n not) Update(e event.UpdateEvent) bool {
+	return !n.predicate.Update(e)
+}
+
+func (n not) Delete(e event.DeleteEvent) bool {
+	return !n.predicate.Delete(e)
+}
+
+func (n not) Generic(e event.GenericEvent) bool {
+	return !n.predicate.Generic(e)
 }
 
 // LabelSelectorPredicate constructs a Predicate from a LabelSelector.

--- a/pkg/predicate/predicate_test.go
+++ b/pkg/predicate/predicate_test.go
@@ -879,6 +879,28 @@ var _ = Describe("Predicate", func() {
 				Expect(prct.injected).To(BeTrue())
 			})
 		})
+		Describe("When checking a Not predicate", func() {
+			It("should return false when its predicate returns true", func() {
+				n := predicate.Not(passFuncs)
+				Expect(n.Create(event.CreateEvent{})).To(BeFalse())
+				Expect(n.Update(event.UpdateEvent{})).To(BeFalse())
+				Expect(n.Delete(event.DeleteEvent{})).To(BeFalse())
+				Expect(n.Generic(event.GenericEvent{})).To(BeFalse())
+			})
+			It("should return true when its predicate returns false", func() {
+				n := predicate.Not(failFuncs)
+				Expect(n.Create(event.CreateEvent{})).To(BeTrue())
+				Expect(n.Update(event.UpdateEvent{})).To(BeTrue())
+				Expect(n.Delete(event.DeleteEvent{})).To(BeTrue())
+				Expect(n.Generic(event.GenericEvent{})).To(BeTrue())
+			})
+			It("should inject into its predicate", func() {
+				prct := &injectablePredicate{}
+				n := predicate.Not(prct)
+				Expect(injectFunc(n)).To(Succeed())
+				Expect(prct.injected).To(BeTrue())
+			})
+		})
 	})
 
 	Describe("NewPredicateFuncs with a namespace filter function", func() {


### PR DESCRIPTION
This PR adds a new boolean NOT predicate function (`predicate.Not()`) to complement `predicate.And()` and `predicate.Or()` added in https://github.com/kubernetes-sigs/controller-runtime/pull/1043.

While not extremely useful, I think it can make code for bootstrapping controllers easier to read. And avoid having to create a dedicated predicate just for selecting the complement set selected by another predicate.

I have also seen a few examples of this implemented as a utility in publicly available controllers.