### PR TITLE
✨ Add have jsonpath matcher to komega

### DIFF
--- a/pkg/envtest/komega/havejsonpath.go
+++ b/pkg/envtest/komega/havejsonpath.go
@@ -17,7 +17,7 @@ type haveJSONPathMatcher struct {
 }
 
 // HaveJSONPath returns the matcher for a given JSON path and subsequent matcher
-func HaveJSONPath(jsonpath string, matcher types.GomegaMatcher) *haveJSONPathMatcher {
+func HaveJSONPath(jsonpath string, matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &haveJSONPathMatcher{
 		jsonpath: jsonpath,
 		matcher:  matcher,
@@ -29,7 +29,7 @@ func HaveJSONPath(jsonpath string, matcher types.GomegaMatcher) *haveJSONPathMat
 func (m *haveJSONPathMatcher) Match(actual interface{}) (success bool, err error) {
 	j := jsonpath.New("")
 	if err := j.Parse(m.jsonpath); err != nil {
-		return false, fmt.Errorf("JSON Path '%s' is invalid: %w", m.jsonpath, err.Error())
+		return false, fmt.Errorf("JSON Path '%s' is invalid: %w", m.jsonpath, err)
 	}
 
 	if o, ok := actual.(client.Object); ok {
@@ -47,7 +47,7 @@ func (m *haveJSONPathMatcher) Match(actual interface{}) (success bool, err error
 
 	results, err := j.FindResults(obj)
 	if err != nil {
-		return false, fmt.Errorf("JSON Path '%s' failed: %w", m.jsonpath, err.Error())
+		return false, fmt.Errorf("JSON Path '%s' failed: %w", m.jsonpath, err)
 	}
 
 	values := []interface{}{}

--- a/pkg/envtest/komega/havejsonpath.go
+++ b/pkg/envtest/komega/havejsonpath.go
@@ -1,0 +1,72 @@
+package komega
+
+import (
+	"fmt"
+
+	"github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/util/jsonpath"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type HaveJSONPathMatcher struct {
+	jsonpath string
+	matcher  types.GomegaMatcher
+	name     string
+	value    interface{}
+}
+
+func HaveJSONPath(jsonpath string, matcher types.GomegaMatcher) *HaveJSONPathMatcher {
+	return &HaveJSONPathMatcher{
+		jsonpath: jsonpath,
+		matcher:  matcher,
+	}
+}
+
+func (m *HaveJSONPathMatcher) Match(actual interface{}) (success bool, err error) {
+	j := jsonpath.New("")
+	if err := j.Parse(m.jsonpath); err != nil {
+		return false, fmt.Errorf("JSON Path '%s' is invalid: %s", m.jsonpath, err.Error())
+	}
+
+	if o, ok := actual.(client.Object); ok {
+		m.name = fmt.Sprintf("%T %s/%s", actual, o.GetNamespace(), o.GetName())
+	} else {
+		m.name = fmt.Sprintf("%T", actual)
+	}
+
+	var obj interface{}
+	if u, ok := actual.(*unstructured.Unstructured); ok {
+		obj = u.UnstructuredContent()
+	} else {
+		obj = actual
+	}
+
+	results, err := j.FindResults(obj)
+	if err != nil {
+		return false, fmt.Errorf("JSON Path '%s' failed: %s", m.jsonpath, err.Error())
+	}
+
+	values := []interface{}{}
+	for i := range results {
+		for j := range results[i] {
+			values = append(values, results[i][j].Interface())
+		}
+	}
+	m.value = values
+
+	// flatten values if single result
+	if len(values) == 1 {
+		m.value = values[0]
+	}
+
+	return m.matcher.Match(m.value)
+}
+
+func (m *HaveJSONPathMatcher) FailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("%s at %s: %s", m.name, m.jsonpath, m.matcher.FailureMessage(m.value))
+}
+
+func (m *HaveJSONPathMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return fmt.Sprintf("%s at %s: %s", m.name, m.jsonpath, m.matcher.NegatedFailureMessage(m.value))
+}

--- a/pkg/envtest/komega/havejsonpath_test.go
+++ b/pkg/envtest/komega/havejsonpath_test.go
@@ -1,0 +1,110 @@
+package komega
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("HaveJSONPathMatcher", func() {
+	DescribeTable("Matching on a JSON path",
+		func(obj interface{}, matcher types.GomegaMatcher, expectedErr types.GomegaMatcher, want types.GomegaMatcher) {
+			success, err := matcher.Match(obj)
+			Expect(err).Should(expectedErr)
+			Expect(success).Should(want)
+		},
+		Entry("should error when passed an invalid jsonpath",
+			&corev1.Pod{},
+			HaveJSONPath("{^}", BeTrue()),
+			MatchError(fmt.Errorf("JSON Path '{^}' is invalid: unrecognized character in action: U+005E '^'")),
+			BeFalse(),
+		),
+		Entry("should error when passed a jsonpath to an invalid location",
+			&corev1.Pod{},
+			HaveJSONPath("{.foo}", BeTrue()),
+			MatchError(fmt.Errorf("JSON Path '{.foo}' failed: foo is not found")),
+			BeFalse(),
+		),
+		Entry("should succeed when passed a jsonpath to a valid location and correct matcher",
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			HaveJSONPath("{.metadata.name}", Equal("foo")),
+			Succeed(),
+			BeTrue(),
+		),
+		Entry("should fail when passed a jsonpath to a valid location and incorrect matcher",
+			&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			HaveJSONPath("{.metadata.name}", Equal("bar")),
+			Succeed(),
+			BeFalse(),
+		),
+		Entry("should succeed when passed a jsonpath to a valid location and unstructured",
+			func() *unstructured.Unstructured {
+				u := &unstructured.Unstructured{}
+				u.SetName("foo")
+				return u
+			}(),
+			HaveJSONPath("{.metadata.name}", Equal("foo")),
+			Succeed(),
+			BeTrue(),
+		),
+		Entry("should succeed when passed a jsonpath to a struct and correct matcher",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "my-pod",
+					Namespace: "namespace",
+					Labels: map[string]string{
+						"hello": "pod",
+					},
+				},
+			},
+			HaveJSONPath("{.metadata}", MatchFields(IgnoreExtras, Fields{
+				"Name":      Equal("my-pod"),
+				"Namespace": Equal("namespace"),
+				"Labels":    HaveKeyWithValue("hello", "pod"),
+			})),
+			Succeed(),
+			BeTrue(),
+		),
+		Entry("should succeed when passed a jsonpath to a condition and correct matcher",
+			&corev1.Pod{
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			HaveJSONPath(`{.status.conditions[?(@.type=="Ready")]}`, MatchFields(IgnoreExtras, Fields{
+				"Status": BeEquivalentTo(corev1.ConditionTrue),
+			})),
+			Succeed(),
+			BeTrue(),
+		),
+		Entry("should succeed when passed a jsonpath to an array and correct matcher",
+			&corev1.PodList{
+				Items: []corev1.Pod{
+					{},
+					{},
+					{},
+				},
+			},
+			HaveJSONPath("{.items[*].metadata.name}", HaveLen(3)),
+			Succeed(),
+			BeTrue(),
+		),
+	)
+})
+
+func TestHaveJSONPathMatcher(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conditions")
+}

--- a/pkg/envtest/komega/havejsonpath_test.go
+++ b/pkg/envtest/komega/havejsonpath_test.go
@@ -1,7 +1,6 @@
 package komega
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,13 +22,13 @@ var _ = Describe("HaveJSONPathMatcher", func() {
 		Entry("should error when passed an invalid jsonpath",
 			&corev1.Pod{},
 			HaveJSONPath("{^}", BeTrue()),
-			MatchError(fmt.Errorf("JSON Path '{^}' is invalid: unrecognized character in action: U+005E '^'")),
+			MatchError("JSON Path '{^}' is invalid: unrecognized character in action: U+005E '^'"),
 			BeFalse(),
 		),
 		Entry("should error when passed a jsonpath to an invalid location",
 			&corev1.Pod{},
 			HaveJSONPath("{.foo}", BeTrue()),
-			MatchError(fmt.Errorf("JSON Path '{.foo}' failed: foo is not found")),
+			MatchError("JSON Path '{.foo}' failed: foo is not found"),
 			BeFalse(),
 		),
 		Entry("should succeed when passed a jsonpath to a valid location and correct matcher",


### PR DESCRIPTION
This PR adds a new matcher to Komega.

It's intended to be used in conjunction with the `Object` and `ObjectList` helper functions, transforming the actual based on the jsonpath provided. It works similarly to the `HaveField` matcher however has all the familiar benefits of using a [JSON path](https://kubernetes.io/docs/reference/kubectl/jsonpath/). E.g. `{.status.conditions[?(@.type=="Ready")]}`.

When the JSON path resolves to a single result the result slice is flattened to a single value for convenience. E.g. `HaveJSONPath("{.metadata.name}", Equal("foo"))`.

This is my first time contributing so apologies if I'm missing anything or not following any processes correctly :) 