### PR TITLE
:warning: Add client.SubResourceWriter

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -288,40 +288,152 @@ func (c *client) List(ctx context.Context, obj ObjectList, opts ...ListOption) e
 }
 
 // Status implements client.StatusClient.
-func (c *client) Status() StatusWriter {
-	return &statusWriter{client: c}
+func (c *client) Status() SubResourceWriter {
+	return c.SubResource("status")
 }
 
-// statusWriter is client.StatusWriter that writes status subresource.
-type statusWriter struct {
-	client *client
+func (c *client) SubResource(subResource string) SubResourceWriter {
+	return &subResourceWriter{client: c, subResource: subResource}
 }
 
-// ensure statusWriter implements client.StatusWriter.
-var _ StatusWriter = &statusWriter{}
+// subResourceWriter is client.SubResourceWriter that writes to subresources.
+type subResourceWriter struct {
+	client      *client
+	subResource string
+}
 
-// Update implements client.StatusWriter.
-func (sw *statusWriter) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
-	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
-	switch obj.(type) {
-	case *unstructured.Unstructured:
-		return sw.client.unstructuredClient.UpdateStatus(ctx, obj, opts...)
-	case *metav1.PartialObjectMetadata:
-		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
-	default:
-		return sw.client.typedClient.UpdateStatus(ctx, obj, opts...)
+// ensure subResourceWriter implements client.SubResourceWriter.
+var _ SubResourceWriter = &subResourceWriter{}
+
+// SubResourceUpdateOptions holds all the possible configuration
+// for a subresource update request.
+type SubResourceUpdateOptions struct {
+	UpdateOptions
+	SubResourceBody Object
+}
+
+// ApplyToSubResourceUpdate updates the configuration on the given create options
+func (uo *SubResourceUpdateOptions) ApplyToSubResourceUpdate(o *SubResourceUpdateOptions) {
+	uo.UpdateOptions.ApplyToUpdate(&o.UpdateOptions)
+	if uo.SubResourceBody != nil {
+		o.SubResourceBody = uo.SubResourceBody
 	}
 }
 
-// Patch implements client.Client.
-func (sw *statusWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+// ApplyOptions applies the given options.
+func (uo *SubResourceUpdateOptions) ApplyOptions(opts []SubResourceUpdateOption) *SubResourceUpdateOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceUpdate(uo)
+	}
+
+	return uo
+}
+
+// SubResourceUpdateAndPatchOption is an option that can be used for either
+// a subresource update or patch request.
+type SubResourceUpdateAndPatchOption interface {
+	SubResourceUpdateOption
+	SubResourcePatchOption
+}
+
+// WithSubResourceBody returns an option that uses the given body
+// for a subresource Update or Patch operation.
+func WithSubResourceBody(body Object) SubResourceUpdateAndPatchOption {
+	return &withSubresourceBody{body: body}
+}
+
+type withSubresourceBody struct {
+	body Object
+}
+
+func (wsr *withSubresourceBody) ApplyToSubResourceUpdate(o *SubResourceUpdateOptions) {
+	o.SubResourceBody = wsr.body
+}
+
+func (wsr *withSubresourceBody) ApplyToSubResourcePatch(o *SubResourcePatchOptions) {
+	o.SubResourceBody = wsr.body
+}
+
+// SubResourceCreateOptions are all the possible configurations for a subresource
+// create request.
+type SubResourceCreateOptions struct {
+	CreateOptions
+}
+
+// ApplyOptions applies the given options.
+func (co *SubResourceCreateOptions) ApplyOptions(opts []SubResourceCreateOption) *SubResourceCreateOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceCreate(co)
+	}
+
+	return co
+}
+
+// ApplyToSubresourceCreate applies the the configuration on the given create options.
+func (co *SubResourceCreateOptions) ApplyToSubresourceCreate(o *SubResourceCreateOptions) {
+	co.CreateOptions.ApplyToCreate(&co.CreateOptions)
+}
+
+// SubResourcePatchOptions holds all possible configurations for a subresource patch
+// request.
+type SubResourcePatchOptions struct {
+	PatchOptions
+	SubResourceBody Object
+}
+
+// ApplyOptions applies the given options.
+func (po *SubResourcePatchOptions) ApplyOptions(opts []SubResourcePatchOption) *SubResourcePatchOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourcePatch(po)
+	}
+
+	return po
+}
+
+// ApplyToSubResourcePatch applies the configuration on the given patch options.
+func (po *SubResourcePatchOptions) ApplyToSubResourcePatch(o *SubResourcePatchOptions) {
+	po.PatchOptions.ApplyToPatch(&o.PatchOptions)
+	if po.SubResourceBody != nil {
+		o.SubResourceBody = po.SubResourceBody
+	}
+}
+
+func (sw *subResourceWriter) Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error {
+	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	defer sw.client.resetGroupVersionKind(subResource, subResource.GetObjectKind().GroupVersionKind())
+
+	switch obj.(type) {
+	case *unstructured.Unstructured:
+		return sw.client.unstructuredClient.CreateSubResource(ctx, obj, subResource, sw.subResource, opts...)
+	case *metav1.PartialObjectMetadata:
+		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
+	default:
+		return sw.client.typedClient.CreateSubResource(ctx, obj, subResource, sw.subResource, opts...)
+	}
+}
+
+// Update implements client.SubResourceWriter.
+func (sw *subResourceWriter) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
 	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
 	switch obj.(type) {
 	case *unstructured.Unstructured:
-		return sw.client.unstructuredClient.PatchStatus(ctx, obj, patch, opts...)
+		return sw.client.unstructuredClient.UpdateSubResource(ctx, obj, sw.subResource, opts...)
 	case *metav1.PartialObjectMetadata:
-		return sw.client.metadataClient.PatchStatus(ctx, obj, patch, opts...)
+		return fmt.Errorf("cannot update status using only metadata -- did you mean to patch?")
 	default:
-		return sw.client.typedClient.PatchStatus(ctx, obj, patch, opts...)
+		return sw.client.typedClient.UpdateSubResource(ctx, obj, sw.subResource, opts...)
+	}
+}
+
+// Patch implements client.SubResourceWriter.
+func (sw *subResourceWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+	defer sw.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+	switch obj.(type) {
+	case *unstructured.Unstructured:
+		return sw.client.unstructuredClient.PatchSubResource(ctx, obj, sw.subResource, patch, opts...)
+	case *metav1.PartialObjectMetadata:
+		return sw.client.metadataClient.PatchSubResource(ctx, obj, sw.subResource, patch, opts...)
+	default:
+		return sw.client.typedClient.PatchSubResource(ctx, obj, sw.subResource, patch, opts...)
 	}
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -18,6 +18,7 @@ package client_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -25,7 +26,11 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -130,6 +135,8 @@ var _ = Describe("Client", func() {
 	var dep *appsv1.Deployment
 	var pod *corev1.Pod
 	var node *corev1.Node
+	var serviceAccount *corev1.ServiceAccount
+	var csr *certificatesv1.CertificateSigningRequest
 	var count uint64 = 0
 	var replicaCount int32 = 2
 	var ns = "default"
@@ -164,6 +171,30 @@ var _ = Describe("Client", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("node-name-%v", count)},
 			Spec:       corev1.NodeSpec{},
 		}
+		serviceAccount = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("sa-%v", count), Namespace: ns}}
+		csr = &certificatesv1.CertificateSigningRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("csr-%v", count)},
+			Spec: certificatesv1.CertificateSigningRequestSpec{
+				SignerName: "org.io/my-signer",
+				Request: []byte(`-----BEGIN CERTIFICATE REQUEST-----
+MIIChzCCAW8CAQAwQjELMAkGA1UEBhMCWFgxFTATBgNVBAcMDERlZmF1bHQgQ2l0
+eTEcMBoGA1UECgwTRGVmYXVsdCBDb21wYW55IEx0ZDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBANe06dLX/bDNm6mVEnKdJexcJM6WKMFSt5o6BEdD1+Ki
+WyUcvfNgIBbwAZjkF9U1r7+KuDcc6XYFnb6ky1wPo4C+XwcIIx7Nnbf8IdWJukPb
+2BCsqO4NCsG6kKFavmH9J3q//nwKUvlQE+AJ2MPuOAZTwZ4KskghiGuS8hyk6/PZ
+XH9QhV7Jma43bDzQozd2C7OujRBhLsuP94KSu839RRFWd9ms3XHgTxLxb7nxwZDx
+9l7/ZVAObJoQYlHENqs12NCVP4gpJfbcY8/rd+IG4ftcZEmpeO4kKO+d2TpRKQqw
+bjCMoAdD5Y43iLTtyql4qRnbMe3nxYG2+1inEryuV/cCAwEAAaAAMA0GCSqGSIb3
+DQEBCwUAA4IBAQDH5hDByRN7wERQtC/o6uc8Y+yhjq9YcBJjjbnD6Vwru5pOdWtx
+qfKkkXI5KNOdEhWzLnJyOcWHjj8UoHqI3AjxGC7dTM95eGjxQGUpsUOX8JSd4MiZ
+cct4g4BKBj02AGqZLiEgN+PLCYAmEaYU7oZc4OAh6WzMrljNRsj66awMQpw8O1eY
+YuBa8vwz8ko8vn/pn7IrFu8cZ+EA3rluJ+budX/QrEGi1hijg27q7/Qr0wNI9f1v
+086mLKdqaBTkblXWEvF3WP4CcLNyrSNi4eu+G0fcAgGp1F/Nqh0MuWKSOLprv5Om
+U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
+-----END CERTIFICATE REQUEST-----`),
+				Usages: []certificatesv1.KeyUsage{certificatesv1.UsageClientAuth},
+			},
+		}
 		scheme = kscheme.Scheme
 	})
 
@@ -182,6 +213,11 @@ var _ = Describe("Client", func() {
 			err = clientset.CoreV1().Nodes().Delete(ctx, node.Name, *delOptions)
 			Expect(err).NotTo(HaveOccurred())
 		}
+		err = clientset.CoreV1().ServiceAccounts(ns).Delete(ctx, serviceAccount.Name, *delOptions)
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+
+		err = clientset.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, *delOptions)
+		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
 	})
 
 	// TODO(seans): Cast "cl" as "client" struct from "Client" interface. Then validate the
@@ -702,6 +738,390 @@ var _ = Describe("Client", func() {
 				Expect(testOption.applied).To(Equal(true))
 			})
 		})
+	})
+
+	Describe("SubResourceWriter", func() {
+		Context("with structured objects", func() {
+			It("should be able to create ServiceAccount tokens", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the serviceAccount")
+				_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.Namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
+				Expect((err)).NotTo(HaveOccurred())
+
+				token := &authenticationv1.TokenRequest{}
+				err = cl.SubResource("token").Create(ctx, serviceAccount, token)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(token.Status.Token).NotTo(Equal(""))
+			})
+
+			It("should be able to create Pod evictions", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				// Make the pod valid
+				pod.Spec.Containers = []corev1.Container{{Name: "foo", Image: "busybox"}}
+
+				By("Creating the pod")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating the eviction")
+				eviction := &policyv1.Eviction{
+					DeleteOptions: &metav1.DeleteOptions{GracePeriodSeconds: ptr(int64(0))},
+				}
+				err = cl.SubResource("eviction").Create(ctx, pod, eviction)
+				Expect((err)).NotTo(HaveOccurred())
+
+				By("Asserting the pod is gone")
+				_, err = clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("should be able to create Pod bindings", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				// Make the pod valid
+				pod.Spec.Containers = []corev1.Container{{Name: "foo", Image: "busybox"}}
+
+				By("Creating the pod")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating the binding")
+				binding := &corev1.Binding{
+					Target: corev1.ObjectReference{Name: node.Name},
+				}
+				err = cl.SubResource("binding").Create(ctx, pod, binding)
+				Expect((err)).NotTo(HaveOccurred())
+
+				By("Asserting the pod is bound")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.NodeName).To(Equal(node.Name))
+			})
+
+			It("should be able to approve CSRs", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the CSR")
+				csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Approving the CSR")
+				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+				})
+				err = cl.SubResource("approval").Update(ctx, csr)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Asserting the CSR is approved")
+				csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(ctx, csr.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csr.Status.Conditions[0].Type).To(Equal(certificatesv1.CertificateApproved))
+				Expect(csr.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			})
+
+			It("should be able to approve CSRs using Patch", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the CSR")
+				csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Approving the CSR")
+				patch := client.MergeFrom(csr.DeepCopy())
+				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+				})
+				err = cl.SubResource("approval").Patch(ctx, csr, patch)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Asserting the CSR is approved")
+				csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(ctx, csr.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csr.Status.Conditions[0].Type).To(Equal(certificatesv1.CertificateApproved))
+				Expect(csr.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			})
+
+			It("should be able to update the scale subresource", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating a deployment")
+				dep, err := clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the scale subresurce")
+				replicaCount := *dep.Spec.Replicas
+				scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: replicaCount}}
+				err = cl.SubResource("scale").Update(ctx, dep, client.WithSubResourceBody(scale))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Asserting replicas got updated")
+				dep, err = clientset.AppsV1().Deployments(dep.Namespace).Get(ctx, dep.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*dep.Spec.Replicas).To(Equal(replicaCount))
+			})
+
+			It("should be able to patch the scale subresource", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating a deployment")
+				dep, err := clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the scale subresurce")
+				replicaCount := *dep.Spec.Replicas
+				patch := client.MergeFrom(&autoscalingv1.Scale{})
+				scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: replicaCount}}
+				err = cl.SubResource("scale").Patch(ctx, dep, patch, client.WithSubResourceBody(scale))
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Asserting replicas got updated")
+				dep, err = clientset.AppsV1().Deployments(dep.Namespace).Get(ctx, dep.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*dep.Spec.Replicas).To(Equal(replicaCount))
+			})
+		})
+
+		Context("with unstructured objects", func() {
+			It("should be able to create ServiceAccount tokens", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the serviceAccount")
+				_, err = clientset.CoreV1().ServiceAccounts(serviceAccount.Namespace).Create(ctx, serviceAccount, metav1.CreateOptions{})
+				Expect((err)).NotTo(HaveOccurred())
+
+				serviceAccount.APIVersion = "v1"
+				serviceAccount.Kind = "ServiceAccount"
+				serviceAccountUnstructured, err := toUnstructured(serviceAccount)
+				Expect(err).NotTo(HaveOccurred())
+
+				token := &unstructured.Unstructured{}
+				token.SetAPIVersion("authentication.k8s.io/v1")
+				token.SetKind("TokenRequest")
+				err = cl.SubResource("token").Create(ctx, serviceAccountUnstructured, token)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(token.GetAPIVersion()).To(Equal("authentication.k8s.io/v1"))
+				Expect(token.GetKind()).To(Equal("TokenRequest"))
+
+				val, found, err := unstructured.NestedString(token.UnstructuredContent(), "status", "token")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(found).To(BeTrue())
+				Expect(val).NotTo(Equal(""))
+			})
+
+			It("should be able to create Pod evictions", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				// Make the pod valid
+				pod.Spec.Containers = []corev1.Container{{Name: "foo", Image: "busybox"}}
+
+				By("Creating the pod")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				pod.APIVersion = "v1"
+				pod.Kind = "Pod"
+				podUnstructured, err := toUnstructured(pod)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating the eviction")
+				eviction := &unstructured.Unstructured{}
+				eviction.SetAPIVersion("policy/v1")
+				eviction.SetKind("Eviction")
+				err = unstructured.SetNestedField(eviction.UnstructuredContent(), int64(0), "deleteOptions", "gracePeriodSeconds")
+				Expect(err).NotTo(HaveOccurred())
+				err = cl.SubResource("eviction").Create(ctx, podUnstructured, eviction)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(eviction.GetAPIVersion()).To(Equal("policy/v1"))
+				Expect(eviction.GetKind()).To(Equal("Eviction"))
+
+				By("Asserting the pod is gone")
+				_, err = clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+				Expect(apierrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("should be able to create Pod bindings", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				// Make the pod valid
+				pod.Spec.Containers = []corev1.Container{{Name: "foo", Image: "busybox"}}
+
+				By("Creating the pod")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				pod.APIVersion = "v1"
+				pod.Kind = "Pod"
+				podUnstructured, err := toUnstructured(pod)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Creating the binding")
+				binding := &unstructured.Unstructured{}
+				binding.SetAPIVersion("v1")
+				binding.SetKind("Binding")
+				err = unstructured.SetNestedField(binding.UnstructuredContent(), node.Name, "target", "name")
+				Expect(err).NotTo(HaveOccurred())
+
+				err = cl.SubResource("binding").Create(ctx, podUnstructured, binding)
+				Expect((err)).NotTo(HaveOccurred())
+				Expect(binding.GetAPIVersion()).To(Equal("v1"))
+				Expect(binding.GetKind()).To(Equal("Binding"))
+
+				By("Asserting the pod is bound")
+				pod, err = clientset.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(pod.Spec.NodeName).To(Equal(node.Name))
+			})
+
+			It("should be able to approve CSRs", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the CSR")
+				csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Approving the CSR")
+				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+				})
+				csr.APIVersion = "certificates.k8s.io/v1"
+				csr.Kind = "CertificateSigningRequest"
+				csrUnstructured, err := toUnstructured(csr)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = cl.SubResource("approval").Update(ctx, csrUnstructured)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csrUnstructured.GetAPIVersion()).To(Equal("certificates.k8s.io/v1"))
+				Expect(csrUnstructured.GetKind()).To(Equal("CertificateSigningRequest"))
+
+				By("Asserting the CSR is approved")
+				csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(ctx, csr.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csr.Status.Conditions[0].Type).To(Equal(certificatesv1.CertificateApproved))
+				Expect(csr.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			})
+
+			It("should be able to approve CSRs using Patch", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating the CSR")
+				csr, err := clientset.CertificatesV1().CertificateSigningRequests().Create(ctx, csr, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Approving the CSR")
+				patch := client.MergeFrom(csr.DeepCopy())
+				csr.Status.Conditions = append(csr.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:   certificatesv1.CertificateApproved,
+					Status: corev1.ConditionTrue,
+				})
+				csr.APIVersion = "certificates.k8s.io/v1"
+				csr.Kind = "CertificateSigningRequest"
+				csrUnstructured, err := toUnstructured(csr)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = cl.SubResource("approval").Patch(ctx, csrUnstructured, patch)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csrUnstructured.GetAPIVersion()).To(Equal("certificates.k8s.io/v1"))
+				Expect(csrUnstructured.GetKind()).To(Equal("CertificateSigningRequest"))
+
+				By("Asserting the CSR is approved")
+				csr, err = clientset.CertificatesV1().CertificateSigningRequests().Get(ctx, csr.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(csr.Status.Conditions[0].Type).To(Equal(certificatesv1.CertificateApproved))
+				Expect(csr.Status.Conditions[0].Status).To(Equal(corev1.ConditionTrue))
+			})
+
+			It("should be able to update the scale subresource", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating a deployment")
+				dep, err := clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				dep.APIVersion = "apps/v1"
+				dep.Kind = "Deployment"
+				depUnstructured, err := toUnstructured(dep)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the scale subresurce")
+				replicaCount := *dep.Spec.Replicas
+				scale := &unstructured.Unstructured{}
+				scale.SetAPIVersion("autoscaling/v1")
+				scale.SetKind("Scale")
+				Expect(unstructured.SetNestedField(scale.Object, int64(replicaCount), "spec", "replicas")).NotTo(HaveOccurred())
+				err = cl.SubResource("scale").Update(ctx, depUnstructured, client.WithSubResourceBody(scale))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(scale.GetAPIVersion()).To(Equal("autoscaling/v1"))
+				Expect(scale.GetKind()).To(Equal("Scale"))
+
+				By("Asserting replicas got updated")
+				dep, err = clientset.AppsV1().Deployments(dep.Namespace).Get(ctx, dep.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*dep.Spec.Replicas).To(Equal(replicaCount))
+			})
+
+			It("should be able to patch the scale subresource", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				By("Creating a deployment")
+				dep, err := clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				dep.APIVersion = "apps/v1"
+				dep.Kind = "Deployment"
+				depUnstructured, err := toUnstructured(dep)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Updating the scale subresurce")
+				replicaCount := *dep.Spec.Replicas
+				scale := &unstructured.Unstructured{}
+				scale.SetAPIVersion("autoscaling/v1")
+				scale.SetKind("Scale")
+				patch := client.MergeFrom(scale.DeepCopy())
+				Expect(unstructured.SetNestedField(scale.Object, int64(replicaCount), "spec", "replicas")).NotTo(HaveOccurred())
+				err = cl.SubResource("scale").Patch(ctx, depUnstructured, patch, client.WithSubResourceBody(scale))
+				Expect(err).NotTo(HaveOccurred())
+				Expect(scale.GetAPIVersion()).To(Equal("autoscaling/v1"))
+				Expect(scale.GetKind()).To(Equal("Scale"))
+
+				By("Asserting replicas got updated")
+				dep, err = clientset.AppsV1().Deployments(dep.Namespace).Get(ctx, dep.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*dep.Spec.Replicas).To(Equal(replicaCount))
+			})
+		})
+
 	})
 
 	Describe("StatusClient", func() {
@@ -3439,4 +3859,17 @@ func (f *fakeReader) Get(ctx context.Context, key client.ObjectKey, obj client.O
 func (f *fakeReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	f.Called++
 	return nil
+}
+
+func ptr[T any](to T) *T {
+	return &to
+}
+
+func toUnstructured(o client.Object) (*unstructured.Unstructured, error) {
+	serialized, err := json.Marshal(o)
+	if err != nil {
+		return nil, err
+	}
+	u := &unstructured.Unstructured{}
+	return u, json.Unmarshal(serialized, u)
 }

--- a/pkg/client/dryrun.go
+++ b/pkg/client/dryrun.go
@@ -82,25 +82,34 @@ func (c *dryRunClient) List(ctx context.Context, obj ObjectList, opts ...ListOpt
 }
 
 // Status implements client.StatusClient.
-func (c *dryRunClient) Status() StatusWriter {
-	return &dryRunStatusWriter{client: c.client.Status()}
+func (c *dryRunClient) Status() SubResourceWriter {
+	return c.SubResource("status")
 }
 
-// ensure dryRunStatusWriter implements client.StatusWriter.
-var _ StatusWriter = &dryRunStatusWriter{}
+// SubResource implements client.SubResourceClient.
+func (c *dryRunClient) SubResource(subResource string) SubResourceWriter {
+	return &dryRunSubResourceWriter{client: c.client.SubResource(subResource)}
+}
 
-// dryRunStatusWriter is client.StatusWriter that writes status subresource with dryRun mode
+// ensure dryRunSubResourceWriter implements client.SubResourceWriter.
+var _ SubResourceWriter = &dryRunSubResourceWriter{}
+
+// dryRunSubResourceWriter is client.SubResourceWriter that writes status subresource with dryRun mode
 // enforced.
-type dryRunStatusWriter struct {
-	client StatusWriter
+type dryRunSubResourceWriter struct {
+	client SubResourceWriter
 }
 
-// Update implements client.StatusWriter.
-func (sw *dryRunStatusWriter) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+func (sw *dryRunSubResourceWriter) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
+	return sw.client.Create(ctx, obj, subResource, append(opts, DryRunAll)...)
+}
+
+// Update implements client.SubResourceWriter.
+func (sw *dryRunSubResourceWriter) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
 	return sw.client.Update(ctx, obj, append(opts, DryRunAll)...)
 }
 
-// Patch implements client.StatusWriter.
-func (sw *dryRunStatusWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+// Patch implements client.SubResourceWriter.
+func (sw *dryRunSubResourceWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	return sw.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
 }

--- a/pkg/client/dryrun_test.go
+++ b/pkg/client/dryrun_test.go
@@ -226,7 +226,7 @@ var _ = Describe("DryRunClient", func() {
 	It("should not change objects via update status with opts", func() {
 		changedDep := dep.DeepCopy()
 		changedDep.Status.Replicas = 99
-		opts := &client.UpdateOptions{DryRun: []string{"Bye", "Pippa"}}
+		opts := &client.SubResourceUpdateOptions{UpdateOptions: client.UpdateOptions{DryRun: []string{"Bye", "Pippa"}}}
 
 		Expect(getClient().Status().Update(ctx, changedDep, opts)).NotTo(HaveOccurred())
 
@@ -252,7 +252,7 @@ var _ = Describe("DryRunClient", func() {
 		changedDep := dep.DeepCopy()
 		changedDep.Status.Replicas = 99
 
-		opts := &client.PatchOptions{DryRun: []string{"Bye", "Pippa"}}
+		opts := &client.SubResourcePatchOptions{PatchOptions: client.PatchOptions{DryRun: []string{"Bye", "Pippa"}}}
 
 		Expect(getClient().Status().Patch(ctx, changedDep, client.MergeFrom(dep), opts)).ToNot(HaveOccurred())
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -82,20 +82,64 @@ type Writer interface {
 // StatusClient knows how to create a client which can update status subresource
 // for kubernetes objects.
 type StatusClient interface {
-	Status() StatusWriter
+	Status() SubResourceWriter
 }
 
-// StatusWriter knows how to update status subresource of a Kubernetes object.
-type StatusWriter interface {
+// SubResourceClient knows how to create a client which can update subresource
+// for kubernetes objects.
+type SubResourceClient interface {
+	// SubResource returns a subresource client for the named subResource. Known
+	// upstream subResources are:
+	// - ServiceAccount tokens:
+	//     sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     token := &authenticationv1.TokenRequest{}
+	//     c.SubResourceClient("token").Create(ctx, sa, token)
+	//
+	// - Pod evictions:
+	//     pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     c.SubResourceClient("eviction").Create(ctx, pod, &policyv1.Eviction{})
+	//
+	// - Pod bindings:
+	//     pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     binding := &corev1.Binding{Target: corev1.ObjectReference{Name: "my-node"}}
+	//     c.SubResourceClient("binding").Create(ctx, pod, binding)
+	//
+	// - CertificateSigningRequest approval:
+	//     csr := &certificatesv1.CertificateSigningRequest{
+	//	     ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"},
+	//       Status: certificatesv1.CertificateSigningRequestStatus{
+	//         Conditions: []certificatesv1.[]CertificateSigningRequestCondition{{
+	//           Type: certificatesv1.CertificateApproved,
+	//           Status: corev1.ConditionTrue,
+	//         }},
+	//       },
+	//     }
+	//     c.SubResourceClient("approval").Update(ctx, csr)
+	//
+	// - Scale update:
+	//     dep := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: "foo", Name: "bar"}}
+	//     scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 2}}
+	//     c.SubResourceClient("scale").Update(ctx, dep, client.WithSubResourceBody(scale))
+	SubResource(subResource string) SubResourceWriter
+}
+
+// StatusWriter is kept for backward compatibility.
+type StatusWriter = SubResourceWriter
+
+// SubResourceWriter knows how to update subresource of a Kubernetes object.
+type SubResourceWriter interface {
+	// Create saves the subResource object in the Kubernetes cluster. obj must be a
+	// struct pointer so that obj can be updated with the content returned by the Server.
+	Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error
 	// Update updates the fields corresponding to the status subresource for the
 	// given obj. obj must be a struct pointer so that obj can be updated
 	// with the content returned by the Server.
-	Update(ctx context.Context, obj Object, opts ...UpdateOption) error
+	Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error
 
 	// Patch patches the given object's subresource. obj must be a struct
 	// pointer so that obj can be updated with the content returned by the
 	// Server.
-	Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error
+	Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error
 }
 
 // Client knows how to perform CRUD operations on Kubernetes objects.
@@ -103,6 +147,7 @@ type Client interface {
 	Reader
 	Writer
 	StatusClient
+	SubResourceClient
 
 	// Scheme returns the scheme this client is using.
 	Scheme() *runtime.Scheme

--- a/pkg/client/metadata_client.go
+++ b/pkg/client/metadata_client.go
@@ -168,7 +168,7 @@ func (mc *metadataClient) List(ctx context.Context, obj ObjectList, opts ...List
 	return nil
 }
 
-func (mc *metadataClient) PatchStatus(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+func (mc *metadataClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
 	metadata, ok := obj.(*metav1.PartialObjectMetadata)
 	if !ok {
 		return fmt.Errorf("metadata client did not understand object: %T", obj)
@@ -180,16 +180,24 @@ func (mc *metadataClient) PatchStatus(ctx context.Context, obj Object, patch Pat
 		return err
 	}
 
-	data, err := patch.Data(obj)
+	patchOpts := &SubResourcePatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	body := obj
+	if patchOpts.SubResourceBody != nil {
+		body = patchOpts.SubResourceBody
+	}
+
+	data, err := patch.Data(body)
 	if err != nil {
 		return err
 	}
 
-	patchOpts := &PatchOptions{}
-	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions(), "status")
+	res, err := resInt.Patch(ctx, metadata.Name, patch.Type(), data, *patchOpts.AsPatchOptions(), subResource)
 	if err != nil {
 		return err
 	}
+
 	*metadata = *res
 	metadata.SetGroupVersionKind(gvk) // restore the GVK, which isn't set on metadata
 	return nil

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -161,23 +161,45 @@ func (n *namespacedClient) List(ctx context.Context, obj ObjectList, opts ...Lis
 }
 
 // Status implements client.StatusClient.
-func (n *namespacedClient) Status() StatusWriter {
-	return &namespacedClientStatusWriter{StatusClient: n.client.Status(), namespace: n.namespace, namespacedclient: n}
+func (n *namespacedClient) Status() SubResourceWriter {
+	return n.SubResource("status")
 }
 
-// ensure namespacedClientStatusWriter implements client.StatusWriter.
-var _ StatusWriter = &namespacedClientStatusWriter{}
+// SubResource implements client.SubResourceClient.
+func (n *namespacedClient) SubResource(subResource string) SubResourceWriter {
+	return &namespacedClientSubResourceWriter{StatusClient: n.client.SubResource(subResource), namespace: n.namespace, namespacedclient: n}
+}
 
-type namespacedClientStatusWriter struct {
-	StatusClient     StatusWriter
+// ensure namespacedClientSubResourceWriter implements client.SubResourceWriter.
+var _ SubResourceWriter = &namespacedClientSubResourceWriter{}
+
+type namespacedClientSubResourceWriter struct {
+	StatusClient     SubResourceWriter
 	namespace        string
 	namespacedclient Client
 }
 
-// Update implements client.StatusWriter.
-func (nsw *namespacedClientStatusWriter) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+func (nsw *namespacedClientSubResourceWriter) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
 	isNamespaceScoped, err := objectutil.IsAPINamespaced(obj, nsw.namespacedclient.Scheme(), nsw.namespacedclient.RESTMapper())
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
 
+	objectNamespace := obj.GetNamespace()
+	if objectNamespace != nsw.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	}
+
+	if isNamespaceScoped && objectNamespace == "" {
+		obj.SetNamespace(nsw.namespace)
+	}
+
+	return nsw.StatusClient.Create(ctx, obj, subResource, opts...)
+}
+
+// Update implements client.SubResourceWriter.
+func (nsw *namespacedClientSubResourceWriter) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+	isNamespaceScoped, err := objectutil.IsAPINamespaced(obj, nsw.namespacedclient.Scheme(), nsw.namespacedclient.RESTMapper())
 	if err != nil {
 		return fmt.Errorf("error finding the scope of the object: %w", err)
 	}
@@ -193,8 +215,8 @@ func (nsw *namespacedClientStatusWriter) Update(ctx context.Context, obj Object,
 	return nsw.StatusClient.Update(ctx, obj, opts...)
 }
 
-// Patch implements client.StatusWriter.
-func (nsw *namespacedClientStatusWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+// Patch implements client.SubResourceWriter.
+func (nsw *namespacedClientSubResourceWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	isNamespaceScoped, err := objectutil.IsAPINamespaced(obj, nsw.namespacedclient.Scheme(), nsw.namespacedclient.RESTMapper())
 
 	if err != nil {

--- a/pkg/client/namespaced_client_test.go
+++ b/pkg/client/namespaced_client_test.go
@@ -480,7 +480,7 @@ var _ = Describe("NamespacedClient", func() {
 		})
 	})
 
-	Describe("StatusWriter", func() {
+	Describe("SubResourceWriter", func() {
 		var err error
 		BeforeEach(func() {
 			dep, err = clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{})
@@ -495,7 +495,7 @@ var _ = Describe("NamespacedClient", func() {
 			changedDep := dep.DeepCopy()
 			changedDep.Status.Replicas = 99
 
-			Expect(getClient().Status().Update(ctx, changedDep)).NotTo(HaveOccurred())
+			Expect(getClient().SubResource("status").Update(ctx, changedDep)).NotTo(HaveOccurred())
 
 			actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -509,14 +509,14 @@ var _ = Describe("NamespacedClient", func() {
 			changedDep.SetNamespace("test")
 			changedDep.Status.Replicas = 99
 
-			Expect(getClient().Status().Update(ctx, changedDep)).To(HaveOccurred())
+			Expect(getClient().SubResource("status").Update(ctx, changedDep)).To(HaveOccurred())
 		})
 
 		It("should change objects via status patch", func() {
 			changedDep := dep.DeepCopy()
 			changedDep.Status.Replicas = 99
 
-			Expect(getClient().Status().Patch(ctx, changedDep, client.MergeFrom(dep))).NotTo(HaveOccurred())
+			Expect(getClient().SubResource("status").Patch(ctx, changedDep, client.MergeFrom(dep))).NotTo(HaveOccurred())
 
 			actual, err := clientset.AppsV1().Deployments(ns).Get(ctx, dep.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
@@ -530,7 +530,7 @@ var _ = Describe("NamespacedClient", func() {
 			changedDep.Status.Replicas = 99
 			changedDep.SetNamespace("test")
 
-			Expect(getClient().Status().Patch(ctx, changedDep, client.MergeFrom(dep))).To(HaveOccurred())
+			Expect(getClient().SubResource("status").Patch(ctx, changedDep, client.MergeFrom(dep))).To(HaveOccurred())
 		})
 	})
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -67,6 +67,24 @@ type DeleteAllOfOption interface {
 	ApplyToDeleteAllOf(*DeleteAllOfOptions)
 }
 
+// SubResourceUpdateOption is some configuration that modifies options for a update request.
+type SubResourceUpdateOption interface {
+	// ApplyToSubResourceUpdate applies this configuration to the given update options.
+	ApplyToSubResourceUpdate(*SubResourceUpdateOptions)
+}
+
+// SubResourceCreateOption is some configuration that modifies options for a create request.
+type SubResourceCreateOption interface {
+	// ApplyToSubResourceCreate applies this configuration to the given create options.
+	ApplyToSubResourceCreate(*SubResourceCreateOptions)
+}
+
+// SubResourcePatchOption configures a subresource patch request.
+type SubResourcePatchOption interface {
+	// ApplyToSubResourcePatch applies the configuration on the given patch options.
+	ApplyToSubResourcePatch(*SubResourcePatchOptions)
+}
+
 // }}}
 
 // {{{ Multi-Type Options
@@ -96,7 +114,20 @@ func (dryRunAll) ApplyToPatch(opts *PatchOptions) {
 func (dryRunAll) ApplyToDelete(opts *DeleteOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
+
 func (dryRunAll) ApplyToDeleteAllOf(opts *DeleteAllOfOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourceCreate(opts *SubResourceCreateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
+func (dryRunAll) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
 

--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -61,8 +61,9 @@ func NewDelegatingClient(in NewDelegatingClientInput) (Client, error) {
 			uncachedGVKs:      uncachedGVKs,
 			cacheUnstructured: in.CacheUnstructured,
 		},
-		Writer:       in.Client,
-		StatusClient: in.Client,
+		Writer:            in.Client,
+		StatusClient:      in.Client,
+		SubResourceClient: in.Client,
 	}, nil
 }
 
@@ -70,6 +71,7 @@ type delegatingClient struct {
 	Reader
 	Writer
 	StatusClient
+	SubResourceClient
 
 	scheme *runtime.Scheme
 	mapper meta.RESTMapper

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -24,7 +24,6 @@ import (
 
 var _ Reader = &typedClient{}
 var _ Writer = &typedClient{}
-var _ StatusWriter = &typedClient{}
 
 // client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
 // new clients at the time they are used, and caches the client.
@@ -168,8 +167,32 @@ func (c *typedClient) List(ctx context.Context, obj ObjectList, opts ...ListOpti
 		Into(obj)
 }
 
-// UpdateStatus used by StatusWriter to write status.
-func (c *typedClient) UpdateStatus(ctx context.Context, obj Object, opts ...UpdateOption) error {
+func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subResourceObj Object, subResource string, opts ...SubResourceCreateOption) error {
+	o, err := c.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	createOpts := &SubResourceCreateOptions{}
+	createOpts.ApplyOptions(opts)
+
+	return o.Post().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		Body(subResourceObj).
+		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
+// UpdateSubResource used by SubResourceWriter to write status.
+func (c *typedClient) UpdateSubResource(ctx context.Context, obj Object, subResource string, opts ...SubResourceUpdateOption) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
@@ -178,42 +201,58 @@ func (c *typedClient) UpdateStatus(ctx context.Context, obj Object, opts ...Upda
 	// wrapped to improve the UX ?
 	// It will be nice to receive an error saying the object doesn't implement
 	// status subresource and check CRD definition
-	updateOpts := &UpdateOptions{}
+	updateOpts := &SubResourceUpdateOptions{}
 	updateOpts.ApplyOptions(opts)
+
+	body := obj
+	if updateOpts.SubResourceBody != nil {
+		body = updateOpts.SubResourceBody
+	}
+	if body.GetName() == "" {
+		body.SetName(obj.GetName())
+	}
+	if body.GetNamespace() == "" {
+		body.SetNamespace(obj.GetNamespace())
+	}
 
 	return o.Put().
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.GetName()).
-		SubResource("status").
-		Body(obj).
+		SubResource(subResource).
+		Body(body).
 		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
 		Do(ctx).
-		Into(obj)
+		Into(body)
 }
 
-// PatchStatus used by StatusWriter to write status.
-func (c *typedClient) PatchStatus(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+// PatchSubResource used by SubResourceWriter to write subresource.
+func (c *typedClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
 
-	data, err := patch.Data(obj)
+	patchOpts := &SubResourcePatchOptions{}
+	patchOpts.ApplyOptions(opts)
+
+	body := obj
+	if patchOpts.SubResourceBody != nil {
+		body = patchOpts.SubResourceBody
+	}
+
+	data, err := patch.Data(body)
 	if err != nil {
 		return err
 	}
-
-	patchOpts := &PatchOptions{}
-	patchOpts.ApplyOptions(opts)
 
 	return o.Patch(patch.Type()).
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.GetName()).
-		SubResource("status").
+		SubResource(subResource).
 		Body(data).
 		VersionedParams(patchOpts.AsPatchOptions(), c.paramCodec).
 		Do(ctx).
-		Into(obj)
+		Into(body)
 }

--- a/pkg/envtest/komega/default.go
+++ b/pkg/envtest/komega/default.go
@@ -74,7 +74,7 @@ func Update(obj client.Object, f func(), opts ...client.UpdateOption) func() err
 //	})).To(gomega.Succeed())
 //
 // By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
-func UpdateStatus(obj client.Object, f func(), opts ...client.UpdateOption) func() error {
+func UpdateStatus(obj client.Object, f func(), opts ...client.SubResourceUpdateOption) func() error {
 	checkDefaultClient()
 	return defaultK.UpdateStatus(obj, f, opts...)
 }

--- a/pkg/envtest/komega/interfaces.go
+++ b/pkg/envtest/komega/interfaces.go
@@ -57,7 +57,7 @@ type Komega interface {
 	//     return &deployment
 	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
-	UpdateStatus(client.Object, func(), ...client.UpdateOption) func() error
+	UpdateStatus(client.Object, func(), ...client.SubResourceUpdateOption) func() error
 
 	// Object returns a function that fetches a resource and returns the object.
 	// It can be used with gomega.Eventually() like this:

--- a/pkg/envtest/komega/komega.go
+++ b/pkg/envtest/komega/komega.go
@@ -81,7 +81,7 @@ func (k *komega) Update(obj client.Object, updateFunc func(), opts ...client.Upd
 }
 
 // UpdateStatus returns a function that fetches a resource, applies the provided update function and then updates the resource's status.
-func (k *komega) UpdateStatus(obj client.Object, updateFunc func(), opts ...client.UpdateOption) func() error {
+func (k *komega) UpdateStatus(obj client.Object, updateFunc func(), opts ...client.SubResourceUpdateOption) func() error {
 	key := types.NamespacedName{
 		Name:      obj.GetName(),
 		Namespace: obj.GetNamespace(),


### PR DESCRIPTION
This change adds a SubResourceWriter to the client package that can be used to Create, Update or Patch arbitrary subresources.

This fixes the majority of  https://github.com/kubernetes-sigs/controller-runtime/issues/172, the only thing missing for it to close would be to add subresource Get, as I think there is no existing usage of subresource Delete.

Relative to https://github.com/kubernetes-sigs/controller-runtime/pull/1922 the main changes are:
* Use distinct options for subresource Update and Patch which makes this a breaking change
* Add subresource Create, needed for example for ServiceAccount tokens

Supersedes and thereby closes https://github.com/kubernetes-sigs/controller-runtime/pull/1922
Supersedes and thereby closes https://github.com/kubernetes-sigs/controller-runtime/pull/2015

/cc @fillzpp @joelanford @sbueringer 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
