### PR TITLE
:running: Use HTTPClient to create the API Reader

### DIFF
--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -202,7 +202,7 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 	}
 
 	// Create the API Reader, a client with no cache.
-	apiReader, err := client.New(config, client.Options{Scheme: options.Scheme, Mapper: mapper})
+	apiReader, err := client.New(config, client.Options{HTTPClient: options.HTTPClient, Scheme: options.Scheme, Mapper: mapper})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
In #2122, I forgot to pass the HTTPClient to the API Reader (https://github.com/kubernetes-sigs/controller-runtime/pull/2122#discussion_r1092734760). Thanks @alvaroaleman for pointing this out.
