### PR TITLE
🐛 Skip custom mutation handler when delete a CR

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"net/http"
 
+	admissionv1 "k8s.io/api/admission/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -58,6 +60,16 @@ func (h *defaulterForType) Handle(ctx context.Context, req Request) Response {
 	}
 	if h.object == nil {
 		panic("object should never be nil")
+	}
+
+	// Always skip when a DELETE operation received in custom mutation handler.
+	if req.Operation == admissionv1.Delete {
+		return Response{AdmissionResponse: admissionv1.AdmissionResponse{
+			Allowed: true,
+			Result: &metav1.Status{
+				Code: http.StatusOK,
+			},
+		}}
 	}
 
 	ctx = NewContextWithRequest(ctx, req)


### PR DESCRIPTION
Signed-off-by: iiiceoo <[ziqian.xue@daocloud.io](mailto:ziqian.xue@daocloud.io)>

closes [#2048](https://github.com/kubernetes-sigs/controller-runtime/issues/2048)

Mutating webhook registered by func `WithDefaulter()` returns an error `"there is no content to decode"` when processing CR deletion request. Refer to the solution [here](https://github.com/kubernetes-sigs/controller-runtime/blob/1ead647/pkg/webhook/admission/defaulter.go#L61-L70), add the same logic to the handler of the interface `CustomDefaulter`.