### PR TITLE
✨ envtest: Add Environment.KubeConfig field

### DIFF
--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
-
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -680,6 +680,14 @@ var _ = Describe("Test", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
+	})
+
+	It("should set a working KubeConfig", func() {
+		kubeconfigRESTConfig, err := clientcmd.RESTConfigFromKubeConfig(env.KubeConfig)
+		Expect(err).ToNot(HaveOccurred())
+		kubeconfigClient, err := client.New(kubeconfigRESTConfig, client.Options{Scheme: s})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kubeconfigClient.List(context.Background(), &apiextensionsv1.CustomResourceDefinitionList{})).To(Succeed())
 	})
 
 	It("should update CRDs if already present in the cluster", func() {


### PR DESCRIPTION
Pulling function from internal https://github.com/kubernetes-sigs/controller-runtime/blob/b826f390522092f54fbea9ff18a97ddde4a828b5/pkg/internal/testing/controlplane/kubectl.go#L42-L81

This is useful for creating kubeconfig file in order to pass filename to KUBECONFIG env which can be helpful in writing [unit tests](https://github.com/vmware-tanzu/velero/blob/a51cc56b43b34ac379a2a5d9908b0e0427c25a34/pkg/cmd/cli/install/install_test.go#L84-L97) without having to break apart some of the current client code to accept a rest.Config

Signed-off-by: Tiger Kaovilai <tkaovila@redhat.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Used in
- https://github.com/vmware-tanzu/velero/pull/6152
- https://github.com/vmware-tanzu/velero/pull/6155