### PR TITLE
🐛 Allow building a fake client with graceful deleting Pods

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1286,7 +1286,7 @@ func allowsGracefulDelete(gvk schema.GroupVersionKind, obj runtime.Object) bool 
 	// If the object is a Pod, it can have the deletionTimestamp set without any finalizers.
 	// This is a special case allowed with graceful deletion. For more details, please see:
 	// https://github.com/kubernetes/kubernetes/blob/7935006af2925dc081605c17fcb5e656cedee286/pkg/registry/core/pod/strategy.go#L163-L194
-	if gvk.Group == corev1.GroupName && gvk.Kind == "Pod" && gvk.Version == "v1" {
+	if gvk == corev1.SchemeGroupVersion.WithKind("Pod") {
 		pod := obj.(*corev1.Pod)
 		// If the pod is not scheduled, it will be deleted immediately.
 		if len(pod.Spec.NodeName) == 0 {

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -50,7 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/testing"
-	"k8s.io/utils/pointer"
+	"k8s.io/utils/ptr"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -290,7 +290,7 @@ func (t versionedTracker) Add(obj runtime.Object) error {
 				return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp but no finalizers", accessor.GetName())
 			}
 		} else {
-			if accessor.GetDeletionTimestamp() != nil && pointer.Int64Deref(accessor.GetDeletionGracePeriodSeconds(), 0) <= 0 {
+			if accessor.GetDeletionTimestamp() != nil && ptr.Deref(accessor.GetDeletionGracePeriodSeconds(), 0) <= 0 {
 				return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp and non-positive metadata.deletionGracePeriodSeconds", accessor.GetName())
 			}
 		}

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1058,7 +1058,7 @@ var _ = Describe("Fake client", func() {
 			By("Getting the Pod")
 			obj = &corev1.Pod{}
 			err := cl.Get(context.Background(), namespacedName, obj)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should reject changes to deletionTimestamp on Patch", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

The change here allows user to build a fake client with graceful deleting Pods, which have their `.metadata.deletionTimestamp` set and have no finalizers. This is a special case allowed in the kube-apiserver. 

The PR reflects the behaviour precisely according the [strategy code from Kubernetes](https://github.com/kubernetes/kubernetes/blob/7935006af2925dc081605c17fcb5e656cedee286/pkg/registry/core/pod/strategy.go#L163-L194). 

It should fix the #2359.