### PR TITLE
:warning: Unexport delegating logger, remove async init

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -35,7 +35,10 @@ package log
 
 import (
 	"context"
-	"sync"
+	"fmt"
+	"os"
+	"runtime/debug"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -43,35 +46,24 @@ import (
 
 // SetLogger sets a concrete logging implementation for all deferred Loggers.
 func SetLogger(l logr.Logger) {
-	loggerWasSetLock.Lock()
-	defer loggerWasSetLock.Unlock()
-
-	loggerWasSet = true
-	dlog.Fulfill(l.GetSink())
+	logFullfilled.Store(true)
+	rootLog.Fulfill(l.GetSink())
 }
 
-// It is safe to assume that if this wasn't set within the first 30 seconds of a binaries
-// lifetime, it will never get set. The DelegatingLogSink causes a high number of memory
-// allocations when not given an actual Logger, so we set a NullLogSink to avoid that.
-//
-// We need to keep the DelegatingLogSink because we have various inits() that get a logger from
-// here. They will always get executed before any code that imports controller-runtime
-// has a chance to run and hence to set an actual logger.
-func init() {
-	// Init is blocking, so start a new goroutine
-	go func() {
-		time.Sleep(30 * time.Second)
-		loggerWasSetLock.Lock()
-		defer loggerWasSetLock.Unlock()
-		if !loggerWasSet {
-			dlog.Fulfill(NullLogSink{})
+func eventuallyFulfillRoot() {
+	if logFullfilled.Load() {
+		return
+	}
+	if time.Since(rootLogCreated).Seconds() >= 30 {
+		if logFullfilled.CompareAndSwap(false, true) {
+			fmt.Fprintf(os.Stderr, "[controller-runtime] log.SetLogger(...) was never called, logs will not be displayed:\n%s", debug.Stack())
+			SetLogger(logr.New(NullLogSink{}))
 		}
-	}()
+	}
 }
 
 var (
-	loggerWasSetLock sync.Mutex
-	loggerWasSet     bool
+	logFullfilled atomic.Bool
 )
 
 // Log is the base logger used by kubebuilder.  It delegates
@@ -80,8 +72,10 @@ var (
 // the first 30 seconds of a binaries lifetime, it will get
 // set to a NullLogSink.
 var (
-	dlog = NewDelegatingLogSink(NullLogSink{})
-	Log  = logr.New(dlog)
+	rootLog, rootLogCreated = func() (*delegatingLogSink, time.Time) {
+		return newDelegatingLogSink(NullLogSink{}), time.Now()
+	}()
+	Log = logr.New(rootLog)
 )
 
 // FromContext returns a logger with predefined values from a context.Context.

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ logr.LogSink = &DelegatingLogSink{}
+var _ logr.LogSink = &delegatingLogSink{}
 
 // logInfo is the information for a particular fakeLogger message.
 type logInfo struct {
@@ -124,13 +124,13 @@ var _ = Describe("logging", func() {
 		var (
 			root     *fakeLoggerRoot
 			baseLog  logr.LogSink
-			delegLog *DelegatingLogSink
+			delegLog *delegatingLogSink
 		)
 
 		BeforeEach(func() {
 			root = &fakeLoggerRoot{}
 			baseLog = &fakeLogger{root: root}
-			delegLog = NewDelegatingLogSink(NullLogSink{})
+			delegLog = newDelegatingLogSink(NullLogSink{})
 		})
 
 		It("should delegate with name", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes #1655
