### PR TITLE
🌱 client/cache/client_cache.go should be called resources

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -112,7 +112,7 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		}
 	}
 
-	clientcache := &clientCache{
+	resources := &clientRestResources{
 		config: config,
 		scheme: options.Scheme,
 		mapper: options.Mapper,
@@ -129,11 +129,11 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 
 	c := &client{
 		typedClient: typedClient{
-			cache:      clientcache,
+			resources:  resources,
 			paramCodec: runtime.NewParameterCodec(options.Scheme),
 		},
 		unstructuredClient: unstructuredClient{
-			cache:      clientcache,
+			resources:  resources,
 			paramCodec: noConversionParamCodec{},
 		},
 		metadataClient: metadataClient{
@@ -149,8 +149,8 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 
 var _ Client = &client{}
 
-// client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
-// new clients at the time they are used, and caches the client.
+// client is a client.Client that reads and writes directly from/to an API server.
+// It lazily initializes new clients at the time they are used.
 type client struct {
 	typedClient        typedClient
 	unstructuredClient unstructuredClient

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -30,8 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// clientCache creates and caches rest clients and metadata for Kubernetes types.
-type clientCache struct {
+// clientRestResources creates and stores rest clients and metadata for Kubernetes types.
+type clientRestResources struct {
 	// config is the rest.Config to talk to an apiserver
 	config *rest.Config
 
@@ -44,16 +44,16 @@ type clientCache struct {
 	// codecs are used to create a REST client for a gvk
 	codecs serializer.CodecFactory
 
-	// structuredResourceByType caches structured type metadata
+	// structuredResourceByType stores structured type metadata
 	structuredResourceByType map[schema.GroupVersionKind]*resourceMeta
-	// unstructuredResourceByType caches unstructured type metadata
+	// unstructuredResourceByType stores unstructured type metadata
 	unstructuredResourceByType map[schema.GroupVersionKind]*resourceMeta
 	mu                         sync.RWMutex
 }
 
 // newResource maps obj to a Kubernetes Resource and constructs a client for that Resource.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientCache) newResource(gvk schema.GroupVersionKind, isList, isUnstructured bool) (*resourceMeta, error) {
+func (c *clientRestResources) newResource(gvk schema.GroupVersionKind, isList, isUnstructured bool) (*resourceMeta, error) {
 	if strings.HasSuffix(gvk.Kind, "List") && isList {
 		// if this was a list, treat it as a request for the item's resource
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
@@ -72,7 +72,7 @@ func (c *clientCache) newResource(gvk schema.GroupVersionKind, isList, isUnstruc
 
 // getResource returns the resource meta information for the given type of object.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
+func (c *clientRestResources) getResource(obj runtime.Object) (*resourceMeta, error) {
 	gvk, err := apiutil.GVKForObject(obj, c.scheme)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (c *clientCache) getResource(obj runtime.Object) (*resourceMeta, error) {
 }
 
 // getObjMeta returns objMeta containing both type and object metadata and state.
-func (c *clientCache) getObjMeta(obj runtime.Object) (*objMeta, error) {
+func (c *clientRestResources) getObjMeta(obj runtime.Object) (*objMeta, error) {
 	r, err := c.getResource(obj)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ func (c *clientCache) getObjMeta(obj runtime.Object) (*objMeta, error) {
 	return &objMeta{resourceMeta: r, Object: m}, err
 }
 
-// resourceMeta caches state for a Kubernetes type.
+// resourceMeta stores state for a Kubernetes type.
 type resourceMeta struct {
 	// client is the rest client used to talk to the apiserver
 	rest.Interface

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -25,16 +25,14 @@ import (
 var _ Reader = &typedClient{}
 var _ Writer = &typedClient{}
 
-// client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
-// new clients at the time they are used, and caches the client.
 type typedClient struct {
-	cache      *clientCache
+	resources  *clientRestResources
 	paramCodec runtime.ParameterCodec
 }
 
 // Create implements client.Client.
 func (c *typedClient) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -53,7 +51,7 @@ func (c *typedClient) Create(ctx context.Context, obj Object, opts ...CreateOpti
 
 // Update implements client.Client.
 func (c *typedClient) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -73,7 +71,7 @@ func (c *typedClient) Update(ctx context.Context, obj Object, opts ...UpdateOpti
 
 // Delete implements client.Client.
 func (c *typedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -92,7 +90,7 @@ func (c *typedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOpti
 
 // DeleteAllOf implements client.Client.
 func (c *typedClient) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -111,7 +109,7 @@ func (c *typedClient) DeleteAllOf(ctx context.Context, obj Object, opts ...Delet
 
 // Patch implements client.Client.
 func (c *typedClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -136,7 +134,7 @@ func (c *typedClient) Patch(ctx context.Context, obj Object, patch Patch, opts .
 
 // Get implements client.Client.
 func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
-	r, err := c.cache.getResource(obj)
+	r, err := c.resources.getResource(obj)
 	if err != nil {
 		return err
 	}
@@ -151,7 +149,7 @@ func (c *typedClient) Get(ctx context.Context, key ObjectKey, obj Object, opts .
 
 // List implements client.Client.
 func (c *typedClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
-	r, err := c.cache.getResource(obj)
+	r, err := c.resources.getResource(obj)
 	if err != nil {
 		return err
 	}
@@ -168,7 +166,7 @@ func (c *typedClient) List(ctx context.Context, obj ObjectList, opts ...ListOpti
 }
 
 func (c *typedClient) GetSubResource(ctx context.Context, obj, subResourceObj Object, subResource string, opts ...SubResourceGetOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -191,7 +189,7 @@ func (c *typedClient) GetSubResource(ctx context.Context, obj, subResourceObj Ob
 }
 
 func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subResourceObj Object, subResource string, opts ...SubResourceCreateOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -216,7 +214,7 @@ func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subReso
 
 // UpdateSubResource used by SubResourceWriter to write status.
 func (c *typedClient) UpdateSubResource(ctx context.Context, obj Object, subResource string, opts ...SubResourceUpdateOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -251,7 +249,7 @@ func (c *typedClient) UpdateSubResource(ctx context.Context, obj Object, subReso
 
 // PatchSubResource used by SubResourceWriter to write subresource.
 func (c *typedClient) PatchSubResource(ctx context.Context, obj Object, subResource string, patch Patch, opts ...SubResourcePatchOption) error {
-	o, err := c.cache.getObjMeta(obj)
+	o, err := c.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -28,10 +28,8 @@ import (
 var _ Reader = &unstructuredClient{}
 var _ Writer = &unstructuredClient{}
 
-// client is a client.Client that reads and writes directly from/to an API server.  It lazily initializes
-// new clients at the time they are used, and caches the client.
 type unstructuredClient struct {
-	cache      *clientCache
+	resources  *clientRestResources
 	paramCodec runtime.ParameterCodec
 }
 
@@ -44,7 +42,7 @@ func (uc *unstructuredClient) Create(ctx context.Context, obj Object, opts ...Cr
 
 	gvk := u.GroupVersionKind()
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -73,7 +71,7 @@ func (uc *unstructuredClient) Update(ctx context.Context, obj Object, opts ...Up
 
 	gvk := u.GroupVersionKind()
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -100,7 +98,7 @@ func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...De
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -123,7 +121,7 @@ func (uc *unstructuredClient) DeleteAllOf(ctx context.Context, obj Object, opts 
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -146,7 +144,7 @@ func (uc *unstructuredClient) Patch(ctx context.Context, obj Object, patch Patch
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -181,7 +179,7 @@ func (uc *unstructuredClient) Get(ctx context.Context, key ObjectKey, obj Object
 	getOpts := GetOptions{}
 	getOpts.ApplyOptions(opts)
 
-	r, err := uc.cache.getResource(obj)
+	r, err := uc.resources.getResource(obj)
 	if err != nil {
 		return err
 	}
@@ -209,7 +207,7 @@ func (uc *unstructuredClient) List(ctx context.Context, obj ObjectList, opts ...
 	gvk := u.GroupVersionKind()
 	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
-	r, err := uc.cache.getResource(obj)
+	r, err := uc.resources.getResource(obj)
 	if err != nil {
 		return err
 	}
@@ -238,7 +236,7 @@ func (uc *unstructuredClient) GetSubResource(ctx context.Context, obj, subResour
 		subResourceObj.SetName(obj.GetName())
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -269,7 +267,7 @@ func (uc *unstructuredClient) CreateSubResource(ctx context.Context, obj, subRes
 		subResourceObj.SetName(obj.GetName())
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -293,7 +291,7 @@ func (uc *unstructuredClient) UpdateSubResource(ctx context.Context, obj Object,
 		return fmt.Errorf("unstructured client did not understand object: %T", obj)
 	}
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}
@@ -331,7 +329,7 @@ func (uc *unstructuredClient) PatchSubResource(ctx context.Context, obj Object, 
 
 	gvk := u.GroupVersionKind()
 
-	o, err := uc.cache.getObjMeta(obj)
+	o, err := uc.resources.getObjMeta(obj)
 	if err != nil {
 		return err
 	}

--- a/pkg/client/watch.go
+++ b/pkg/client/watch.go
@@ -85,7 +85,7 @@ func (w *watchingClient) unstructuredWatch(ctx context.Context, obj *unstructure
 	gvk := obj.GroupVersionKind()
 	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
-	r, err := w.client.unstructuredClient.cache.getResource(obj)
+	r, err := w.client.unstructuredClient.resources.getResource(obj)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (w *watchingClient) unstructuredWatch(ctx context.Context, obj *unstructure
 }
 
 func (w *watchingClient) typedWatch(ctx context.Context, obj ObjectList, opts ...ListOption) (watch.Interface, error) {
-	r, err := w.client.typedClient.cache.getResource(obj)
+	r, err := w.client.typedClient.resources.getResource(obj)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This file and bits in it were confusing, the client struct doesn't have any sort of built-in cache (as in, watch/list cache from informers). Every request goes to the API server directly instead. The "internal cache" is really just a storage for all rest client resources, this commit changes that to clarify and avoid confusion.

Signed-off-by: Vince Prignano <vince@prigna.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
