### PR TITLE
:sparkles: Add function to get reconcileID from context

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -153,3 +153,6 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		RecoverPanic:            options.RecoverPanic,
 	}, nil
 }
+
+// ReconcileIDFromContext gets the reconcileID from the current context.
+var ReconcileIDFromContext = controller.ReconcileIDFromContext

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/util/workqueue"
@@ -311,9 +312,11 @@ func (c *Controller) reconcileHandler(ctx context.Context, obj interface{}) {
 	}
 
 	log := c.LogConstructor(&req)
+	reconcileID := uuid.NewUUID()
 
-	log = log.WithValues("reconcileID", uuid.NewUUID())
+	log = log.WithValues("reconcileID", reconcileID)
 	ctx = logf.IntoContext(ctx, log)
+	ctx = addReconcileID(ctx, reconcileID)
 
 	// RunInformersAndControllers the syncHandler, passing it the Namespace/Name string of the
 	// resource to be synced.
@@ -357,4 +360,22 @@ func (c *Controller) InjectFunc(f inject.Func) error {
 // updateMetrics updates prometheus metrics within the controller.
 func (c *Controller) updateMetrics(reconcileTime time.Duration) {
 	ctrlmetrics.ReconcileTime.WithLabelValues(c.Name).Observe(reconcileTime.Seconds())
+}
+
+// ReconcileIDFromContext gets the reconcileID from the current context.
+func ReconcileIDFromContext(ctx context.Context) types.UID {
+	r, ok := ctx.Value(reconcileIDKey{}).(types.UID)
+	if !ok {
+		return ""
+	}
+
+	return r
+}
+
+// reconcileIDKey is a context.Context Value key. Its associated value should
+// be a types.UID.
+type reconcileIDKey struct{}
+
+func addReconcileID(ctx context.Context, reconcileID types.UID) context.Context {
+	return context.WithValue(ctx, reconcileIDKey{}, reconcileID)
 }

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -873,6 +873,23 @@ var _ = Describe("controller", func() {
 	})
 })
 
+var _ = Describe("ReconcileIDFromContext function", func() {
+	It("should return an empty string if there is nothing in the context", func() {
+		ctx := context.Background()
+		reconcileID := ReconcileIDFromContext(ctx)
+
+		Expect(reconcileID).To(Equal(types.UID("")))
+	})
+
+	It("should return the correct reconcileID from context", func() {
+		const expectedReconcileID = types.UID("uuid")
+		ctx := addReconcileID(context.Background(), expectedReconcileID)
+		reconcileID := ReconcileIDFromContext(ctx)
+
+		Expect(reconcileID).To(Equal(expectedReconcileID))
+	})
+})
+
 type DelegatingQueue struct {
 	workqueue.RateLimitingInterface
 	mu sync.Mutex


### PR DESCRIPTION
This creates a new function `ReconcileIDFromContext` which allows to get the logged reconcile ID from context. It is proposed in #2055.

Since the controller package , where the reconcileID is created and added is internal, I had to reference the function in `pkg/controller/controller.go`. To expose the function in `pkg/reconcile` or `pkg/log` is not possible because of import cycles. And the creation of a new package `pkg/context` seemed a little exaggerated to me.
