### PR TITLE
🌱 [0.14] Deprecate component configuration package

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	cfg "sigs.k8s.io/controller-runtime/pkg/config"
+	cfg "sigs.k8s.io/controller-runtime/pkg/config" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -99,7 +99,8 @@ var (
 	// ConfigFile returns the cfg.File function for deferred config file loading,
 	// this is passed into Options{}.From() to populate the Options fields for
 	// the manager.
-	ConfigFile = cfg.File
+	// Deprecated: This is deprecated in favor of using Options directly.
+	ConfigFile = cfg.File //nolint:staticcheck
 
 	// NewControllerManagedBy returns a new controller builder that will be started by the provided Manager.
 	NewControllerManagedBy = builder.ControllerManagedBy

--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -285,7 +285,7 @@ func (blder *Builder) getControllerName(gvk schema.GroupVersionKind, hasGVK bool
 }
 
 func (blder *Builder) doController(r reconcile.Reconciler) error {
-	globalOpts := blder.mgr.GetControllerOptions()
+	globalOpts := blder.mgr.GetControllerOptions() //nolint:staticcheck
 
 	ctrlOptions := blder.ctrlOptions
 	if ctrlOptions.Reconciler == nil {

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -36,7 +36,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -235,7 +235,7 @@ var _ = Describe("application", func() {
 
 			By("creating a controller manager")
 			m, err := manager.New(cfg, manager.Options{
-				Controller: v1alpha1.ControllerConfigurationSpec{
+				Controller: v1alpha1.ControllerConfigurationSpec{ //nolint:staticcheck
 					GroupKindConcurrency: map[string]int{
 						"ReplicaSet.apps": maxConcurrentReconciles,
 					},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,20 +24,24 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 )
 
 // ControllerManagerConfiguration defines the functions necessary to parse a config file
 // and to configure the Options struct for the ctrl.Manager.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfiguration interface {
 	runtime.Object
 
 	// Complete returns the versioned configuration
-	Complete() (v1alpha1.ControllerManagerConfigurationSpec, error)
+	Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) //nolint:staticcheck
 }
 
 // DeferredFileLoader is used to configure the decoder for loading controller
 // runtime component config types.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 type DeferredFileLoader struct {
 	ControllerManagerConfiguration
 	path   string
@@ -52,6 +56,8 @@ type DeferredFileLoader struct {
 // Defaults:
 // * Path: "./config.yaml"
 // * Kind: GenericControllerManagerConfiguration
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func File() *DeferredFileLoader {
 	scheme := runtime.NewScheme()
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
@@ -63,6 +69,8 @@ func File() *DeferredFileLoader {
 }
 
 // Complete will use sync.Once to set the scheme.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) {
 	d.once.Do(d.loadFile)
 	if d.err != nil {
@@ -71,25 +79,33 @@ func (d *DeferredFileLoader) Complete() (v1alpha1.ControllerManagerConfiguration
 	return d.ControllerManagerConfiguration.Complete()
 }
 
-// AtPath will set the path to load the file for the decoder.
+// AtPath will set the path to load the file for the decoder
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) AtPath(path string) *DeferredFileLoader {
 	d.path = path
 	return d
 }
 
 // OfKind will set the type to be used for decoding the file into.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) OfKind(obj ControllerManagerConfiguration) *DeferredFileLoader {
 	d.ControllerManagerConfiguration = obj
 	return d
 }
 
 // InjectScheme will configure the scheme to be used for decoding the file.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) InjectScheme(scheme *runtime.Scheme) error {
 	d.scheme = scheme
 	return nil
 }
 
 // loadFile is used from the mutex.Once to load the file.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (d *DeferredFileLoader) loadFile() {
 	if d.scheme == nil {
 		d.err = fmt.Errorf("scheme not supplied to controller configuration loader")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -19,8 +19,8 @@ package config_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"sigs.k8s.io/controller-runtime/pkg/config"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config"          //nolint:staticcheck
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 )
 
 var _ = Describe("config", func() {
@@ -33,7 +33,7 @@ var _ = Describe("config", func() {
 		})
 
 		It("should load a config from file", func() {
-			conf := v1alpha1.ControllerManagerConfiguration{}
+			conf := v1alpha1.ControllerManagerConfiguration{} //nolint:staticcheck
 			loader := config.File().AtPath("./testdata/config.yaml").OfKind(&conf)
 			Expect(conf.CacheNamespace).To(Equal(""))
 

--- a/pkg/config/doc.go
+++ b/pkg/config/doc.go
@@ -22,4 +22,6 @@ limitations under the License.
 // This uses a deferred file decoding allowing you to chain your configuration
 // setup. You can pass this into manager.Options#File and it will load your
 // config.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 package config

--- a/pkg/config/example_test.go
+++ b/pkg/config/example_test.go
@@ -21,9 +21,8 @@ import (
 	"os"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/config"
-
 	"sigs.k8s.io/controller-runtime/examples/configfile/custom/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config" //nolint:staticcheck
 )
 
 var scheme = runtime.NewScheme()

--- a/pkg/config/v1alpha1/doc.go
+++ b/pkg/config/v1alpha1/doc.go
@@ -17,4 +17,6 @@ limitations under the License.
 // Package v1alpha1 provides the ControllerManagerConfiguration used for
 // configuring ctrl.Manager
 // +kubebuilder:object:generate=true
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 package v1alpha1

--- a/pkg/config/v1alpha1/register.go
+++ b/pkg/config/v1alpha1/register.go
@@ -23,12 +23,18 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects.
+	//
+	// Deprecated: This package has been deprecated and will be removed in a future release.
 	GroupVersion = schema.GroupVersion{Group: "controller-runtime.sigs.k8s.io", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme.
+	//
+	// Deprecated: This package has been deprecated and will be removed in a future release.
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 
 	// AddToScheme adds the types in this group-version to the given scheme.
+	//
+	// Deprecated: This package has been deprecated and will be removed in a future release.
 	AddToScheme = SchemeBuilder.AddToScheme
 )
 

--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -25,6 +25,8 @@ import (
 )
 
 // ControllerManagerConfigurationSpec defines the desired state of GenericControllerManagerConfiguration.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfigurationSpec struct {
 	// SyncPeriod determines the minimum frequency at which watched resources are
 	// reconciled. A lower period will correct entropy more quickly, but reduce
@@ -75,6 +77,8 @@ type ControllerManagerConfigurationSpec struct {
 
 // ControllerConfigurationSpec defines the global configuration for
 // controllers registered with the manager.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerConfigurationSpec struct {
 	// GroupKindConcurrency is a map from a Kind to the number of concurrent reconciliation
 	// allowed for that controller.
@@ -149,14 +153,20 @@ type ControllerWebhook struct {
 // +kubebuilder:object:root=true
 
 // ControllerManagerConfiguration is the Schema for the GenericControllerManagerConfigurations API.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 type ControllerManagerConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 
 	// ControllerManagerConfiguration returns the contfigurations for controllers
+	//
+	// Deprecated: This package has been deprecated and will be removed in a future release.
 	ControllerManagerConfigurationSpec `json:",inline"`
 }
 
 // Complete returns the configuration for controller-runtime.
+//
+// Deprecated: This package has been deprecated and will be removed in a future release.
 func (c *ControllerManagerConfigurationSpec) Complete() (ControllerManagerConfigurationSpec, error) {
 	return *c, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -141,7 +141,7 @@ func NewUnmanaged(name string, mgr manager.Manager, options Options) (Controller
 	}
 
 	if options.RecoverPanic == nil {
-		options.RecoverPanic = mgr.GetControllerOptions().RecoverPanic
+		options.RecoverPanic = mgr.GetControllerOptions().RecoverPanic //nolint:staticcheck
 	}
 
 	// Create controller with dependencies set

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/utils/pointer"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -147,7 +147,7 @@ var _ = Describe("controller.Controller", func() {
 		})
 
 		It("should default RecoverPanic from the manager", func() {
-			m, err := manager.New(cfg, manager.Options{Controller: v1alpha1.ControllerConfigurationSpec{RecoverPanic: pointer.Bool(true)}})
+			m, err := manager.New(cfg, manager.Options{Controller: v1alpha1.ControllerConfigurationSpec{RecoverPanic: pointer.Bool(true)}}) //nolint:staticcheck
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{
@@ -163,7 +163,7 @@ var _ = Describe("controller.Controller", func() {
 		})
 
 		It("should not override RecoverPanic on the controller", func() {
-			m, err := manager.New(cfg, manager.Options{Controller: v1alpha1.ControllerConfigurationSpec{RecoverPanic: pointer.Bool(true)}})
+			m, err := manager.New(cfg, manager.Options{Controller: v1alpha1.ControllerConfigurationSpec{RecoverPanic: pointer.Bool(true)}}) //nolint:staticcheck
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{

--- a/pkg/manager/example_test.go
+++ b/pkg/manager/example_test.go
@@ -22,7 +22,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
-	conf "sigs.k8s.io/controller-runtime/pkg/config"
+	conf "sigs.k8s.io/controller-runtime/pkg/config" //nolint:staticcheck
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -92,7 +92,7 @@ func ExampleManager_start() {
 // using defaults.
 func ExampleOptions_andFrom() {
 	opts := manager.Options{}
-	if _, err := opts.AndFrom(conf.File()); err != nil {
+	if _, err := opts.AndFrom(conf.File()); err != nil { //nolint:staticcheck
 		log.Error(err, "unable to load config")
 		os.Exit(1)
 	}
@@ -120,7 +120,7 @@ func ExampleOptions_andFromOrDie() {
 		os.Exit(1)
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{}.AndFromOrDie(conf.File()))
+	mgr, err := manager.New(cfg, manager.Options{}.AndFromOrDie(conf.File())) //nolint:staticcheck
 	if err != nil {
 		log.Error(err, "unable to set up manager")
 		os.Exit(1)

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/internal/httpserver"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
@@ -108,7 +108,7 @@ type controllerManager struct {
 	healthzHandler *healthz.Handler
 
 	// controllerOptions are the global controller options.
-	controllerOptions v1alpha1.ControllerConfigurationSpec
+	controllerOptions v1alpha1.ControllerConfigurationSpec //nolint:staticcheck
 
 	// Logger is the logger that should be used by this manager.
 	// If none is set, it defaults to log.Log global logger.
@@ -325,7 +325,7 @@ func (cm *controllerManager) GetLogger() logr.Logger {
 	return cm.logger
 }
 
-func (cm *controllerManager) GetControllerOptions() v1alpha1.ControllerConfigurationSpec {
+func (cm *controllerManager) GetControllerOptions() v1alpha1.ControllerConfigurationSpec { //nolint:staticcheck
 	return cm.controllerOptions
 }
 

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -36,8 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/config"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config"          //nolint:staticcheck
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
@@ -94,7 +94,11 @@ type Manager interface {
 	GetLogger() logr.Logger
 
 	// GetControllerOptions returns controller global configuration options.
-	GetControllerOptions() v1alpha1.ControllerConfigurationSpec
+	//
+	// Deprecated: In a future version, the returned value is going to be replaced with a
+	// different type that doesn't rely on component configuration types.
+	// This is a temporary warning, and no action is needed as of today.
+	GetControllerOptions() v1alpha1.ControllerConfigurationSpec //nolint:staticcheck
 }
 
 // Options are the arguments for creating a new Manager.
@@ -297,7 +301,11 @@ type Options struct {
 	// Controller contains global configuration options for controllers
 	// registered within this manager.
 	// +optional
-	Controller v1alpha1.ControllerConfigurationSpec
+	//
+	// Deprecated: In a future version, the type of this field is going to be replaced with a
+	// different struct that doesn't rely on component configuration types.
+	// This is a temporary warning, and no action is needed as of today.
+	Controller v1alpha1.ControllerConfigurationSpec //nolint:staticcheck
 
 	// makeBroadcaster allows deferring the creation of the broadcaster to
 	// avoid leaking goroutines if we never call Start on this manager.  It also
@@ -456,6 +464,8 @@ func New(config *rest.Config, options Options) (Manager, error) {
 // AndFrom will use a supplied type and convert to Options
 // any options already set on Options will be ignored, this is used to allow
 // cli flags to override anything specified in the config file.
+//
+// Deprecated: This method will be removed in a future release.
 func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options, error) {
 	if inj, wantsScheme := loader.(inject.Scheme); wantsScheme {
 		err := inj.InjectScheme(o.Scheme)
@@ -521,6 +531,8 @@ func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options,
 }
 
 // AndFromOrDie will use options.AndFrom() and will panic if there are errors.
+//
+// Deprecated: This method will be removed in a future release.
 func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Options {
 	o, err := o.AndFrom(loader)
 	if err != nil {
@@ -529,7 +541,7 @@ func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Opti
 	return o
 }
 
-func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options {
+func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options { //nolint:staticcheck
 	if obj.LeaderElection == nil {
 		// The source does not have any configuration; noop
 		return o

--- a/pkg/manager/manager_options_test.go
+++ b/pkg/manager/manager_options_test.go
@@ -4,11 +4,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"sigs.k8s.io/controller-runtime/pkg/config"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	configv1alpha1 "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config"                         //nolint:staticcheck
+	configv1alpha1 "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 )
 
 var _ = Describe("manager.Options", func() {
@@ -25,7 +24,7 @@ var _ = Describe("manager.Options", func() {
 				o = Options{Scheme: s}
 				c = customConfig{}
 
-				_, err = o.AndFrom(config.File().AtPath("./testdata/custom-config.yaml").OfKind(&c))
+				_, err = o.AndFrom(config.File().AtPath("./testdata/custom-config.yaml").OfKind(&c)) //nolint:staticcheck
 			})
 
 			It("should not panic or fail", func() {

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -47,7 +47,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
-	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1" //nolint:staticcheck
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
 	fakeleaderelection "sigs.k8s.io/controller-runtime/pkg/leaderelection/fake"
@@ -127,8 +127,8 @@ var _ = Describe("manger.Manager", func() {
 			port := int(6090)
 			leaderElect := false
 
-			ccfg := &v1alpha1.ControllerManagerConfiguration{
-				ControllerManagerConfigurationSpec: v1alpha1.ControllerManagerConfigurationSpec{
+			ccfg := &v1alpha1.ControllerManagerConfiguration{ //nolint:staticcheck
+				ControllerManagerConfigurationSpec: v1alpha1.ControllerManagerConfigurationSpec{ //nolint:staticcheck
 					SyncPeriod: &duration,
 					LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
 						LeaderElect:       &leaderElect,
@@ -183,8 +183,8 @@ var _ = Describe("manger.Manager", func() {
 			port := int(6090)
 			leaderElect := false
 
-			ccfg := &v1alpha1.ControllerManagerConfiguration{
-				ControllerManagerConfigurationSpec: v1alpha1.ControllerManagerConfigurationSpec{
+			ccfg := &v1alpha1.ControllerManagerConfiguration{ //nolint:staticcheck
+				ControllerManagerConfigurationSpec: v1alpha1.ControllerManagerConfigurationSpec{ //nolint:staticcheck
 					SyncPeriod: &duration,
 					LeaderElection: &configv1alpha1.LeaderElectionConfiguration{
 						LeaderElect:       &leaderElect,
@@ -1819,7 +1819,7 @@ type fakeDeferredLoader struct {
 	*v1alpha1.ControllerManagerConfiguration
 }
 
-func (f *fakeDeferredLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) {
+func (f *fakeDeferredLoader) Complete() (v1alpha1.ControllerManagerConfigurationSpec, error) { //nolint:staticcheck
 	return f.ControllerManagerConfiguration.ControllerManagerConfigurationSpec, nil
 }
 


### PR DESCRIPTION
This provides an early warning for users on 0.14 that the pkg/config types are going to be removed in a future release and they should migrate off.

Signed-off-by: Vince Prignano <vincepri@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @sbueringer 
