### PR TITLE
:warning: Return an error if the continue list option is set for the cache reader

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -688,6 +688,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(informerCache.List(context.Background(), listObj, labelOpt, limitOpt)).To(Succeed())
 					Expect(listObj.Items).Should(HaveLen(1))
 				})
+
+				It("should return an error if the continue list options is set", func() {
+					listObj := &corev1.PodList{}
+					continueOpt := client.Continue("token")
+					By("verifying that an error is returned")
+					err := informerCache.List(context.Background(), listObj, continueOpt)
+					Expect(err).To(HaveOccurred())
+				})
 			})
 
 			Context("with unstructured objects", func() {
@@ -1001,6 +1009,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("verifying the node list is not empty")
 					Expect(nodeList.Items).NotTo(BeEmpty())
 					Expect(len(nodeList.Items)).To(BeEquivalentTo(1))
+				})
+				It("should return an error if the continue list options is set", func() {
+					podList := &unstructured.Unstructured{}
+					continueOpt := client.Continue("token")
+					By("verifying that an error is returned")
+					err := informerCache.List(context.Background(), podList, continueOpt)
+					Expect(err).To(HaveOccurred())
 				})
 			})
 			Context("with metadata-only objects", func() {

--- a/pkg/cache/internal/cache_reader.go
+++ b/pkg/cache/internal/cache_reader.go
@@ -111,6 +111,10 @@ func (c *CacheReader) List(_ context.Context, out client.ObjectList, opts ...cli
 	listOpts := client.ListOptions{}
 	listOpts.ApplyOptions(opts)
 
+	if listOpts.Continue != "" {
+		return fmt.Errorf("continue list option is not supported by the cache")
+	}
+
 	switch {
 	case listOpts.FieldSelector != nil:
 		// TODO(directxman12): support more complicated field selectors by


### PR DESCRIPTION
Hi, currently the cache reader ignores the continue option. This behavior could lead to a hard-to-find bug when a user mistakenly tries to paginate with the limit and continue option by the cache client. I faced the problem, and that was quite hard to debug since the limit option works correctly and I always received the first page only. I believe it is more user-friendly if we just return an error when a user mistakenly set the option instead of ignoring it silently. Thanks for your review!