### PR TITLE
🐛 Support get config inside snap with SNAP_REAL_HOME

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -152,6 +152,15 @@ func loadConfig(context string) (config *rest.Config, configErr error) {
 		loadingRules.Precedence = append(loadingRules.Precedence, filepath.Join(u.HomeDir, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName))
 	}
 
+	// Add $SNAP_REAL_HOME when in snap and the path contains a `.kube\config` file
+	// https://github.com/snapcore/snapd/pull/9189
+	if value, ok := os.LookupEnv("SNAP_REAL_HOME"); ok {
+		location := filepath.Join(value, clientcmd.RecommendedHomeDir, clientcmd.RecommendedFileName)
+		if _, err := os.Stat(location); err == nil {
+			loadingRules.Precedence = append(loadingRules.Precedence, location)
+		}
+	}
+
 	return loadConfigWithContext("", loadingRules, context)
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
We can't get the config file from $HOME when running as a snap app, as $HOME is remapped in such case. https://github.com/snapcore/snapd/pull/9189

This PR checks for $SNAP_REAL_HOME when the path contains a `.kube\config` file, and add it to loadingRule path when it is available.

Alternative PR:

I've also created a PR in the upstream, it will work fine if either or both of these two PR gets merged.
- https://github.com/kubernetes/kubernetes/pull/117165