### PR TITLE
🐛 Client: use passed in Cache.DisableFor option

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -191,13 +191,13 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 
 	// Load uncached GVKs.
 	c.cacheUnstructured = options.Cache.Unstructured
-	uncachedGVKs := map[schema.GroupVersionKind]struct{}{}
+	c.uncachedGVKs = map[schema.GroupVersionKind]struct{}{}
 	for _, obj := range options.Cache.DisableFor {
 		gvk, err := c.GroupVersionKindFor(obj)
 		if err != nil {
 			return nil, err
 		}
-		uncachedGVKs[gvk] = struct{}{}
+		c.uncachedGVKs[gvk] = struct{}{}
 	}
 	return c, nil
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -277,6 +277,16 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			Expect(cl.List(ctx, &appsv1.DeploymentList{})).To(Succeed())
 			Expect(cache.Called).To(Equal(2))
 		})
+
+		It("should not use the provided reader cache if provided, on get and list for uncached GVKs", func() {
+			cache := &fakeReader{}
+			cl, err := client.New(cfg, client.Options{Cache: &client.CacheOptions{Reader: cache, DisableFor: []client.Object{&corev1.Namespace{}}}})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cl).NotTo(BeNil())
+			Expect(cl.Get(ctx, client.ObjectKey{Name: "default"}, &corev1.Namespace{})).To(Succeed())
+			Expect(cl.List(ctx, &corev1.NamespaceList{})).To(Succeed())
+			Expect(cache.Called).To(Equal(0))
+		})
 	})
 
 	Describe("Create", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Before this PR the client ignored the passed in Cache.DisableFor option as we were just building a map but not using it
