### PR TITLE
⚠️ Flatten fields in controller.Options

### DIFF
--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -217,7 +217,7 @@ var _ = Describe("application", func() {
 			instance, err := ControllerManagedBy(m).
 				For(&appsv1.ReplicaSet{}).
 				Owns(&appsv1.ReplicaSet{}).
-				WithOptions(controller.Options{Controller: config.Controller{MaxConcurrentReconciles: maxConcurrentReconciles}}).
+				WithOptions(controller.Options{MaxConcurrentReconciles: maxConcurrentReconciles}).
 				Build(noop)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(instance).NotTo(BeNil())

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -154,10 +154,8 @@ var _ = Describe("controller.Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{
-				Controller: config.Controller{
-					RecoverPanic: pointer.Bool(false),
-				},
-				Reconciler: reconcile.Func(nil),
+				RecoverPanic: pointer.Bool(false),
+				Reconciler:   reconcile.Func(nil),
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -166,6 +164,129 @@ var _ = Describe("controller.Controller", func() {
 
 			Expect(ctrl.RecoverPanic).NotTo(BeNil())
 			Expect(*ctrl.RecoverPanic).To(BeFalse())
+		})
+
+		It("should default NeedLeaderElection from the manager", func() {
+			m, err := manager.New(cfg, manager.Options{Controller: config.Controller{NeedLeaderElection: pointer.Bool(true)}})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.NeedLeaderElection()).To(BeTrue())
+		})
+
+		It("should not override NeedLeaderElection on the controller", func() {
+			m, err := manager.New(cfg, manager.Options{Controller: config.Controller{NeedLeaderElection: pointer.Bool(true)}})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				NeedLeaderElection: pointer.Bool(false),
+				Reconciler:         reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.NeedLeaderElection()).To(BeFalse())
+		})
+
+		It("Should default MaxConcurrentReconciles from the manager if set", func() {
+			m, err := manager.New(cfg, manager.Options{Controller: config.Controller{MaxConcurrentReconciles: 5}})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.MaxConcurrentReconciles).To(BeEquivalentTo(5))
+		})
+
+		It("Should default MaxConcurrentReconciles to 1 if unset", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.MaxConcurrentReconciles).To(BeEquivalentTo(1))
+		})
+
+		It("Should leave MaxConcurrentReconciles if set", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler:              reconcile.Func(nil),
+				MaxConcurrentReconciles: 5,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.MaxConcurrentReconciles).To(BeEquivalentTo(5))
+		})
+
+		It("Should default CacheSyncTimeout from the manager if set", func() {
+			m, err := manager.New(cfg, manager.Options{Controller: config.Controller{CacheSyncTimeout: 5}})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.CacheSyncTimeout).To(BeEquivalentTo(5))
+		})
+
+		It("Should default CacheSyncTimeout to 2 minutes if unset", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler: reconcile.Func(nil),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.CacheSyncTimeout).To(BeEquivalentTo(2 * time.Minute))
+		})
+
+		It("Should leave CacheSyncTimeout if set", func() {
+			m, err := manager.New(cfg, manager.Options{})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("new-controller", m, controller.Options{
+				Reconciler:       reconcile.Func(nil),
+				CacheSyncTimeout: 5,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller)
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.CacheSyncTimeout).To(BeEquivalentTo(5))
 		})
 
 		It("should default NeedLeaderElection on the controller to true", func() {
@@ -188,10 +309,8 @@ var _ = Describe("controller.Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			c, err := controller.New("new-controller", m, controller.Options{
-				Controller: config.Controller{
-					NeedLeaderElection: pointer.Bool(false),
-				},
-				Reconciler: rec,
+				NeedLeaderElection: pointer.Bool(false),
+				Reconciler:         rec,
 			})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
Currently, `controller.Options` embedds `config.Controller`. This makes its usage pretty annoying, to set `MaxConcurrentReconciles` for example, one has to do it like this:

```
controller.Options{config.Options{MaxConcurrentReconciles: 8}}
```

This makes it harder to find what options exist and causes a lot of churn for downstream consumers. Re-Define the fields from `config.Controller` in `controller.Options` instead to avoid that.

This also fixes some defaulting bugs where we wouldn't default `MaxConcurrentReconciles` and `CacheSyncTimeout` from the `config.Controller` setting in the manager.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
