### PR TITLE
🌱 Fix mail of dependabot action commit

### DIFF
--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -30,6 +30,6 @@ jobs:
       name: Commit changes
       with:
         author_name: dependabot[bot]
-        author_email: support@github.com
+        author_email: 49699333+dependabot[bot]@users.noreply.github.com
         default_author: github_actor
         message: 'Update generated code'


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Follow-up to: https://github.com/kubernetes-sigs/controller-runtime/pull/2447

Looks like someone has fun with the github support mail: 
<img width="2059" alt="image" src="https://github.com/kubernetes-sigs/controller-runtime/assets/4662360/3c312ba9-15bd-4bcc-a4e4-660e19f48875">

So now switching to the obscure mail that somehow works that we use in CAPI.