### PR TITLE
:sparkles: Tidy up startup logging of kindWithCache source

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -83,6 +83,10 @@ func (ks *kindWithCache) Start(ctx context.Context, handler handler.EventHandler
 	return ks.kind.Start(ctx, handler, queue, prct...)
 }
 
+func (ks *kindWithCache) String() string {
+	return ks.kind.String()
+}
+
 func (ks *kindWithCache) WaitForSync(ctx context.Context) error {
 	return ks.kind.WaitForSync(ctx)
 }


### PR DESCRIPTION
Add a `String` method for the `kindWithCache` type to make log messages neater.

When the controller starts a source, the controller logs the message "Starting EventSource" along with the stringification of the source. Most source types implement the `String` method to provide pretty stringifications, but the `kindWithCache` source type was missing this, resulting in log messages like the following:

    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "&{{%!s(*v1.Role=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] [] []} []}) %!s(*cache.multiNamespaceCache=&{map[openshift-config:0xc000712110 openshift-config-managed:0xc000712108 openshift-ingress:0xc0007120f8 openshift-ingress-canary:0xc000712100 openshift-ingress-operator:0xc0007120e8] 0xc000261ea0 0xc00010e190 0xc0007120e0}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "&{{%!s(*v1.RoleBinding=&{{ } {      0 {{0 0 <nil>}} <nil> <nil> map[] map[] [] [] []} [] {  }}) %!s(*cache.multiNamespaceCache=&{map[openshift-config:0xc000712110 openshift-config-managed:0xc000712108 openshift-ingress:0xc0007120f8 openshift-ingress-canary:0xc000712100 openshift-ingress-operator:0xc0007120e8] 0xc000261ea0 0xc00010e190 0xc0007120e0}) %!s(chan error=<nil>) %!s(func()=<nil>)}}"}
    2022-11-23T08:47:35.646-0600    INFO    operator.init   controller/controller.go:241    Starting Controller     {"controller": "configurable_route_controller"}

Because `kindWithCache` wraps `Kind`, the new `String` method simply calls the wrapped `Kind` source's `String` method, which results in log messages like the following:

    2022-11-23T08:48:43.076-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "kind source: *v1.Role"}
    2022-11-23T08:48:43.078-0600    INFO    operator.init   controller/controller.go:241    Starting EventSource    {"controller": "configurable_route_controller", "source": "kind source: *v1.RoleBinding"}
    2022-11-23T08:48:43.078-0600    INFO    operator.init   controller/controller.go:241    Starting Controller     {"controller": "configurable_route_controller"}

* `pkg/source/source.go`: Add a `String` method for `kindWithCache`.

-------

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->