### PR TITLE
:seedling: envtest: set default webhook options for polling

### DIFF
--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -147,6 +147,8 @@ func (o *WebhookInstallOptions) PrepWithoutInstalling() error {
 
 // Install installs specified webhooks to the API server.
 func (o *WebhookInstallOptions) Install(config *rest.Config) error {
+	defaultWebhookOptions(o)
+
 	if len(o.LocalServingCAData) == 0 {
 		if err := o.PrepWithoutInstalling(); err != nil {
 			return err
@@ -166,6 +168,16 @@ func (o *WebhookInstallOptions) Cleanup() error {
 		return os.RemoveAll(o.LocalServingCertDir)
 	}
 	return nil
+}
+
+// defaultWebhookOptions sets the default values for Webhooks.
+func defaultWebhookOptions(o *WebhookInstallOptions) {
+	if o.MaxTime == 0 {
+		o.MaxTime = defaultMaxWait
+	}
+	if o.PollInterval == 0 {
+		o.PollInterval = defaultPollInterval
+	}
 }
 
 // WaitForWebhooks waits for the Webhooks to be available through API server.


### PR DESCRIPTION
Similar to how it's done for the CRD installation, set default webhook options for timeout/poll interval values.

This avoids getting MaxTime=0 which changes its behaviour when moving from k8s deprecated wait.PollImmediate() to wait.PollUntilContextTimeout().

Spun off from: #2189 