### PR TITLE
⚠ builder: return error when multiple reconcilers are set

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -344,6 +344,9 @@ func (blder *Builder) doController(r reconcile.Reconciler) error {
 	globalOpts := blder.mgr.GetControllerOptions()
 
 	ctrlOptions := blder.ctrlOptions
+	if ctrlOptions.Reconciler != nil && r != nil {
+		return errors.New("reconciler was set via WithOptions() and via Build() or Complete()")
+	}
 	if ctrlOptions.Reconciler == nil {
 		ctrlOptions.Reconciler = r
 	}

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -298,7 +298,7 @@ var _ = Describe("application", func() {
 			Expect(instance).NotTo(BeNil())
 		})
 
-		It("should prefer reconciler from options during creation of controller", func() {
+		It("should not allow multiple reconcilers during creation of controller", func() {
 			newController = func(name string, mgr manager.Manager, options controller.Options) (controller.Controller, error) {
 				if options.Reconciler != (typedNoop{}) {
 					return nil, fmt.Errorf("Custom reconciler expected %T but found %T", typedNoop{}, options.Reconciler)
@@ -315,8 +315,8 @@ var _ = Describe("application", func() {
 				Owns(&appsv1.ReplicaSet{}).
 				WithOptions(controller.Options{Reconciler: typedNoop{}}).
 				Build(noop)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(instance).NotTo(BeNil())
+			Expect(err).To(HaveOccurred())
+			Expect(instance).To(BeNil())
 		})
 
 		It("should allow multiple controllers for the same kind", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Just saw this and was confused why we would want this behavior. I also looked at https://github.com/kubernetes-sigs/controller-runtime/issues/1021 but I don't understand the reasoning.

If we want a silent overwrite behavior I would have expected Build/Complete to overwrite the reconciler from the previous set ctrlOptions not the other way around

I think this implementation still covers the original ask, folks can pass in a `nil` reconciler to Build/Complete
