### PR TITLE
🐛 Add cross-version compatibility with client-go 1.27

### DIFF
--- a/pkg/internal/source/event_handler.go
+++ b/pkg/internal/source/event_handler.go
@@ -32,8 +32,6 @@ import (
 
 var log = logf.RuntimeLog.WithName("source").WithName("EventHandler")
 
-var _ cache.ResourceEventHandler = &EventHandler{}
-
 // NewEventHandler creates a new EventHandler.
 func NewEventHandler(ctx context.Context, queue workqueue.RateLimitingInterface, handler handler.EventHandler, predicates []predicate.Predicate) *EventHandler {
 	return &EventHandler{
@@ -53,6 +51,16 @@ type EventHandler struct {
 	handler    handler.EventHandler
 	queue      workqueue.RateLimitingInterface
 	predicates []predicate.Predicate
+}
+
+// HandlerFuncs converts EventHandler to a ResourceEventHandlerFuncs
+// TODO: switch to ResourceEventHandlerDetailedFuncs with client-go 1.27
+func (e *EventHandler) HandlerFuncs() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		AddFunc:    e.OnAdd,
+		UpdateFunc: e.OnUpdate,
+		DeleteFunc: e.OnDelete,
+	}
 }
 
 // OnAdd creates CreateEvent and calls Create on EventHandler.

--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -79,7 +79,7 @@ func (ks *Kind) Start(ctx context.Context, handler handler.EventHandler, queue w
 			return
 		}
 
-		_, err := i.AddEventHandler(NewEventHandler(ctx, queue, handler, prct))
+		_, err := i.AddEventHandler(NewEventHandler(ctx, queue, handler, prct).HandlerFuncs())
 		if err != nil {
 			ks.started <- err
 			return

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -204,7 +204,7 @@ func (is *Informer) Start(ctx context.Context, handler handler.EventHandler, que
 		return fmt.Errorf("must specify Informer.Informer")
 	}
 
-	_, err := is.Informer.AddEventHandler(internal.NewEventHandler(ctx, queue, handler, prct))
+	_, err := is.Informer.AddEventHandler(internal.NewEventHandler(ctx, queue, handler, prct).HandlerFuncs())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2222

I have manually verified this compiles with client-go 1.26 and 1.27, but I am not sure how to get test coverage of this; likely we will not be able to.