### PR TITLE
🌱 Add action to update modules on dependabot PRs

### DIFF
--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -1,0 +1,35 @@
+name: PR dependabot go modules fix
+
+# This action runs on PRs opened by dependabot and updates modules.
+on:
+  pull_request:
+    branches:
+      - dependabot/**
+  push:
+    branches:
+      - dependabot/**
+  workflow_dispatch:
+
+permissions:
+  contents: write # Allow to update the PR.
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # tag=v3.5.3
+    - name: Set up Go
+      uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # tag=v4.0.1
+      with:
+        go-version: '1.20'
+    - name: Update all modules
+      run: make modules
+    - uses: EndBug/add-and-commit@1bad3abcf0d6ec49a5857d124b0bfb52dc7bb081 # tag=v9.1.3
+      name: Commit changes
+      with:
+        author_name: dependabot[bot]
+        author_email: support@github.com
+        default_author: github_actor
+        message: 'Update generated code'


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Dependabot PRs like https://github.com/kubernetes-sigs/controller-runtime/pull/2446 require a regenerate of go modules. This action will regenerate go modules and push the change as a commit.

We've been using this in Cluster API since a while and it works very well

