### PR TITLE
🐛 hasLabels and matchingLabels step on each other

### DIFF
--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -237,6 +237,19 @@ var _ = Describe("MatchingLabels", func() {
 		expectedErrMsg := `values[0][k]: Invalid value: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui": must be no more than 63 characters`
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
+
+	It("Should add matchingLabels to existing selector", func() {
+		listOpts := &client.ListOptions{}
+
+		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
+		matchingLabels2 := client.MatchingLabels(map[string]string{"k2": "v2"})
+
+		matchingLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v"))
+
+		matchingLabels2.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,k2=v2"))
+	})
 })
 
 var _ = Describe("FieldOwner", func() {
@@ -290,5 +303,47 @@ var _ = Describe("ForceOwnership", func() {
 		t := client.ForceOwnership
 		t.ApplyToSubResourcePatch(o)
 		Expect(*o.Force).To(Equal(true))
+	})
+})
+
+var _ = Describe("HasLabels", func() {
+	const invalidLongKey = "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui"
+
+	It("Should produce hasLabels in given order", func() {
+		listOpts := &client.ListOptions{}
+
+		hasLabels := client.HasLabels([]string{"labelApe", "labelFox"})
+		hasLabels.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
+	})
+
+	It("Should produce an empty selector when given invalid input", func() {
+		listOpts := &client.ListOptions{}
+		// construct a valid hasLabels selector
+		hasLabel := client.HasLabels([]string{invalidLongKey})
+		hasLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.Empty()).To(BeTrue())
+	})
+
+	It("Should add hasLabels to existing hasLabels selector", func() {
+		listOpts := &client.ListOptions{}
+
+		hasLabel := client.HasLabels([]string{"labelApe"})
+		hasLabel.ApplyToList(listOpts)
+
+		hasOtherLabel := client.HasLabels([]string{"labelFox"})
+		hasOtherLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
+	})
+
+	It("Should add hasLabels to existing matchingLabels", func() {
+		listOpts := &client.ListOptions{}
+
+		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
+		matchingLabels.ApplyToList(listOpts)
+
+		hasLabel := client.HasLabels([]string{"labelApe"})
+		hasLabel.ApplyToList(listOpts)
+		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,labelApe"))
 	})
 })

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -307,22 +307,12 @@ var _ = Describe("ForceOwnership", func() {
 })
 
 var _ = Describe("HasLabels", func() {
-	const invalidLongKey = "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui"
-
 	It("Should produce hasLabels in given order", func() {
 		listOpts := &client.ListOptions{}
 
 		hasLabels := client.HasLabels([]string{"labelApe", "labelFox"})
 		hasLabels.ApplyToList(listOpts)
 		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
-	})
-
-	It("Should produce an empty selector when given invalid input", func() {
-		listOpts := &client.ListOptions{}
-		// construct a valid hasLabels selector
-		hasLabel := client.HasLabels([]string{invalidLongKey})
-		hasLabel.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.Empty()).To(BeTrue())
 	})
 
 	It("Should add hasLabels to existing hasLabels selector", func() {


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
This pr is try to fix issue #2098, where `HasLabels` and `MatchingLables` will step on each other (or overwrites each other) 
