### PR TITLE
✨ Make setup-envtest store dir deletable for owner

### DIFF
--- a/tools/setup-envtest/store/store.go
+++ b/tools/setup-envtest/store/store.go
@@ -187,11 +187,6 @@ func (s *Store) Add(ctx context.Context, item Item, contents io.Reader) (resErr 
 	}
 	log.V(1).Info("unpacked archive")
 
-	log.V(1).Info("switching version-platform directory to read-only")
-	if err := itemPath.Chmod("", 0555); err != nil {
-		// don't bail, this isn't fatal
-		log.Error(err, "unable to make version-platform directory read-only")
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

The current implementation of `setup-envtest` stores binary in a read-only directory, which (unsurprisingly) makes it hard to delete:

```sh
$ setup-envtest use --bin-dir ./tmp
$ rm -rf ./tmp
rm: ./tmp/k8s/1.26.1-darwin-arm64/etcd: Permission denied
rm: ./tmp/k8s/1.26.1-darwin-arm64/kube-apiserver: Permission denied
rm: ./tmp/k8s/1.26.1-darwin-arm64/kubectl: Permission denied
rm: ./tmp/k8s/1.26.1-darwin-arm64: Permission denied
rm: ./tmp/k8s: Permission denied
rm: ./tmp: Permission denied
```

In my case, I use `setup-envtest` in a GitHub Workflow to download binaries to `.bin/` on a self-hosted runner, along with [`actions/checkout`](https://github.com/actions/checkout). And the action fails to clean up the directory in consecutive runs (so I had to do `sudo rm -rf .bin` in a separate step).

This PR removes setting up explicit permissions to `0555` to the store directory, and permissions are kept `0755` as set before in the following line https://github.com/kubernetes-sigs/controller-runtime/blob/c3c1f058a9a080581e8fe99c004fcc792b2aff07/tools/setup-envtest/store/store.go#L148

