### PR TITLE
:sparkles: add logging to Enqueue_owner event handler

### DIFF
--- a/pkg/handler/eventhandler_suite_test.go
+++ b/pkg/handler/eventhandler_suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handler_test
 
 import (
+	"bytes"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,9 +35,10 @@ func TestEventhandler(t *testing.T) {
 
 var testenv *envtest.Environment
 var cfg *rest.Config
+var logBuffer bytes.Buffer
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(zap.WriteTo(&logBuffer), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}
 	var err error


### PR DESCRIPTION

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR adds logging to Enqueue owner event handler, that is helpful in logging the GVK of the owner that
caused reconciliation.

Fixes: #1186 

In Operator SDK we have a `LoggingEnqueueRequestForOwnerHandler` ([ref](https://github.com/operator-framework/operator-sdk/blob/bd0ccd22e9daa9935770445b0f11c5190042481a/internal/ansible/handler/logging_enqueue_owner.go#L29C1-L31)) that used to add logging to the existing `EnqueueRequestForOwnerHandler`. In C-R 0.15.0 this was made internal, making it difficult to create a wrapper around it. However, adding logging to the existing handler available in c-r would be useful to other consumers also in identifying the cause of reconcile. 
