### PR TITLE
✨: pkg/cache: add options for cache miss policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ generate: $(CONTROLLER_GEN) ## Runs controller-gen for internal types for config
 
 .PHONY: clean
 clean: ## Cleanup.
+	$(GOLANGCI_LINT) cache clean
 	$(MAKE) clean-bin
 
 .PHONY: clean-bin

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -145,6 +145,15 @@ type Options struct {
 	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
+	// ReaderFailOnMissingInformer configures the cache to return a ErrResourceNotCached error when a user
+	// requests, using Get() and List(), a resource the cache does not already have an informer for.
+	//
+	// This error is distinct from an errors.NotFound.
+	//
+	// Defaults to false, which means that the cache will start a new informer
+	// for every new requested resource.
+	ReaderFailOnMissingInformer bool
+
 	// DefaultNamespaces maps namespace names to cache configs. If set, only
 	// the namespaces in here will be watched and it will by used to default
 	// ByObject.Namespaces for all objects if that is nil.
@@ -329,6 +338,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				Transform:             config.Transform,
 				UnsafeDisableDeepCopy: pointer.BoolDeref(config.UnsafeDisableDeepCopy, false),
 			}),
+			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}
 	}
 }

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -230,7 +230,8 @@ func (ip *Informers) WaitForCacheSync(ctx context.Context) bool {
 	return cache.WaitForCacheSync(ctx.Done(), ip.getHasSyncedFuncs()...)
 }
 
-func (ip *Informers) get(gvk schema.GroupVersionKind, obj runtime.Object) (res *Cache, started bool, ok bool) {
+// Peek attempts to get the informer for the GVK, but does not start one if one does not exist.
+func (ip *Informers) Peek(gvk schema.GroupVersionKind, obj runtime.Object) (res *Cache, started bool, ok bool) {
 	ip.mu.RLock()
 	defer ip.mu.RUnlock()
 	i, ok := ip.informersByType(obj)[gvk]
@@ -241,7 +242,7 @@ func (ip *Informers) get(gvk schema.GroupVersionKind, obj runtime.Object) (res *
 // the Informer from the map.
 func (ip *Informers) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *Cache, error) {
 	// Return the informer if it is found
-	i, started, ok := ip.get(gvk, obj)
+	i, started, ok := ip.Peek(gvk, obj)
 	if !ok {
 		var err error
 		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -77,10 +77,12 @@ type CacheOptions struct {
 	// Reader is a cache-backed reader that will be used to read objects from the cache.
 	// +required
 	Reader Reader
-	// DisableFor is a list of objects that should not be read from the cache.
+	// DisableFor is a list of objects that should never be read from the cache.
+	// Objects configured here always result in a live lookup.
 	DisableFor []Object
 	// Unstructured is a flag that indicates whether the cache-backed client should
 	// read unstructured objects or lists from the cache.
+	// If false, unstructured objects will always result in a live lookup.
 	Unstructured bool
 }
 
@@ -342,9 +344,11 @@ func (c *client) Get(ctx context.Context, key ObjectKey, obj Object, opts ...Get
 	if isUncached, err := c.shouldBypassCache(obj); err != nil {
 		return err
 	} else if !isUncached {
+		// Attempt to get from the cache.
 		return c.cache.Get(ctx, key, obj, opts...)
 	}
 
+	// Perform a live lookup.
 	switch obj.(type) {
 	case runtime.Unstructured:
 		return c.unstructuredClient.Get(ctx, key, obj, opts...)
@@ -362,9 +366,11 @@ func (c *client) List(ctx context.Context, obj ObjectList, opts ...ListOption) e
 	if isUncached, err := c.shouldBypassCache(obj); err != nil {
 		return err
 	} else if !isUncached {
+		// Attempt to get from the cache.
 		return c.cache.List(ctx, obj, opts...)
 	}
 
+	// Perform a live lookup.
 	switch x := obj.(type) {
 	case runtime.Unstructured:
 		return c.unstructuredClient.List(ctx, obj, opts...)

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -600,6 +600,16 @@ var _ = Describe("manger.Manager", func() {
 			cancel()
 		})
 
+		It("should be able to create a manager with a cache that fails on missing informer", func() {
+			m, err := New(cfg, Options{
+				Cache: cache.Options{
+					ReaderFailOnMissingInformer: true,
+				},
+			})
+			Expect(m).ToNot(BeNil())
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return an error if the metrics bind address is already in use", func() {
 			ln, err := net.Listen("tcp", ":0") //nolint:gosec
 			Expect(err).ShouldNot(HaveOccurred())


### PR DESCRIPTION
This commit allows users to opt out of the "start informers in the background" behavior that the current cache implementation uses. Additionally, when opting out of this behavior, the client can be configured to do a live lookup on a cache miss. The default behaviors are:

  pkg/cache: backfill data on a miss (today's default, unchanged)
  pkg/client: live lookup when cache is configured to miss

Fixes #2397 