### PR TITLE
✨ fake: Update fake client doc.go to avoid the deprecated method

### DIFF
--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -20,7 +20,7 @@ Package fake provides a fake client for testing.
 A fake client is backed by its simple object store indexed by GroupVersionResource.
 You can create a fake client with optional objects.
 
-	client := NewFakeClientWithScheme(scheme, initObjs...) // initObjs is a slice of runtime.Object
+	client := NewClientBuilder().WithScheme(scheme).Build()
 
 You can invoke the methods defined in the Client interface.
 

--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -20,7 +20,7 @@ Package fake provides a fake client for testing.
 A fake client is backed by its simple object store indexed by GroupVersionResource.
 You can create a fake client with optional objects.
 
-	client := NewClientBuilder().WithScheme(scheme).Build()
+	client := NewClientBuilder().WithScheme(scheme).WithObj(initObjs...).Build()
 
 You can invoke the methods defined in the Client interface.
 


### PR DESCRIPTION
`NewFakeClientWithScheme(scheme, initObjs...)` is deprecated, but the doc for fake-client still uses it. 

This PR updates the doc to use the recommended way to create a fake client.

The updated part is the red box of following image.
<img width="787" alt="image" src="https://github.com/kubernetes-sigs/controller-runtime/assets/756988/11a910d2-f2a3-4aa6-8b9e-dc5083a3ebe1">

