### PR TITLE
✨ Use object's TypeMeta as GVK fallback

### DIFF
--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -135,6 +135,13 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 	// Use the given scheme to retrieve all the GVKs for the object.
 	gvks, isUnversioned, err := scheme.ObjectKinds(obj)
 	if err != nil {
+		if runtime.IsNotRegisteredError(err) && obj.GetObjectKind() != nil {
+			// Use object's current GVK as a last ditch attempt for a type not registered with the scheme.
+			currentGVK := obj.GetObjectKind().GroupVersionKind()
+			if !currentGVK.Empty() {
+				return currentGVK, nil
+			}
+		}
 		return schema.GroupVersionKind{}, err
 	}
 	if isUnversioned {


### PR DESCRIPTION
GVKForObject looks up the GVK for an Object via a Scheme, unless the object is one of a few generic types. When handling multiple similar resources, it's connivent to coerce those resource to a common static type (often a subset of the actual object). These types cannot be registered in the scheme as they do not map to a single GVK.

I would like to be able to resolve a GVK from a non-scheme registered object type so that these types can be used in other useful methods that internally call GVKForObject, like SetControllerReference. To do this, if the lookup from the scheme fails, it will use the TypeMeta fields on the object and return those values as the GVK. This behavior requires the APIVersion and Kind fields are set, otherwise it will fall back to returning the scheme error.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
