### PR TITLE
⚠ Support shutdown controllers and watches dynamically

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -86,6 +86,10 @@ type Controller interface {
 
 	// GetLogger returns this controller logger prefilled with basic information.
 	GetLogger() logr.Logger
+
+	// Stop stops the controller and all its watches dynamically.
+	// Note that it will only trigger the stop but will not wait for them all stopped.
+	Stop() error
 }
 
 // New returns a new Controller registered with the Manager.  The Manager will ensure that shared Caches have


### PR DESCRIPTION
Signed-off-by: FillZpp <FillZpp.pub@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Support shutdown controllers and watches dynamically.

API changes:
- An optional `ControllerCtx` added into `controller.Options` to let developer stop a specific controller and its watches.
- A `Stop()` method added into some stoppable sources, e.g., `Kind`, `KindWithCache`, `Informer`, to let developer only stop a specific watch.

fixes #1884 