### PR TITLE
🐛 initial version of nondestructive hasLabels

### DIFF
--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -237,4 +237,34 @@ var _ = Describe("MatchingLabels", func() {
 		expectedErrMsg := `values[0][k]: Invalid value: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui": must be no more than 63 characters`
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
+	It("Should add to existing selector", func() {
+		matchingLabels := client.MatchingLabels(map[string]string{"label1": "value1"})
+		listOpts := &client.ListOptions{}
+		matchingLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("label1=value1"))
+
+		newMatchingLabels := client.MatchingLabels(map[string]string{"label2": "value2"})
+		newMatchingLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("label1=value1,label2=value2"))
+	})
+})
+
+var _ = Describe("HasLabels", func() {
+	It("Should produce expected serialization", func() {
+		hasLabels := client.HasLabels([]string{"label1", "label2"})
+		listOpts := &client.ListOptions{}
+		hasLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("label1,label2"))
+	})
+	It("Should add to existing selector", func() {
+		hasLabel := client.HasLabels([]string{"label1"})
+		listOpts := &client.ListOptions{}
+		hasLabel.ApplyToList(listOpts)
+		hasOtherLabel := client.HasLabels([]string{"label2"})
+		hasOtherLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("label1,label2"))
+	})
+	It("Should produce an invalid selector when given invalid input", func() {
+		// TODO
+	})
 })


### PR DESCRIPTION
WIP - I still have stuff I want to do on this, but this initial version is non-destructive.
Todo:
- make the unit tests clearly order-consistent or order-independent
- get `HasLabels` to not silently drop invalid requirements
- follow guidance by Alvaro Aleman on making flow clearer

Closes #2098 

Signed-off-by: Jaime Silvela <jaime.silvela@enterprisedb.com>

Fixes the problem that `HasLabels` and `MatchingLabels`, applied as ListOptions, are destructive.
Each will overwrite the LabelSelector with its own arguments, and the last applied wins.
This code attempts to make `HasLabels` and `MatchingLabels` add as an AND, matching intuitive
expectations when applying filters
