### PR TITLE
🐛 Fix fetching all LazyRESTMapper versions after fetching single version

### DIFF
--- a/pkg/client/apiutil/restmapper.go
+++ b/pkg/client/apiutil/restmapper.go
@@ -75,6 +75,12 @@ func (m *mapper) KindFor(resource schema.GroupVersionResource) (schema.GroupVers
 
 // KindsFor implements Mapper.KindsFor.
 func (m *mapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	if resource.Version == "" {
+		if err := m.addKnownGroupAndReload(resource.Group, resource.Version); err != nil {
+			return nil, err
+		}
+	}
+
 	res, err := m.getMapper().KindsFor(resource)
 	if meta.IsNoMatchError(err) {
 		if err := m.addKnownGroupAndReload(resource.Group, resource.Version); err != nil {
@@ -101,6 +107,12 @@ func (m *mapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVer
 
 // ResourcesFor implements Mapper.ResourcesFor.
 func (m *mapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	if input.Version == "" {
+		if err := m.addKnownGroupAndReload(input.Group, input.Version); err != nil {
+			return nil, err
+		}
+	}
+
 	res, err := m.getMapper().ResourcesFor(input)
 	if meta.IsNoMatchError(err) {
 		if err := m.addKnownGroupAndReload(input.Group, input.Version); err != nil {
@@ -127,6 +139,12 @@ func (m *mapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RES
 
 // RESTMappings implements Mapper.RESTMappings.
 func (m *mapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	if len(versions) == 0 {
+		if err := m.addKnownGroupAndReload(gk.Group, versions...); err != nil {
+			return nil, err
+		}
+	}
+
 	res, err := m.getMapper().RESTMappings(gk, versions...)
 	if meta.IsNoMatchError(err) {
 		if err := m.addKnownGroupAndReload(gk.Group, versions...); err != nil {

--- a/pkg/client/apiutil/restmapper_test.go
+++ b/pkg/client/apiutil/restmapper_test.go
@@ -210,6 +210,37 @@ func TestLazyRestMapperProvider(t *testing.T) {
 		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
 	})
 
+	t.Run("LazyRESTMapper should trigger addKnownGroupAndReload when fetching multiple items and input is partial", func(t *testing.T) {
+		g := gmg.NewWithT(t)
+
+		httpClient, err := rest.HTTPClientFor(restCfg)
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		mappings, err := lazyRestMapper.RESTMappings(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+		g.Expect(len(mappings)).To(gmg.BeNumerically(">", 1))
+
+		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "autoscaling", Kind: "horizontalpodautoscaler"}, "v1")
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		kinds, err := lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "autoscaling", Resource: "horizontalpodautoscaler"})
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+		g.Expect(len(kinds)).To(gmg.BeNumerically(">", 1))
+
+		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "flowcontrol.apiserver.k8s.io", Kind: "prioritylevelconfiguration"}, "v1beta2")
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+
+		resources, err := lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "flowcontrol.apiserver.k8s.io", Resource: "prioritylevelconfiguration"})
+		g.Expect(err).NotTo(gmg.HaveOccurred())
+		g.Expect(len(resources)).To(gmg.BeNumerically(">", 1))
+	})
+
 	t.Run("LazyRESTMapper should work correctly with multiple API group versions", func(t *testing.T) {
 		g := gmg.NewWithT(t)
 


### PR DESCRIPTION
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/2349
