### PR TITLE
:bug: fix: set DeleteStateUnknown when obj is DeletedFinalStateUnknown

### DIFF
--- a/pkg/internal/source/event_handler.go
+++ b/pkg/internal/source/event_handler.go
@@ -133,6 +133,9 @@ func (e *EventHandler) OnDelete(obj interface{}) {
 			return
 		}
 
+		// Set DeleteStateUnknown to true
+		d.DeleteStateUnknown = true
+
 		// Set obj to the tombstone obj
 		obj = tombstone.Obj
 	}

--- a/pkg/internal/source/internal_test.go
+++ b/pkg/internal/source/internal_test.go
@@ -269,6 +269,7 @@ var _ = Describe("Internal", func() {
 			funcs.DeleteFunc = func(ctx context.Context, evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
 				defer GinkgoRecover()
 				Expect(evt.Object).To(Equal(pod))
+				Expect(evt.DeleteStateUnknown).Should(BeTrue())
 			}
 
 			instance.OnDelete(tombstone)


### PR DESCRIPTION
As the document says, DeleteStateUnknown should be true if the object was deleted but delete event was missed.

https://github.com/kubernetes-sigs/controller-runtime/blob/b6fc422accf925890b9bd8832f99ecd0eba40c6c/pkg/event/event.go#L44-L46
