### PR TITLE
:warning: fix redundant values in log entries

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -319,7 +318,6 @@ func (blder *Builder) doController(r reconcile.Reconciler) error {
 			log := log
 			if req != nil {
 				log = log.WithValues(
-					gvk.Kind, klog.KRef(req.Namespace, req.Name),
 					"namespace", req.Namespace, "name", req.Name,
 				)
 			}


### PR DESCRIPTION
With the current log configuration we get following reconcile log entries:

```console
level=INFO msg="creating certificate request" controller=certificate controllerGroup=example.com controllerKind=Certificate Certificate="{certificate-sample appl-k8s-e2etests1-e1}" namespace=appl-k8s-e2etests1-e1 name=certificate-sample reconcileID=8e0379c3-ec61-42a7-9bb1-09b19f57bfb6 rev=1
```

As you can see, we have an entry `Certificate="{certificate-sample appl-k8s-e2etests1-e1}"`, but this information is redundant, because we already have:


 `controllerKind=Certificate namespace=appl-k8s-e2etests1-e1 name=certificate-sample`


If you want to search for this entry, it is probably easier and more flexible to filter by `controllerKind`, `namespace` and `name`.


The above commit changes the log entry to:

```console
level=INFO msg="creating certificate request" controller=certificate controllerGroup=example.com controllerKind=Certificate namespace=appl-k8s-e2etests1-e1 name=certificate-sample reconcileID=8e0379c3-ec61-42a7-9bb1-09b19f57bfb6 rev=1
```

 
