### PR TITLE
🌱  Implement missing client methods for komega interface

### DIFF
--- a/pkg/envtest/komega/default.go
+++ b/pkg/envtest/komega/default.go
@@ -79,6 +79,30 @@ func UpdateStatus(obj client.Object, f func(), opts ...client.SubResourceUpdateO
 	return defaultK.UpdateStatus(obj, f, opts...)
 }
 
+// Delete returns a function that deletes a resource and returns the occurring error.
+// It can be used with gomega.Eventually() like this:
+//
+//	deployment := appsv1.Deployment{ ... }
+//	gomega.Eventually(k.Delete(&deployment).To(gomega.Succeed())
+//
+// By calling the returned function directly it can also be used as gomega.Expect(k.Delete(...)()).To(...)
+func Delete(obj client.Object, opts ...client.DeleteOption) func() error {
+	checkDefaultClient()
+	return defaultK.Delete(obj, opts...)
+}
+
+// DeleteAllOf returns a function that deletes a list of resources and returns the occurring error.
+// It can be used with gomega.Eventually() like this:
+//
+//	deployments := appsv1.Deployment{ ... }
+//	gomega.Eventually(k.DeleteAllOf(&deployments, client.InNamespace("default")).To(gomega.Succeed())
+//
+// By calling the returned function directly it can also be used as gomega.Expect(k.DeleteAllOf(...)()).To(...)
+func DeleteAllOf(obj client.Object, opts ...client.DeleteAllOfOption) func() error {
+	checkDefaultClient()
+	return defaultK.DeleteAllOf(obj, opts...)
+}
+
 // Object returns a function that fetches a resource and returns the object.
 // It can be used with gomega.Eventually() like this:
 //

--- a/pkg/envtest/komega/interfaces.go
+++ b/pkg/envtest/komega/interfaces.go
@@ -49,6 +49,27 @@ type Komega interface {
 	// By calling the returned function directly it can also be used as gomega.Expect(k.Update(...)()).To(...)
 	Update(client.Object, func(), ...client.UpdateOption) func() error
 
+	// Patch returns a function that applies the provided patch on the resource and returns the occurring error.
+	// It can be used with gomega.Eventually() like this:
+	//   deployment := appsv1.Deployment{ ... }
+	//   gomega.Eventually(k.Patch(&deployment, client.RawPatch(types.StrategicMergePatchType, patch)).To(gomega.Succeed())
+	// By calling the returned function directly it can also be used as gomega.Expect(k.PatchStatus(...)()).To(...)
+	Patch(client.Object, client.Patch, ...client.PatchOption) func() error
+
+	// Delete returns a function that deletes a resource and returns the occurring error.
+	// It can be used with gomega.Eventually() like this:
+	//   deployment := appsv1.Deployment{ ... }
+	//   gomega.Eventually(k.Delete(&deployment).To(gomega.Succeed())
+	// By calling the returned function directly it can also be used as gomega.Expect(k.Delete(...)()).To(...)
+	Delete(client.Object, ...client.DeleteOption) func() error
+
+	// DeleteAllOf returns a function that deletes a list of resources and returns the occurring error.
+	// It can be used with gomega.Eventually() like this:
+	//   deployments := appsv1.Deployment{ ... }
+	//   gomega.Eventually(k.DeleteAllOf(&deployments, client.InNamespace("default")).To(gomega.Succeed())
+	// By calling the returned function directly it can also be used as gomega.Expect(k.DeleteAllOf(...)()).To(...)
+	DeleteAllOf(client.Object, ...client.DeleteAllOfOption) func() error
+
 	// UpdateStatus returns a function that fetches a resource, applies the provided update function and then updates the resource's status.
 	// It can be used with gomega.Eventually() like this:
 	//   deployment := appsv1.Deployment{ ... }
@@ -58,6 +79,13 @@ type Komega interface {
 	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
 	UpdateStatus(client.Object, func(), ...client.SubResourceUpdateOption) func() error
+
+	// PatchStatus returns a function that applies the provided patch on the resource status and returns the occurring error.
+	// It can be used with gomega.Eventually() like this:
+	//   deployment := appsv1.Deployment{ ... }
+	//   gomega.Eventually(k.PatchStatus(&deployment, client.RawPatch(types.StrategicMergePatchType, patch)).To(gomega.Succeed())
+	// By calling the returned function directly it can also be used as gomega.Expect(k.PatchStatus(...)()).To(...)
+	PatchStatus(client.Object, client.Patch, ...client.SubResourcePatchOption) func() error
 
 	// Object returns a function that fetches a resource and returns the object.
 	// It can be used with gomega.Eventually() like this:

--- a/pkg/envtest/komega/komega.go
+++ b/pkg/envtest/komega/komega.go
@@ -80,6 +80,34 @@ func (k *komega) Update(obj client.Object, updateFunc func(), opts ...client.Upd
 	}
 }
 
+// Delete returns a function that deletes a resource and returns the occurring error.
+func (k *komega) Delete(obj client.Object, opts ...client.DeleteOption) func() error {
+	return func() error {
+		return k.client.Delete(k.ctx, obj, opts...)
+	}
+}
+
+// Patch returns a function that applies the provided patch on the resource and returns the occurring error.
+func (k *komega) Patch(obj client.Object, patch client.Patch, opts ...client.PatchOption) func() error {
+	return func() error {
+		return k.client.Patch(k.ctx, obj, patch, opts...)
+	}
+}
+
+// PatchStatus returns a function that applies the provided patch on the resource status and returns the occurring error.
+func (k *komega) PatchStatus(obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) func() error {
+	return func() error {
+		return k.client.Status().Patch(k.ctx, obj, patch, opts...)
+	}
+}
+
+// DeleteAllOf returns a function that deletes a list of resources and returns the occurring error.
+func (k *komega) DeleteAllOf(obj client.Object, opts ...client.DeleteAllOfOption) func() error {
+	return func() error {
+		return k.client.DeleteAllOf(k.ctx, obj, opts...)
+	}
+}
+
 // UpdateStatus returns a function that fetches a resource, applies the provided update function and then updates the resource's status.
 func (k *komega) UpdateStatus(obj client.Object, updateFunc func(), opts ...client.SubResourceUpdateOption) func() error {
 	key := types.NamespacedName{


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR adds some missing interface members for komega, making it more suitable for general use in tests.
