### PR TITLE
:bug: builder: handle core Group correctly in webhook paths

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -240,11 +240,17 @@ func (blder *WebhookBuilder) isAlreadyHandled(path string) bool {
 }
 
 func generateMutatePath(gvk schema.GroupVersionKind) string {
-	return "/mutate-" + strings.ReplaceAll(gvk.Group, ".", "-") + "-" +
-		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+	return strings.Join([]string{
+		"/mutate",
+		strings.ReplaceAll(strings.Replace(gvk.GroupVersion().String(), "/", "-", 1), ".", "-"),
+		strings.ToLower(gvk.Kind),
+	}, "-")
 }
 
 func generateValidatePath(gvk schema.GroupVersionKind) string {
-	return "/validate-" + strings.ReplaceAll(gvk.Group, ".", "-") + "-" +
-		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+	return strings.Join([]string{
+		"/validate",
+		strings.ReplaceAll(strings.Replace(gvk.GroupVersion().String(), "/", "-", 1), ".", "-"),
+		strings.ToLower(gvk.Kind),
+	}, "-")
 }


### PR DESCRIPTION
Webhooks for the legacy/core v1 Kinds registered using the builder gives paths like "/mutate--v1-pod" which may not be very intuitive to use in the markers.

To follow the schema.GroupVersion().String() convention, just leave empty Group out of the webhook path to get "/mutate-v1-pod" (also as it was in the examples/builtin originally).