### PR TITLE
🐛 fakeClient.Status().Update(...) cannot recognize resource version conflicts

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -992,11 +992,11 @@ func copyNonStatusFrom(old, new runtime.Object) error {
 		}
 	}
 
-	newClientObject.SetResourceVersion(rv)
-
 	if err := fromMapStringAny(newMapStringAny, new); err != nil {
 		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
 	}
+	newClientObject.SetResourceVersion(rv)
+
 	return nil
 }
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1431,14 +1431,15 @@ var _ = Describe("Fake client", func() {
 	It("should return a conflict error when an incorrect RV is used on status update", func() {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "node",
+				Name:            "node",
+				ResourceVersion: trackerAddResourceVersion,
 			},
 		}
 		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
 
 		obj.Status.Phase = corev1.NodeRunning
 		obj.ResourceVersion = "invalid"
-		err := cl.Update(context.Background(), obj)
+		err := cl.Status().Update(context.Background(), obj)
 		Expect(apierrors.IsConflict(err)).To(BeTrue())
 	})
 


### PR DESCRIPTION
The fake client of subresource is unable to correctly handle the case of resource version conflict when updating. The phenomenon is that it did not return a 409 status error.

Ref:
#2362 

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>