### PR TITLE
🐛 improve RegisterFlags()

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -33,8 +33,8 @@ import (
 const KubeconfigFlagName = "kubeconfig"
 
 var (
-	kubeconfig string
-	log        = logf.RuntimeLog.WithName("client").WithName("config")
+	kubeconfigFlagVal flag.Value
+	log               = logf.RuntimeLog.WithName("client").WithName("config")
 )
 
 // init registers the "kubeconfig" flag to the default command line FlagSet.
@@ -51,9 +51,10 @@ func RegisterFlags(fs *flag.FlagSet) {
 		fs = flag.CommandLine
 	}
 	if f := fs.Lookup(KubeconfigFlagName); f != nil {
-		kubeconfig = f.Value.String()
+		kubeconfigFlagVal = f.Value
 	} else {
-		fs.StringVar(&kubeconfig, KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+		fs.String(KubeconfigFlagName, "", "Paths to a kubeconfig. Only required if out-of-cluster.")
+		kubeconfigFlagVal = fs.Lookup(KubeconfigFlagName).Value
 	}
 }
 
@@ -115,8 +116,8 @@ var loadInClusterConfig = rest.InClusterConfig
 // loadConfig loads a REST Config as per the rules specified in GetConfig.
 func loadConfig(context string) (config *rest.Config, configErr error) {
 	// If a flag is specified with the config location, use that
-	if len(kubeconfig) > 0 {
-		return loadConfigWithContext("", &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfig}, context)
+	if kubeconfigFlagVal != nil && len(kubeconfigFlagVal.String()) > 0 {
+		return loadConfigWithContext("", &clientcmd.ClientConfigLoadingRules{ExplicitPath: kubeconfigFlagVal.String()}, context)
 	}
 
 	// If the recommended kubeconfig env variable is not specified,

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
@@ -53,7 +54,7 @@ var _ = Describe("Config", func() {
 
 	AfterEach(func() {
 		os.Unsetenv(clientcmd.RecommendedConfigPathEnvVar)
-		kubeconfig = ""
+		kubeconfigFlagVal = nil
 		clientcmd.RecommendedHomeFile = origRecommendedHomeFile
 
 		err := os.RemoveAll(dir)
@@ -176,7 +177,9 @@ var _ = Describe("Config", func() {
 func setConfigs(tc testCase, dir string) {
 	// Set kubeconfig flag value
 	if len(tc.kubeconfigFlag) > 0 {
-		kubeconfig = filepath.Join(dir, tc.kubeconfigFlag)
+		fs := flag.NewFlagSet("", flag.ContinueOnError)
+		fs.String(KubeconfigFlagName, filepath.Join(dir, tc.kubeconfigFlag), "")
+		kubeconfigFlagVal = fs.Lookup(KubeconfigFlagName).Value
 	}
 
 	// Set KUBECONFIG env value


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Function `RegisterFlags()` When `fs.Lookup(KubeconfigFlagName) != nil`, the variable `kubeconfig` will be assigned an empty string, unless `flag.Parse()` has been called. This behavior does not match the function name `RegisterFlags()`, which seems to be called before `flag.Parse()`.

Here's some changes that allow this library to "register" kubeconfig flag when it's already defined. Please feel free to point out if there is anything that needs improvement.