### PR TITLE
🐛 Use http client from leaderElectionConfig

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -364,7 +364,11 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		if err != nil {
 			return nil, err
 		}
-		leaderRecorderProvider, err = options.newRecorderProvider(leaderConfig, cluster.GetHTTPClient(), scheme, options.Logger.WithName("events"), options.makeBroadcaster)
+		httpClient, err := rest.HTTPClientFor(options.LeaderElectionConfig)
+		if err != nil {
+			return nil, err
+		}
+		leaderRecorderProvider, err = options.newRecorderProvider(leaderConfig, httpClient, scheme, options.Logger.WithName("events"), options.makeBroadcaster)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
During creation of the manager, the default `cluster.HTTPClient` is being used during leader election causing cert issues and not responding to events because of the conflict of the kubeconfig it uses for the manager.  It never uses the kubeconfig from the leaderElectionConfig when being set.  

This PR sets that value and creates a httpClient from the restConfig passed in on the `options.LeaderElectionConfig`

- [x] Use the http client from the leaderElectionConfig from options in manager 

Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/2454