### PR TITLE
:bug: Prevent manager from getting started a second time

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -409,6 +409,8 @@ func (cm *controllerManager) Start(ctx context.Context) (err error) {
 		cm.Unlock()
 		return errors.New("manager already started")
 	}
+	cm.started = true
+
 	var ready bool
 	defer func() {
 		// Only unlock the manager if we haven't reached


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Currently it is possible to start the mgr multiple times, which will cause all sorts of issues. Prevent that from happening.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2083