### PR TITLE
:seedling:fix default value for cfg.Burst

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -98,12 +98,12 @@ func GetConfigWithContext(context string) (*rest.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	if cfg.QPS == 0.0 {
 		cfg.QPS = 20.0
-		cfg.Burst = 30.0
 	}
-
+	if cfg.Burst == 0 {
+		cfg.Burst = 30
+	}
 	return cfg, nil
 }
 


### PR DESCRIPTION
Signed-off-by: yanggang <gang.yang@daocloud.io>


<!-- What does this do, and why do we need it? -->
fix config default value.
when the cfg.Burst!=0 , can not change it value.