### PR TITLE
:seedling: Update golangci-lint to v1.50.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,5 +19,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.49.0
+          version: v1.50.1
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ linters:
   enable:
   - asciicheck
   - bodyclose
-  - deadcode
   - depguard
   - dogsled
   - errcheck
@@ -18,7 +17,6 @@ linters:
   - gosec
   - gosimple
   - govet
-  - ifshort
   - importas
   - ineffassign
   - misspell
@@ -29,19 +27,14 @@ linters:
   - revive
   - rowserrcheck
   - staticcheck
-  - structcheck
   - stylecheck
   - typecheck
   - unconvert
   - unparam
   - unused
-  - varcheck
   - whitespace
 
 linters-settings:
-  ifshort:
-    # Maximum length of variable declaration measured in number of characters, after which linter won't suggest using short syntax.
-    max-decl-chars: 50
   importas:
     no-unaliased: true
     alias:

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -892,7 +892,7 @@ func (*TestCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj r
 	}
 
 	v := newObj.(*TestValidator)
-	old := oldObj.(*TestValidator) //nolint:ifshort
+	old := oldObj.(*TestValidator)
 	if v.Replica < 0 {
 		return errors.New("number of replica should be greater than or equal to 0")
 	}

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -81,7 +81,7 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 	// (unstructured, partial, etc)
 
 	// check for PartialObjectMetadata, which is analogous to unstructured, but isn't handled by ObjectKinds
-	_, isPartial := obj.(*metav1.PartialObjectMetadata) //nolint:ifshort
+	_, isPartial := obj.(*metav1.PartialObjectMetadata)
 	_, isPartialList := obj.(*metav1.PartialObjectMetadataList)
 	if isPartial || isPartialList {
 		// we require that the GVK be populated in order to recognize the object

--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -207,7 +207,7 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f M
 		return OperationResultCreated, nil
 	}
 
-	existing := obj.DeepCopyObject() //nolint
+	existing := obj.DeepCopyObject()
 	if err := mutate(f, key, obj); err != nil {
 		return OperationResultNone, err
 	}


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@prigna.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

All removed linters have been deprecated
