### PR TITLE
:bug: Avoid creating a new scheme object when combining the options

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -288,6 +288,12 @@ func (options Options) inheritFrom(inherited Options) (*Options, error) {
 }
 
 func combineScheme(inherited *runtime.Scheme, new *runtime.Scheme) *runtime.Scheme {
+	if inherited == nil {
+		return new
+	}
+	if new == nil {
+		return inherited
+	}
 	for gvk, t := range new.AllKnownTypes() {
 		inherited.AddKnownTypeWithName(gvk, reflect.New(t).Interface().(runtime.Object))
 	}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -287,20 +287,11 @@ func (options Options) inheritFrom(inherited Options) (*Options, error) {
 	return &combined, nil
 }
 
-func combineScheme(schemes ...*runtime.Scheme) *runtime.Scheme {
-	var out *runtime.Scheme
-	for _, sch := range schemes {
-		if sch == nil {
-			continue
-		}
-		for gvk, t := range sch.AllKnownTypes() {
-			if out == nil {
-				out = runtime.NewScheme()
-			}
-			out.AddKnownTypeWithName(gvk, reflect.New(t).Interface().(runtime.Object))
-		}
+func combineScheme(inherited *runtime.Scheme, new *runtime.Scheme) *runtime.Scheme {
+	for gvk, t := range new.AllKnownTypes() {
+		inherited.AddKnownTypeWithName(gvk, reflect.New(t).Interface().(runtime.Object))
 	}
-	return out
+	return inherited
 }
 
 func selectMapper(def, override meta.RESTMapper) meta.RESTMapper {


### PR DESCRIPTION
<!-- please add a :bug: (`:bug:`) to the title of this PR, and delete this line and similar ones -->

<!-- What does this do, and why do we need it? -->

This keeps the inherited scheme object created by the cluster when combining the options instead of creating a new one.
That scheme object can be used later on to register schemes. 

The inherited scheme was already configured in the cluster object, by creating a new scheme object 
for the cache object when combining the schemes will not allow the schemes registered afterwards into the
cluster scheme object to be visible into the cache, and it will result in an error when the controller is started (see below).

<!-- What issue does this fix (e.g. Fixes #XYZ) -->

Configure the controller as follows:

```
	ctrlOpts := ctrl.Options{
		NewCache: cache.BuilderWithOptions(cache.Options{
			SelectorsByObject: cache.SelectorsByObject{
				&corev1.Pod{}: {
					Label: labels.SelectorFromSet(labels.Set{
						bindata.EnableRecordingLabel: "true",
					}),
				},
			},
		}),
	}

	mgr, err := ctrl.NewManager(cfg, ctrlOpts)
	if err != nil {
		return fmt.Errorf("create manager: %w", err)
	}

        if err := spodv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
		return fmt.Errorf("add SPOD config API to scheme: %w", err)
	}

        if err := mgr.Start(sigHandler); err != nil {
		return fmt.Errorf("SPOd error: %w", err)
	}
```

This fix will allow the controller to start properly instead of getting this error that the scheme is not registered:

```
E0314 10:44:24.541365 1302480 source.go:146] controller-runtime/source "msg"="kind must be registered to the Scheme" 
"error"="no kind is registered for the type v1alpha1.SecurityProfilesOperatorDaemon in scheme \"pkg/runtime/scheme.go:100"  
```

You can see more details in https://github.com/kubernetes-sigs/security-profiles-operator/pull/1543 where we encountered this issue.
