### PR TITLE
🌱 Remove reviewers which are also approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -22,10 +22,7 @@ aliases:
   # include approvers & admins -- those count too via the OWNERS
   # file)
   controller-runtime-reviewers:
-  - vincepri
   - varshaprasad96
-  - fillzpp
-  - sbueringer
 
   # folks to can approve things in the directly-ported
   # testing_frameworks portions of the codebase


### PR DESCRIPTION
Removing me and @fillzpp from reviewers as we're now also approvers based on
```
   # folks who can review and LGTM any PRs in the repo (doesn't
   # include approvers & admins -- those count too via the OWNERS
   # file)
```