### PR TITLE
📖 Add documentation to clarify the ContentType behavior

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -110,6 +110,9 @@ var (
 	NewWebhookManagedBy = builder.WebhookManagedBy
 
 	// NewManager returns a new Manager for creating Controllers.
+	// Note that if ContentType in the given config is not set, "application/vnd.kubernetes.protobuf"
+	// will be used for all built-in resources of Kubernetes, and "application/json" is for other types
+	// including all CRD resources.
 	NewManager = manager.New
 
 	// CreateOrUpdate creates or updates the given object obj in the Kubernetes

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -390,6 +390,9 @@ type LeaderElectionRunnable interface {
 }
 
 // New returns a new Manager for creating Controllers.
+// Note that if ContentType in the given config is not set, "application/vnd.kubernetes.protobuf"
+// will be used for all built-in resources of Kubernetes, and "application/json" is for other types
+// including all CRD resources.
 func New(config *rest.Config, options Options) (Manager, error) {
 	// Set default values for options fields
 	options = setOptionsDefaults(options)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Add documentation to clarify the ContentType behavior. `application/vnd.kubernetes.protobuf` will be used for all built-in resources by default.

fixes #2408 