### PR TITLE
🌱 Return the error from rest.HTTPClientFor instead of hiding it

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -427,7 +427,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 		opts.HTTPClient, err = rest.HTTPClientFor(config)
 		if err != nil {
 			logger.Error(err, "Failed to get HTTP client")
-			return opts, fmt.Errorf("could not create HTTP client from config")
+			return opts, fmt.Errorf("could not create HTTP client from config: %w", err)
 		}
 	}
 
@@ -442,7 +442,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 		opts.Mapper, err = apiutil.NewDiscoveryRESTMapper(config, opts.HTTPClient)
 		if err != nil {
 			logger.Error(err, "Failed to get API Group-Resources")
-			return opts, fmt.Errorf("could not create RESTMapper from config")
+			return opts, fmt.Errorf("could not create RESTMapper from config: %w", err)
 		}
 	}
 


### PR DESCRIPTION
Follow-up PR for https://github.com/kubernetes-sigs/controller-runtime/pull/2122 (see https://github.com/kubernetes-sigs/controller-runtime/pull/2122#discussion_r1092334261)