### PR TITLE
⚠ Refactor controllers to require a cluster on watches, remove dep inject

### DIFF
--- a/examples/builtins/main.go
+++ b/examples/builtins/main.go
@@ -59,13 +59,13 @@ func main() {
 	}
 
 	// Watch ReplicaSets and enqueue ReplicaSet object key
-	if err := c.Watch(&source.Kind{Type: &appsv1.ReplicaSet{}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(mgr, &source.Kind{Type: &appsv1.ReplicaSet{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		entryLog.Error(err, "unable to watch ReplicaSets")
 		os.Exit(1)
 	}
 
 	// Watch Pods and enqueue owning ReplicaSet key
-	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}},
+	if err := c.Watch(mgr, &source.Kind{Type: &corev1.Pod{}},
 		&handler.EnqueueRequestForOwner{OwnerType: &appsv1.ReplicaSet{}, IsController: true}); err != nil {
 		entryLog.Error(err, "unable to watch Pods")
 		os.Exit(1)

--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -224,7 +224,7 @@ func (blder *Builder) doWatch() error {
 		src := &source.Kind{Type: typeForSrc}
 		hdler := &handler.EnqueueRequestForObject{}
 		allPredicates := append(blder.globalPredicates, blder.forInput.predicates...)
-		if err := blder.ctrl.Watch(src, hdler, allPredicates...); err != nil {
+		if err := blder.ctrl.Watch(blder.mgr, src, hdler, allPredicates...); err != nil {
 			return err
 		}
 	}
@@ -245,7 +245,7 @@ func (blder *Builder) doWatch() error {
 		}
 		allPredicates := append([]predicate.Predicate(nil), blder.globalPredicates...)
 		allPredicates = append(allPredicates, own.predicates...)
-		if err := blder.ctrl.Watch(src, hdler, allPredicates...); err != nil {
+		if err := blder.ctrl.Watch(blder.mgr, src, hdler, allPredicates...); err != nil {
 			return err
 		}
 	}
@@ -267,7 +267,7 @@ func (blder *Builder) doWatch() error {
 			srckind.Type = typeForSrc
 		}
 
-		if err := blder.ctrl.Watch(w.src, w.eventhandler, allPredicates...); err != nil {
+		if err := blder.ctrl.Watch(blder.mgr, w.src, w.eventhandler, allPredicates...); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog/v2"
 
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/internal/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -74,7 +75,7 @@ type Controller interface {
 	// Watch may be provided one or more Predicates to filter events before
 	// they are given to the EventHandler.  Events will be passed to the
 	// EventHandler if all provided Predicates evaluate to true.
-	Watch(src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
+	Watch(cluster cluster.Cluster, src source.Source, eventhandler handler.EventHandler, predicates ...predicate.Predicate) error
 
 	// Start starts the controller.  Start blocks until the context is closed or a
 	// controller has an error starting.
@@ -152,7 +153,6 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 		},
 		MaxConcurrentReconciles: options.MaxConcurrentReconciles,
 		CacheSyncTimeout:        options.CacheSyncTimeout,
-		SetFields:               mgr.SetFields,
 		Name:                    name,
 		LogConstructor:          options.LogConstructor,
 		RecoverPanic:            options.RecoverPanic,

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -64,12 +64,12 @@ var _ = Describe("controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Watching Resources")
-			err = instance.Watch(&source.Kind{Type: &appsv1.ReplicaSet{}}, &handler.EnqueueRequestForOwner{
+			err = instance.Watch(cm, &source.Kind{Type: &appsv1.ReplicaSet{}}, &handler.EnqueueRequestForOwner{
 				OwnerType: &appsv1.Deployment{},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = instance.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForObject{})
+			err = instance.Watch(cm, &source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForObject{})
 			Expect(err).NotTo(HaveOccurred())
 
 			err = cm.GetClient().Get(ctx, types.NamespacedName{Name: "foo"}, &corev1.Namespace{})

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -111,7 +111,7 @@ var _ = Describe("controller.Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{Reconciler: rec})
-			Expect(c.Watch(watch, &handler.EnqueueRequestForObject{})).To(Succeed())
+			Expect(c.Watch(m, watch, &handler.EnqueueRequestForObject{})).To(Succeed())
 			Expect(err).NotTo(HaveOccurred())
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/controller/example_test.go
+++ b/pkg/controller/example_test.go
@@ -71,7 +71,7 @@ func ExampleController() {
 	}
 
 	// Watch for Pod create / update / delete events and call Reconcile
-	err = c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(mgr, &source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "unable to watch pods")
 		os.Exit(1)
@@ -108,7 +108,7 @@ func ExampleController_unstructured() {
 		Version: "v1",
 	})
 	// Watch for Pod create / update / delete events and call Reconcile
-	err = c.Watch(&source.Kind{Type: u}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(mgr, &source.Kind{Type: u}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		log.Error(err, "unable to watch pods")
 		os.Exit(1)
@@ -139,7 +139,7 @@ func ExampleNewUnmanaged() {
 		os.Exit(1)
 	}
 
-	if err := c.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{}); err != nil {
+	if err := c.Watch(mgr, &source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{}); err != nil {
 		log.Error(err, "unable to watch pods")
 		os.Exit(1)
 	}

--- a/pkg/handler/example_test.go
+++ b/pkg/handler/example_test.go
@@ -25,17 +25,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var c controller.Controller
+var (
+	mgr manager.Manager
+	c   controller.Controller
+)
 
 // This example watches Pods and enqueues Requests with the Name and Namespace of the Pod from
 // the Event (i.e. change caused by a Create, Update, Delete).
 func ExampleEnqueueRequestForObject() {
 	// controller is a controller.controller
 	err := c.Watch(
+		mgr,
 		&source.Kind{Type: &corev1.Pod{}},
 		&handler.EnqueueRequestForObject{},
 	)
@@ -49,6 +54,7 @@ func ExampleEnqueueRequestForObject() {
 func ExampleEnqueueRequestForOwner() {
 	// controller is a controller.controller
 	err := c.Watch(
+		mgr,
 		&source.Kind{Type: &appsv1.ReplicaSet{}},
 		&handler.EnqueueRequestForOwner{
 			OwnerType:    &appsv1.Deployment{},
@@ -65,6 +71,7 @@ func ExampleEnqueueRequestForOwner() {
 func ExampleEnqueueRequestsFromMapFunc() {
 	// controller is a controller.controller
 	err := c.Watch(
+		mgr,
 		&source.Kind{Type: &appsv1.Deployment{}},
 		handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 			return []reconcile.Request{
@@ -88,6 +95,7 @@ func ExampleEnqueueRequestsFromMapFunc() {
 func ExampleFuncs() {
 	// controller is a controller.controller
 	err := c.Watch(
+		mgr,
 		&source.Kind{Type: &corev1.Pod{}},
 		handler.Funcs{
 			CreateFunc: func(e event.CreateEvent, q workqueue.RateLimitingInterface) {

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -56,7 +56,7 @@ var _ = Describe("recorder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Watching Resources")
-			err = instance.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForObject{})
+			err = instance.Watch(cm, &source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequestForObject{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Starting the Manager")

--- a/pkg/source/example_test.go
+++ b/pkg/source/example_test.go
@@ -21,15 +21,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+var mgr manager.Manager
 var ctrl controller.Controller
 
 // This example Watches for Pod Events (e.g. Create / Update / Delete) and enqueues a reconcile.Request
 // with the Name and Namespace of the Pod.
 func ExampleKind() {
-	err := ctrl.Watch(&source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{})
+	err := ctrl.Watch(mgr, &source.Kind{Type: &corev1.Pod{}}, &handler.EnqueueRequestForObject{})
 	if err != nil {
 		// handle it
 	}
@@ -41,6 +43,7 @@ func ExampleChannel() {
 	events := make(chan event.GenericEvent)
 
 	err := ctrl.Watch(
+		mgr,
 		&source.Channel{Source: events},
 		&handler.EnqueueRequestForObject{},
 	)


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vince@prigna.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Marking this as ⚠ given that a public interface is now changed and it removes a public field in the Controller struct.

Previously, a Controller exposed a SetFields field, which was used to perform dependency injection on sources. A controller is always associated with a Manager when created, which then calls `SetFields()` on it. This PR removes a layer of indirection which allows using SetFields directly, and instead it gets the required dependencies from the Cluster object.

Further cleanup is needed although that's going to be slated future PRs.

By passing in a Cluster as the Watch parameter, in the future we should be able to add watches for different clusters based on the given source and handlers.