### PR TITLE
⚠️ make *http.Client configurable and use/ share the same http.Client in the default configuration

### DIFF
--- a/pkg/cache/informer_cache_test.go
+++ b/pkg/cache/informer_cache_test.go
@@ -31,7 +31,9 @@ var _ = Describe("informerCache", func() {
 	It("should not require LeaderElection", func() {
 		cfg := &rest.Config{}
 
-		mapper, err := apiutil.NewDynamicRESTMapper(cfg, apiutil.WithLazyDiscovery)
+		httpClient, err := rest.HTTPClientFor(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		mapper, err := apiutil.NewDynamicRESTMapper(cfg, httpClient, apiutil.WithLazyDiscovery)
 		Expect(err).ToNot(HaveOccurred())
 
 		c, err := cache.New(cfg, cache.Options{Mapper: mapper})

--- a/pkg/client/apiutil/dynamicrestmapper.go
+++ b/pkg/client/apiutil/dynamicrestmapper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiutil
 
 import (
+	"net/http"
 	"sync"
 	"sync/atomic"
 
@@ -75,8 +76,12 @@ func WithCustomMapper(newMapper func() (meta.RESTMapper, error)) DynamicRESTMapp
 // NewDynamicRESTMapper returns a dynamic RESTMapper for cfg. The dynamic
 // RESTMapper dynamically discovers resource types at runtime. opts
 // configure the RESTMapper.
-func NewDynamicRESTMapper(cfg *rest.Config, opts ...DynamicRESTMapperOption) (meta.RESTMapper, error) {
-	client, err := discovery.NewDiscoveryClientForConfig(cfg)
+func NewDynamicRESTMapper(cfg *rest.Config, httpClient *http.Client, opts ...DynamicRESTMapperOption) (meta.RESTMapper, error) {
+	if httpClient == nil {
+		panic("httpClient must not be nil")
+	}
+
+	client, err := discovery.NewDiscoveryClientForConfigAndClient(cfg, httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"net/http"
 	"strings"
 	"sync"
 
@@ -32,6 +33,9 @@ import (
 
 // clientRestResources creates and stores rest clients and metadata for Kubernetes types.
 type clientRestResources struct {
+	// httpClient is the http client to use for requests
+	httpClient *http.Client
+
 	// config is the rest.Config to talk to an apiserver
 	config *rest.Config
 
@@ -59,7 +63,7 @@ func (c *clientRestResources) newResource(gvk schema.GroupVersionKind, isList, i
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
 
-	client, err := apiutil.RESTClientForGVK(gvk, isUnstructured, c.config, c.codecs)
+	client, err := apiutil.RESTClientForGVK(gvk, isUnstructured, c.config, c.codecs, c.httpClient)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -45,7 +46,7 @@ var _ = Describe("cluster.Cluster", func() {
 		It("should return an error if it can't create a RestMapper", func() {
 			expected := fmt.Errorf("expected error: RestMapper")
 			c, err := New(cfg, func(o *Options) {
-				o.MapperProvider = func(c *rest.Config) (meta.RESTMapper, error) { return nil, expected }
+				o.MapperProvider = func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) { return nil, expected }
 			})
 			Expect(c).To(BeNil())
 			Expect(err).To(Equal(expected))
@@ -87,7 +88,7 @@ var _ = Describe("cluster.Cluster", func() {
 
 		It("should return an error it can't create a recorder.Provider", func() {
 			c, err := New(cfg, func(o *Options) {
-				o.newRecorderProvider = func(_ *rest.Config, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
+				o.newRecorderProvider = func(_ *rest.Config, _ *http.Client, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
 					return nil, fmt.Errorf("expected error")
 				}
 			})

--- a/pkg/cluster/internal.go
+++ b/pkg/cluster/internal.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -34,9 +35,10 @@ type cluster struct {
 	// config is the rest.config used to talk to the apiserver.  Required.
 	config *rest.Config
 
-	scheme *runtime.Scheme
-	cache  cache.Cache
-	client client.Client
+	httpClient *http.Client
+	scheme     *runtime.Scheme
+	cache      cache.Cache
+	client     client.Client
 
 	// apiReader is the reader that will make requests to the api server and not the cache.
 	apiReader client.Reader
@@ -59,6 +61,10 @@ type cluster struct {
 
 func (c *cluster) GetConfig() *rest.Config {
 	return c.config
+}
+
+func (c *cluster) GetHTTPClient() *http.Client {
+	return c.httpClient
 }
 
 func (c *cluster) GetClient() client.Client {

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -51,8 +52,9 @@ var _ = Describe("Eventhandler", func() {
 		}
 		Expect(cfg).NotTo(BeNil())
 
-		var err error
-		mapper, err = apiutil.NewDiscoveryRESTMapper(cfg)
+		httpClient, err := rest.HTTPClientFor(cfg)
+		Expect(err).ShouldNot(HaveOccurred())
+		mapper, err = apiutil.NewDiscoveryRESTMapper(cfg, httpClient)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 

--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -19,6 +19,7 @@ package recorder
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 
 	"github.com/go-logr/logr"
@@ -110,8 +111,12 @@ func (p *Provider) getBroadcaster() record.EventBroadcaster {
 }
 
 // NewProvider create a new Provider instance.
-func NewProvider(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, makeBroadcaster EventBroadcasterProducer) (*Provider, error) {
-	corev1Client, err := corev1client.NewForConfig(config)
+func NewProvider(config *rest.Config, httpClient *http.Client, scheme *runtime.Scheme, logger logr.Logger, makeBroadcaster EventBroadcasterProducer) (*Provider, error) {
+	if httpClient == nil {
+		panic("httpClient must not be nil")
+	}
+
+	corev1Client, err := corev1client.NewForConfigAndClient(config, httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to init client: %w", err)
 	}

--- a/pkg/internal/recorder/recorder_suite_test.go
+++ b/pkg/internal/recorder/recorder_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package recorder_test
 
 import (
+	"net/http"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -35,6 +36,7 @@ func TestRecorder(t *testing.T) {
 
 var testenv *envtest.Environment
 var cfg *rest.Config
+var httpClient *http.Client
 var clientset *kubernetes.Clientset
 
 var _ = BeforeSuite(func() {
@@ -45,6 +47,9 @@ var _ = BeforeSuite(func() {
 	var err error
 	cfg, err = testenv.Start()
 	Expect(err).NotTo(HaveOccurred())
+
+	httpClient, err = rest.HTTPClientFor(cfg)
+	Expect(err).ToNot(HaveOccurred())
 
 	clientset, err = kubernetes.NewForConfig(cfg)
 	Expect(err).NotTo(HaveOccurred())

--- a/pkg/internal/recorder/recorder_test.go
+++ b/pkg/internal/recorder/recorder_test.go
@@ -29,7 +29,7 @@ var _ = Describe("recorder.Provider", func() {
 	makeBroadcaster := func() (record.EventBroadcaster, bool) { return record.NewBroadcaster(), true }
 	Describe("NewProvider", func() {
 		It("should return a provider instance and a nil error.", func() {
-			provider, err := recorder.NewProvider(cfg, scheme.Scheme, logr.Discard(), makeBroadcaster)
+			provider, err := recorder.NewProvider(cfg, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster)
 			Expect(provider).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -38,14 +38,14 @@ var _ = Describe("recorder.Provider", func() {
 			// Invalid the config
 			cfg1 := *cfg
 			cfg1.Host = "invalid host"
-			_, err := recorder.NewProvider(&cfg1, scheme.Scheme, logr.Discard(), makeBroadcaster)
+			_, err := recorder.NewProvider(&cfg1, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster)
 			Expect(err).NotTo(BeNil())
 			Expect(err.Error()).To(ContainSubstring("failed to init client"))
 		})
 	})
 	Describe("GetEventRecorder", func() {
 		It("should return a recorder instance.", func() {
-			provider, err := recorder.NewProvider(cfg, scheme.Scheme, logr.Discard(), makeBroadcaster)
+			provider, err := recorder.NewProvider(cfg, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster)
 			Expect(err).NotTo(HaveOccurred())
 
 			recorder := provider.GetEventRecorderFor("test")

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -249,6 +249,10 @@ func (cm *controllerManager) AddReadyzCheck(name string, check healthz.Checker) 
 	return nil
 }
 
+func (cm *controllerManager) GetHTTPClient() *http.Client {
+	return cm.cluster.GetHTTPClient()
+}
+
 func (cm *controllerManager) GetConfig() *rest.Config {
 	return cm.cluster.GetConfig()
 }

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -64,7 +64,7 @@ var _ = Describe("manger.Manager", func() {
 		It("should return an error if it can't create a RestMapper", func() {
 			expected := fmt.Errorf("expected error: RestMapper")
 			m, err := New(cfg, Options{
-				MapperProvider: func(c *rest.Config) (meta.RESTMapper, error) { return nil, expected },
+				MapperProvider: func(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) { return nil, expected },
 			})
 			Expect(m).To(BeNil())
 			Expect(err).To(Equal(expected))
@@ -106,7 +106,7 @@ var _ = Describe("manger.Manager", func() {
 
 		It("should return an error it can't create a recorder.Provider", func() {
 			m, err := New(cfg, Options{
-				newRecorderProvider: func(_ *rest.Config, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
+				newRecorderProvider: func(_ *rest.Config, _ *http.Client, _ *runtime.Scheme, _ logr.Logger, _ intrec.EventBroadcasterProducer) (*intrec.Provider, error) {
 					return nil, fmt.Errorf("expected error")
 				},
 			})


### PR DESCRIPTION
client-go has all these fancy `NewForConfigAndClient` constructor functions.
Let's expose this functionality to the controller-runtime user too & reduce the number of different http.Clients that we use.

In https://github.com/kubernetes/kubernetes/pull/105490, the decision for making http.Client configurable is explained: "when using a custom transport, this has the consequence that each group/version had an independent TCP connection to the API server"
By re-using the same http client for all the clients, we can share customized transports, resulting in no additional TCP connections (see https://github.com/kubernetes/kubernetes/blob/5681b0da14f11165fc53ad82a3400fd027979fc4/test/integration/apiserver/apiserver_test.go#L2517-L2574 for an example)