### PR TITLE
✨ fake: simply WithStatusSubresource() signature

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -115,7 +115,7 @@ type ClientBuilder struct {
 	initObject            []client.Object
 	initLists             []client.ObjectList
 	initRuntimeObjects    []runtime.Object
-	withStatusSubresource []client.Object
+	withStatusSubresource []runtime.Object
 	objectTracker         testing.ObjectTracker
 	interceptorFuncs      *interceptor.Funcs
 
@@ -204,7 +204,7 @@ func (f *ClientBuilder) WithIndex(obj runtime.Object, field string, extractValue
 
 // WithStatusSubresource configures the passed object with a status subresource, which means
 // calls to Update and Patch will not alter its status.
-func (f *ClientBuilder) WithStatusSubresource(o ...client.Object) *ClientBuilder {
+func (f *ClientBuilder) WithStatusSubresource(o ...runtime.Object) *ClientBuilder {
 	f.withStatusSubresource = append(f.withStatusSubresource, o...)
 	return f
 }


### PR DESCRIPTION


<!-- What does this do, and why do we need it? -->
simply WithStatusSubresource() signature

runtime.Object is a subinterface of client.Object,
and is all that's needed here
    
you really need a client to get a client.Object,
so it doesn't really make sense to use a client.Object
to initialize a client.