### PR TITLE
:bug: Fix Defaulting of the User Agent

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -334,6 +334,11 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 }
 
 func defaultOpts(config *rest.Config, opts Options) (Options, error) {
+	config = rest.CopyConfig(config)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	// Use the rest HTTP client for the provided config if unset
 	if opts.HTTPClient == nil {
 		var err error

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -110,6 +110,11 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		return nil, fmt.Errorf("must provide non-nil rest.Config to client.New")
 	}
 
+	config = rest.CopyConfig(config)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	if !options.WarningHandler.SuppressWarnings {
 		// surface warnings
 		logger := log.Log.WithName("KubeAPIWarningLogger")
@@ -117,7 +122,6 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		// is log.KubeAPIWarningLogger with deduplication enabled.
 		// See log.KubeAPIWarningLoggerOptions for considerations
 		// regarding deduplication.
-		config = rest.CopyConfig(config)
 		config.WarningHandler = log.NewKubeAPIWarningLogger(
 			logger,
 			log.KubeAPIWarningLoggerOptions{
@@ -160,7 +164,7 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		unstructuredResourceByType: make(map[schema.GroupVersionKind]*resourceMeta),
 	}
 
-	rawMetaClient, err := metadata.NewForConfigAndClient(config, options.HTTPClient)
+	rawMetaClient, err := metadata.NewForConfigAndClient(metadata.ConfigFor(config), options.HTTPClient)
 	if err != nil {
 		return nil, fmt.Errorf("unable to construct metadata-only client for use as part of client: %w", err)
 	}

--- a/pkg/cluster/cluster.go
+++ b/pkg/cluster/cluster.go
@@ -158,6 +158,13 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 		return nil, errors.New("must specify Config")
 	}
 
+	originalConfig := config
+
+	config = rest.CopyConfig(config)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+
 	options := Options{}
 	for _, opt := range opts {
 		opt(&options)
@@ -241,7 +248,7 @@ func New(config *rest.Config, opts ...Option) (Cluster, error) {
 	}
 
 	return &cluster{
-		config:           config,
+		config:           originalConfig,
 		httpClient:       options.HTTPClient,
 		scheme:           options.Scheme,
 		cache:            cache,

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -18,6 +18,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -319,6 +320,9 @@ type LeaderElectionRunnable interface {
 // will be used for all built-in resources of Kubernetes, and "application/json" is for other types
 // including all CRD resources.
 func New(config *rest.Config, options Options) (Manager, error) {
+	if config == nil {
+		return nil, errors.New("must specify Config")
+	}
 	// Set default values for options fields
 	options = setOptionsDefaults(options)
 
@@ -334,6 +338,11 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	config = rest.CopyConfig(config)
+	if config.UserAgent == "" {
+		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
 	// Create the recorder provider to inject event recorders for the components.


### PR DESCRIPTION
This broke when we added the HTTP client, because the user-agent gets set by a roundtripper that is constructed within `rest.HTTPClientFor`. As a result, we have to default it before we do that. Currently, it ends up being defaulted to `Go-http-client` which is not very useful.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
