### PR TITLE
📖 Build out & fix mirroring example to be more descriptive

### DIFF
--- a/designs/move-cluster-specific-code-out-of-manager.md
+++ b/designs/move-cluster-specific-code-out-of-manager.md
@@ -180,16 +180,16 @@ type secretMirrorReconciler struct {
 	referenceClusterClient, mirrorClusterClient client.Client
 }
 
-func (r *secretMirrorReconciler) Reconcile(context context.Context, req reconcile.Request)(reconcile.Result, error){
+func (r *secretMirrorReconciler) Reconcile(ctx context.Context, req reconcile.Request)(reconcile.Result, error){
 	s := &corev1.Secret{}
-	if err := r.referenceClusterClient.Get(context.TODO(), req.NamespacedName, s); err != nil {
+	if err := r.referenceClusterClient.Get(ctx, req.NamespacedName, s); err != nil {
 		if kerrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}
 		return reconcile.Result{}, err
 	}
 
-	if err := r.mirrorClusterClient.Get(context.TODO(), req.NamespacedName, &corev1.Secret); err != nil {
+	if err := r.mirrorClusterClient.Get(ctx, req.NamespacedName, &corev1.Secret); err != nil {
 		if !kerrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
@@ -198,7 +198,7 @@ func (r *secretMirrorReconciler) Reconcile(context context.Context, req reconcil
 			ObjectMeta: metav1.ObjectMeta{Namespace: s.Namespace, Name: s.Name},
 			Data: s.Data,
 		}
-		return reconcile.Result{}, r.mirrorClusterClient.Create(context.TODO(), mirrorSecret)
+		return reconcile.Result{}, r.mirrorClusterClient.Create(ctx, mirrorSecret)
 	}
 
 	return reconcile.Result{}, nil

--- a/designs/move-cluster-specific-code-out-of-manager.md
+++ b/designs/move-cluster-specific-code-out-of-manager.md
@@ -193,13 +193,15 @@ func (r *secretMirrorReconciler) Reconcile(context context.Context, req reconcil
 		if !kerrors.IsNotFound(err) {
 			return reconcile.Result{}, err
 		}
+
+		mirrorSecret := &corev1.Secret {
+			ObjectMeta: metav1.ObjectMeta{Namespace: s.Namespace, Name: s.Name},
+			Data: s.Data,
+		}
+		return reconcile.Result{}, r.mirrorClusterClient.Create(context.TODO(), mirrorSecret)
 	}
 
-	mirrorSecret := &corev1.Secret {
-		ObjectMeta: metav1.ObjectMeta{Namespace: s.Namespace, Name: s.Name},
-		Data: s.Data,
-	}
-	return reconcile.Result{}, r.mirrorClusterClient.Create(context.TODO(), mirrorSecret)
+	return reconcile.Result{}, nil
 }
 
 func NewSecretMirrorReconciler(mgr manager.Manager, mirrorCluster cluster.Cluster) error {


### PR DESCRIPTION
Hi,

I went and tried to implement the mirroring example. As I am fairly new to the controller-runtime, it took me a while to understand the example. Going through it, there were a few things I was stumbling about:

- `secretMirrorReconciler` and`reconcile.Request` both named `r`
- context missing from `Reconcile` method's parameters
- Position of `secret` creation. It was inside an error block.
- Imports - took a while to find the right imports. Especially `kerrors`, as there are other go packages named this way.
- Additional `}` in `NewSecretMirrorReconciler`

