### PR TITLE
🐛 Allow to set GracefulShutdownTimeout to -1, disabling timeouts

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -509,7 +509,12 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 	//
 	// The shutdown context immediately expires if the gracefulShutdownTimeout is not set.
 	var shutdownCancel context.CancelFunc
-	cm.shutdownCtx, shutdownCancel = context.WithTimeout(context.Background(), cm.gracefulShutdownTimeout)
+	if cm.gracefulShutdownTimeout < 0 {
+		// We want to wait forever for the runnables to stop.
+		cm.shutdownCtx, shutdownCancel = context.WithCancel(context.Background())
+	} else {
+		cm.shutdownCtx, shutdownCancel = context.WithTimeout(context.Background(), cm.gracefulShutdownTimeout)
+	}
 	defer shutdownCancel()
 
 	// Start draining the errors before acquiring the lock to make sure we don't deadlock

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -936,6 +936,50 @@ var _ = Describe("manger.Manager", func() {
 				<-runnableStopped
 			})
 
+			It("should wait forever for runnables if gracefulShutdownTimeout is <0 (-1)", func() {
+				m, err := New(cfg, options)
+				Expect(err).NotTo(HaveOccurred())
+				for _, cb := range callbacks {
+					cb(m)
+				}
+				m.(*controllerManager).gracefulShutdownTimeout = time.Duration(-1)
+
+				Expect(m.Add(RunnableFunc(func(ctx context.Context) error {
+					<-ctx.Done()
+					time.Sleep(100 * time.Millisecond)
+					return nil
+				}))).ToNot(HaveOccurred())
+				Expect(m.Add(RunnableFunc(func(ctx context.Context) error {
+					<-ctx.Done()
+					time.Sleep(200 * time.Millisecond)
+					return nil
+				}))).ToNot(HaveOccurred())
+				Expect(m.Add(RunnableFunc(func(ctx context.Context) error {
+					<-ctx.Done()
+					time.Sleep(500 * time.Millisecond)
+					return nil
+				}))).ToNot(HaveOccurred())
+				Expect(m.Add(RunnableFunc(func(ctx context.Context) error {
+					<-ctx.Done()
+					time.Sleep(1500 * time.Millisecond)
+					return nil
+				}))).ToNot(HaveOccurred())
+
+				ctx, cancel := context.WithCancel(context.Background())
+				managerStopDone := make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					Expect(m.Start(ctx)).NotTo(HaveOccurred())
+					close(managerStopDone)
+				}()
+				<-m.Elected()
+				cancel()
+
+				beforeDone := time.Now()
+				<-managerStopDone
+				Expect(time.Since(beforeDone)).To(BeNumerically(">=", 1500*time.Millisecond))
+			})
+
 		}
 
 		Context("with defaults", func() {


### PR DESCRIPTION
Signed-off-by: Vince Prignano <vincepri@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This is already specified in the documentation https://github.com/kubernetes-sigs/controller-runtime/blob/v0.14.1/pkg/manager/manager.go#L293 

Fixes #2110 
