### PR TITLE
Backport terminal error fix

### DIFF
--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -112,11 +112,15 @@ type terminalError struct {
 	err error
 }
 
+// This function will return nil if te.err is nil.
 func (te *terminalError) Unwrap() error {
 	return te.err
 }
 
 func (te *terminalError) Error() string {
+	if te.err == nil {
+		return "nil terminal error"
+	}
 	return "terminal error: " + te.err.Error()
 }
 

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -96,5 +96,10 @@ var _ = Describe("reconcile", func() {
 
 			Expect(apierrors.IsGone(terminalError)).To(BeTrue())
 		})
+
+		It("should handle nil terminal errors properly", func() {
+			err := reconcile.TerminalError(nil)
+			Expect(err.Error()).To(Equal("nil terminal error"))
+		})
 	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Backport https://github.com/kubernetes-sigs/controller-runtime/pull/2438 for use with k8s 1.27
