### PR TITLE
:bug: fix a bug in multinamespaced cache implementation

### DIFF
--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -197,7 +197,7 @@ func (c *multiNamespaceCache) WaitForCacheSync(ctx context.Context) bool {
 func (c *multiNamespaceCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
 	isNamespaced, err := apiutil.IsObjectNamespaced(obj, c.Scheme, c.RESTMapper)
 	if err != nil {
-		return nil //nolint:nilerr
+		return err
 	}
 
 	if !isNamespaced {


### PR DESCRIPTION
This commit fixes a bug that was brought in long ago in #1520. When the object's scope is not deterministic from the RESTMapper it should return an error instead of ignoring it.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
