### PR TITLE
:seedling: Ignore Kubernetes Dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,5 +25,12 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: ":seedling:"
+    # Ignore K8 packages as these are done manually
+    ignore:
+      - dependency-name: "k8s.io/api"
+      - dependency-name: "k8s.io/apiextensions-apiserver"
+      - dependency-name: "k8s.io/apimachinery"
+      - dependency-name: "k8s.io/client-go"
+      - dependency-name: "k8s.io/component-base"
     labels:
       - "ok-to-test"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This ignores the kubernetes api dependencies