### PR TITLE
⚠️ Add Get functionality to SubResourceClient

### DIFF
--- a/pkg/client/dryrun.go
+++ b/pkg/client/dryrun.go
@@ -87,29 +87,33 @@ func (c *dryRunClient) Status() SubResourceWriter {
 }
 
 // SubResource implements client.SubResourceClient.
-func (c *dryRunClient) SubResource(subResource string) SubResourceWriter {
-	return &dryRunSubResourceWriter{client: c.client.SubResource(subResource)}
+func (c *dryRunClient) SubResource(subResource string) SubResourceClient {
+	return &dryRunSubResourceClient{client: c.client.SubResource(subResource)}
 }
 
 // ensure dryRunSubResourceWriter implements client.SubResourceWriter.
-var _ SubResourceWriter = &dryRunSubResourceWriter{}
+var _ SubResourceWriter = &dryRunSubResourceClient{}
 
-// dryRunSubResourceWriter is client.SubResourceWriter that writes status subresource with dryRun mode
+// dryRunSubResourceClient is client.SubResourceWriter that writes status subresource with dryRun mode
 // enforced.
-type dryRunSubResourceWriter struct {
-	client SubResourceWriter
+type dryRunSubResourceClient struct {
+	client SubResourceClient
 }
 
-func (sw *dryRunSubResourceWriter) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
+func (sw *dryRunSubResourceClient) Get(ctx context.Context, obj, subResource Object, opts ...SubResourceGetOption) error {
+	return sw.client.Get(ctx, obj, subResource, opts...)
+}
+
+func (sw *dryRunSubResourceClient) Create(ctx context.Context, obj, subResource Object, opts ...SubResourceCreateOption) error {
 	return sw.client.Create(ctx, obj, subResource, append(opts, DryRunAll)...)
 }
 
 // Update implements client.SubResourceWriter.
-func (sw *dryRunSubResourceWriter) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+func (sw *dryRunSubResourceClient) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
 	return sw.client.Update(ctx, obj, append(opts, DryRunAll)...)
 }
 
 // Patch implements client.SubResourceWriter.
-func (sw *dryRunSubResourceWriter) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+func (sw *dryRunSubResourceClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	return sw.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
 }

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -756,8 +756,8 @@ func (c *fakeClient) Status() client.SubResourceWriter {
 	return c.SubResource("status")
 }
 
-func (c *fakeClient) SubResource(subResource string) client.SubResourceWriter {
-	return &fakeSubResourceWriter{client: c}
+func (c *fakeClient) SubResource(subResource string) client.SubResourceClient {
+	return &fakeSubResourceClient{client: c}
 }
 
 func (c *fakeClient) deleteObject(gvr schema.GroupVersionResource, accessor metav1.Object) error {
@@ -786,15 +786,19 @@ func getGVRFromObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupV
 	return gvr, nil
 }
 
-type fakeSubResourceWriter struct {
+type fakeSubResourceClient struct {
 	client *fakeClient
 }
 
-func (sw *fakeSubResourceWriter) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+func (sw *fakeSubResourceClient) Get(ctx context.Context, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
+	panic("fakeSubResourceClient does not support get")
+}
+
+func (sw *fakeSubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
 	panic("fakeSubResourceWriter does not support create")
 }
 
-func (sw *fakeSubResourceWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+func (sw *fakeSubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
 	// TODO(droot): This results in full update of the obj (spec + subresources). Need
 	// a way to update subresource only.
 	updateOptions := client.SubResourceUpdateOptions{}
@@ -807,7 +811,7 @@ func (sw *fakeSubResourceWriter) Update(ctx context.Context, obj client.Object, 
 	return sw.client.Update(ctx, body, &updateOptions.UpdateOptions)
 }
 
-func (sw *fakeSubResourceWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+func (sw *fakeSubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
 	// TODO(droot): This results in full update of the obj (spec + subresources). Need
 	// a way to update subresource only.
 

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -67,6 +67,11 @@ type DeleteAllOfOption interface {
 	ApplyToDeleteAllOf(*DeleteAllOfOptions)
 }
 
+// SubResourceGetOption modifies options for a SubResource Get request.
+type SubResourceGetOption interface {
+	ApplyToSubResourceGet(*SubResourceGetOptions)
+}
+
 // SubResourceUpdateOption is some configuration that modifies options for a update request.
 type SubResourceUpdateOption interface {
 	// ApplyToSubResourceUpdate applies this configuration to the given update options.

--- a/pkg/client/split.go
+++ b/pkg/client/split.go
@@ -61,9 +61,9 @@ func NewDelegatingClient(in NewDelegatingClientInput) (Client, error) {
 			uncachedGVKs:      uncachedGVKs,
 			cacheUnstructured: in.CacheUnstructured,
 		},
-		Writer:            in.Client,
-		StatusClient:      in.Client,
-		SubResourceClient: in.Client,
+		Writer:                       in.Client,
+		StatusClient:                 in.Client,
+		SubResourceClientConstructor: in.Client,
 	}, nil
 }
 
@@ -71,7 +71,7 @@ type delegatingClient struct {
 	Reader
 	Writer
 	StatusClient
-	SubResourceClient
+	SubResourceClientConstructor
 
 	scheme *runtime.Scheme
 	mapper meta.RESTMapper

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -167,6 +167,29 @@ func (c *typedClient) List(ctx context.Context, obj ObjectList, opts ...ListOpti
 		Into(obj)
 }
 
+func (c *typedClient) GetSubResource(ctx context.Context, obj, subResourceObj Object, subResource string, opts ...SubResourceGetOption) error {
+	o, err := c.cache.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+
+	if subResourceObj.GetName() == "" {
+		subResourceObj.SetName(obj.GetName())
+	}
+
+	getOpts := &SubResourceGetOptions{}
+	getOpts.ApplyOptions(opts)
+
+	return o.Get().
+		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.GetName()).
+		SubResource(subResource).
+		VersionedParams(getOpts.AsGetOptions(), c.paramCodec).
+		Do(ctx).
+		Into(subResourceObj)
+}
+
 func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subResourceObj Object, subResource string, opts ...SubResourceCreateOption) error {
 	o, err := c.cache.getObjMeta(obj)
 	if err != nil {


### PR DESCRIPTION
This changes enabled the SubResourceClient to retrieve subresources, thereby completing it for CRUD subresources (under the assumption that there is no such thing as a Delete for subresources, which does hold true for core resources).

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/172

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
