### PR TITLE
Preserve unstructured object GVKs when using *ByObject cache options

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -452,6 +452,7 @@ func convertToByObject[T any](byGVK map[schema.GroupVersionKind]T, scheme *runti
 		if !ok {
 			return nil, def, fmt.Errorf("object %T for GVK %q does not implement client.Object", obj, gvk)
 		}
+		cObj.GetObjectKind().SetGroupVersionKind(gvk)
 		if byObject == nil {
 			byObject = map[client.Object]T{}
 		}

--- a/pkg/cache/cache_unit_test.go
+++ b/pkg/cache/cache_unit_test.go
@@ -468,6 +468,27 @@ var _ = Describe("cache.inheritFrom", func() {
 			))
 		})
 	})
+
+	Context("convertToByObject", func() {
+		It("embeds the GVK in the returned objects", func() {
+			gvk := gv.WithKind("Unstructured")
+			obj := &unstructured.Unstructured{}
+
+			sch := runtime.NewScheme()
+			sch.AddKnownTypeWithName(gvk, obj)
+
+			byObj, def, err := convertToByObject(map[schema.GroupVersionKind]struct{}{
+				gvk: {},
+			}, sch)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(def).To(Equal(struct{}{}))
+			Expect(byObj).To(HaveLen(1))
+			for obj := range byObj {
+				Expect(obj.GetObjectKind().GroupVersionKind()).To(Equal(gvk))
+			}
+		})
+	})
 })
 
 func checkError[T any](v T, err error) T {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This is a backport of #2246 for release-0.14. This is not a straight cherry-pick because the main branch contains breaking changes related to the way cache options are configured for per-object settings. The primary difference is the test, which tests `convertToByObject` directly.
