### PR TITLE
🐛 controllers without For() fail to start

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -216,15 +216,17 @@ func (blder *Builder) project(obj client.Object, proj objectProjection) (client.
 
 func (blder *Builder) doWatch() error {
 	// Reconcile type
-	typeForSrc, err := blder.project(blder.forInput.object, blder.forInput.objectProjection)
-	if err != nil {
-		return err
-	}
-	src := &source.Kind{Type: typeForSrc}
-	hdler := &handler.EnqueueRequestForObject{}
-	allPredicates := append(blder.globalPredicates, blder.forInput.predicates...)
-	if err := blder.ctrl.Watch(src, hdler, allPredicates...); err != nil {
-		return err
+	if blder.forInput.object != nil {
+		typeForSrc, err := blder.project(blder.forInput.object, blder.forInput.objectProjection)
+		if err != nil {
+			return err
+		}
+		src := &source.Kind{Type: typeForSrc}
+		hdler := &handler.EnqueueRequestForObject{}
+		allPredicates := append(blder.globalPredicates, blder.forInput.predicates...)
+		if err := blder.ctrl.Watch(src, hdler, allPredicates...); err != nil {
+			return err
+		}
 	}
 
 	// Watches the managed types

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -376,6 +376,23 @@ var _ = Describe("application", func() {
 			defer cancel()
 			doReconcileTest(ctx, "4", m, true, bldr)
 		})
+
+		It("should Reconcile without For", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			bldr := ControllerManagedBy(m).
+				Named("Deployment").
+				Watches( // Equivalent of For
+						&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForObject{}).
+				Watches( // Equivalent of Owns
+					&source.Kind{Type: &appsv1.ReplicaSet{}},
+					&handler.EnqueueRequestForOwner{OwnerType: &appsv1.Deployment{}, IsController: true})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			doReconcileTest(ctx, "9", m, true, bldr)
+		})
 	})
 
 	Describe("Set custom predicates", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Fixes #2101 

When calling `Builder.Complete()` without `For`, `blder.forInput.object` is nil.
If `source.Kind` with nil Type is passed to Watch(), it results in `must specify Kind.Type` error at https://github.com/kubernetes-sigs/controller-runtime/blob/69f093833822d321742c7a729d4339cd8e101507/pkg/source/source.go#L116 