### PR TITLE
🌱 Kind source should expose type information on timeout

### DIFF
--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -112,6 +112,6 @@ func (ks *Kind) WaitForSync(ctx context.Context) error {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil
 		}
-		return errors.New("timed out waiting for cache to be synced")
+		return fmt.Errorf("timed out waiting for cache to be synced for Kind %T", ks.Type)
 	}
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
