### PR TITLE
:sparkles: Add controller option for setting leader election

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -59,9 +59,9 @@ type Options struct {
 	// Defaults to the Controller.RecoverPanic setting from the Manager if unset.
 	RecoverPanic *bool
 
-	// LeaderElected indicates whether the controller needs to use leader election.
+	// NeedLeaderElection indicates whether the controller needs to use leader election.
 	// Defaults to true, which means the controller will use leader election.
-	LeaderElected *bool
+	NeedLeaderElection *bool
 }
 
 // Controller implements a Kubernetes API.  A Controller manages a work queue fed reconcile.Requests
@@ -160,7 +160,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		Name:                    name,
 		LogConstructor:          options.LogConstructor,
 		RecoverPanic:            options.RecoverPanic,
-		LeaderElected:           options.LeaderElected,
+		LeaderElected:           options.NeedLeaderElection,
 	}, nil
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -58,6 +58,10 @@ type Options struct {
 	// RecoverPanic indicates whether the panic caused by reconcile should be recovered.
 	// Defaults to the Controller.RecoverPanic setting from the Manager if unset.
 	RecoverPanic *bool
+
+	// LeaderElected indicates whether the controller needs to use leader election.
+	// Defaults to true, which means the controller will use leader election.
+	LeaderElected *bool
 }
 
 // Controller implements a Kubernetes API.  A Controller manages a work queue fed reconcile.Requests
@@ -156,6 +160,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		Name:                    name,
 		LogConstructor:          options.LogConstructor,
 		RecoverPanic:            options.RecoverPanic,
+		LeaderElected:           options.LeaderElected,
 	}, nil
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -199,8 +199,8 @@ var _ = Describe("controller.Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{
-				Reconciler:    rec,
-				LeaderElected: pointer.Bool(false),
+				Reconciler:         rec,
+				NeedLeaderElection: pointer.Bool(false),
 			})
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -178,6 +178,50 @@ var _ = Describe("controller.Controller", func() {
 			Expect(ctrl.RecoverPanic).NotTo(BeNil())
 			Expect(*ctrl.RecoverPanic).To(BeFalse())
 		})
+
+		It("should default NeedLeaderElection on the controller to true", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: rec,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.NeedLeaderElection()).To(BeTrue())
+		})
+
+		It("should allow for setting leaderElected to false", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler:    rec,
+				LeaderElected: pointer.Bool(false),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.NeedLeaderElection()).To(BeFalse())
+		})
+
+		It("should implement manager.LeaderElectionRunnable", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: rec,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := c.(manager.LeaderElectionRunnable)
+			Expect(ok).To(BeTrue())
+		})
 	})
 })
 

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -93,6 +93,9 @@ type Controller struct {
 
 	// RecoverPanic indicates whether the panic caused by reconcile should be recovered.
 	RecoverPanic *bool
+
+	// LeaderElected indicates whether the controller is leader elected or always running.
+	LeaderElected *bool
 }
 
 // watchDescription contains all the information necessary to start a watch.
@@ -150,6 +153,14 @@ func (c *Controller) Watch(src source.Source, evthdler handler.EventHandler, prc
 
 	c.LogConstructor(nil).Info("Starting EventSource", "source", src)
 	return src.Start(c.ctx, evthdler, c.Queue, prct...)
+}
+
+// NeedLeaderElection implements the manager.LeaderElectionRunnable interface.
+func (c *Controller) NeedLeaderElection() bool {
+	if c.LeaderElected == nil {
+		return true
+	}
+	return *c.LeaderElected
 }
 
 // Start implements controller.Controller.


### PR DESCRIPTION
## Background

Creating a controller that is not leader elected is seems to require a bit of indirection. You currently have to create a new type that embeds the `Controller` interface and adds a `NeedLeaderElection` method as shown below so that it implements the `manager.LeaderElectionRunnable` interface.

```go
type MyReconciler struct {
	client.Client
	Log      logr.Logger
	Scheme   *runtime.Scheme
	Recorder record.EventRecorder
}

func (rec *MyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
	return ctrl.Result{}, nil
}

func (rec *MyReconciler) SetupWithManager(mgr ctrl.Manager) error {
	cont, err := controller.NewUnmanaged("my-controller", mgr, controller.Options{
		Reconciler: rec,
	})
	if err != nil {
		return err
	}
	cont = MyController{cont}
	cont.Watch(&source.Kind{Type: &netv1.Ingress{}}, &handler.EnqueueRequestForObject{}, commonPredicateFilters)
	return mgr.Add(cont)
}

type MyController struct {
	controller.Controller
}

func (c *MyController) NeedLeaderElection() bool {
	return false
}
```

## What

This PR adds a new controller option, `LeaderElected`, that can be used to disable leader election for the controller, without having to create a new type.

## How

It does this by making `controller.Controller` implement the `manager.LeaderElectionRunnable` interface.
