### PR TITLE
⚠ fake client: use correct RBAC apiGroup name when deciding if to allow unconditional updates

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1177,6 +1177,8 @@ func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
 		case "PodSecurityPolicy":
 			return true
 		}
+	case "rbac":
+		fallthrough
 	case "rbac.authorization.k8s.io":
 		switch gvk.Kind {
 		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1177,7 +1177,7 @@ func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
 		case "PodSecurityPolicy":
 			return true
 		}
-	case "rbac":
+	case "rbac.authorization.k8s.io":
 		switch gvk.Kind {
 		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":
 			return true

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1177,8 +1177,6 @@ func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
 		case "PodSecurityPolicy":
 			return true
 		}
-	case "rbac":
-		fallthrough
 	case "rbac.authorization.k8s.io":
 		switch gvk.Kind {
 		case "ClusterRole", "ClusterRoleBinding", "Role", "RoleBinding":


### PR DESCRIPTION
The fake client logic runs through a switch case, switching on resource group to decide if unconditional update should be allowed for a particular resource or not
However, for rbac resources it checks against the string "rbac" as the group name, as opposed to "rbac.authorization.k8s.io",  which is the actual group name for rbac resources

This issue currently results in an "object modified" error when the fake client tries to update any rbac resource, as it fails the `allowsUnconditionalUpdate` check

This PR fixes that by updating the rbac group name to the correct value
