### PR TITLE
🐛 Fix race condition in channel source

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -74,9 +74,6 @@ type Channel struct {
 	// Source is the source channel to fetch GenericEvents
 	Source <-chan event.GenericEvent
 
-	// stop is to end ongoing goroutine, and close the channels
-	stop <-chan struct{}
-
 	// dest is the destination channels of the added event handlers
 	dest []chan event.GenericEvent
 

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -103,9 +103,6 @@ func (cs *Channel) Start(
 		return fmt.Errorf("must specify Channel.Source")
 	}
 
-	// set the stop channel to be the context.
-	cs.stop = ctx.Done()
-
 	// use default value if DestBufferSize not specified
 	if cs.DestBufferSize == 0 {
 		cs.DestBufferSize = defaultBufferSize


### PR DESCRIPTION
If multiple controllers are listening to the same channel source, `Start()` will be called multiple times by the manager. This causes a race condition setting `cs.stop`

Since `cs.stop` appears not to be used, it seems simplest to remove this line.