### PR TITLE
🌱 Don't call defaultOpts for MultiNamespaceCache twice

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -194,16 +194,18 @@ type ByObject struct {
 
 // New initializes and returns a new Cache.
 func New(config *rest.Config, opts Options) (Cache, error) {
-	opts, err := defaultOpts(config, opts)
-	if err != nil {
-		return nil, err
-	}
 	if len(opts.Namespaces) == 0 {
 		opts.Namespaces = []string{metav1.NamespaceAll}
 	}
 	if len(opts.Namespaces) > 1 {
 		return newMultiNamespaceCache(config, opts)
 	}
+
+	opts, err := defaultOpts(config, opts)
+	if err != nil {
+		return nil, err
+	}
+
 	byGVK, err := convertToInformerOptsByGVK(opts.ByObject, opts.Scheme)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Now we call defaultOpts for MultiNamespaceCache twice: 
1. [Before](https://github.com/kubernetes-sigs/controller-runtime/blob/c304e7ec2ee7879f53ce69c12a7aa133853fccdb/pkg/cache/cache.go#L197) entering newMultiNamespaceCache
2. And right [after](https://github.com/kubernetes-sigs/controller-runtime/blob/c304e7ec2ee7879f53ce69c12a7aa133853fccdb/pkg/cache/multi_namespace_cache.go#L59)

This PR prevents this and ensures that defaultOpts is called only once inside newMultiNamespaceCache function.


