### PR TITLE
🐛 Preserve unstructured object GVKs in cache.Options.ByObject

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -481,6 +481,7 @@ func convertToByObject(in map[schema.GroupVersionKind]internal.InformersOptsByGV
 		if !ok {
 			return nil, fmt.Errorf("object %T for GVK %q does not implement client.Object", obj, gvk)
 		}
+		cObj.GetObjectKind().SetGroupVersionKind(gvk)
 		out[cObj] = ByObject{
 			Field:                 opts.Selector.Field,
 			Label:                 opts.Selector.Label,

--- a/pkg/cache/cache_unit_test.go
+++ b/pkg/cache/cache_unit_test.go
@@ -126,6 +126,23 @@ var _ = Describe("cache.inheritFrom", func() {
 			Expect(checkError(specified.inheritFrom(inherited)).Namespaces).To(Equal(specified.Namespaces))
 		})
 	})
+	Context("ByObject", func() {
+		It("maintains GVKs of unstructured ByObject keys", func() {
+			gvk := gv.WithKind("Unstructured")
+			obj := &unstructured.Unstructured{}
+			obj.SetGroupVersionKind(gvk)
+			specified.Scheme = coreScheme
+			specified.Scheme.AddKnownTypeWithName(gvk, obj)
+			specified.ByObject = map[client.Object]ByObject{
+				obj: {},
+			}
+			byObject := checkError(specified.inheritFrom(inherited)).ByObject
+			Expect(byObject).To(HaveLen(1))
+			for obj := range byObject {
+				Expect(obj.GetObjectKind().GroupVersionKind()).To(Equal(gvk))
+			}
+		})
+	})
 	Context("SelectorsByObject", func() {
 		It("is unchanged when specified and inherited are unset", func() {
 			Expect(checkError(specified.inheritFrom(inherited)).ByObject).To(HaveLen(0))


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

This patch enables unstructured objects that have populated GVKs to be used as keys when configuring `ByObject` cache options.

Prior to this patch, a cache setup like the following causes `manager.New` to return an error with "unstructured object has no kind":
```go
obj := &unstructured.Unstructured{}
obj.SetGroupVersionKind(schema.GroupVersionKind{"example.com", "v1", "MyKind"})
_, err := manager.New(cfg, manager.Options{
	NewCache: cache.BuilderWithOptions(cache.Options {
		ByObject: map[client.Object]cache.ByObject{
			obj: cache.ByObject{}
		},
	})
})
```

<!-- What does this do, and why do we need it? -->
