### PR TITLE
Fake client.Update() should not store omit empty Status fields

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -990,21 +990,8 @@ func copyNonStatusFrom(old, new runtime.Object) error {
 
 // copyStatusFrom copies the status from old into new
 func copyStatusFrom(old, new runtime.Object) error {
-	oldMapStringAny, err := toMapStringAny(old)
-	if err != nil {
-		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
-	}
-	newMapStringAny, err := toMapStringAny(new)
-	if err != nil {
-		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
-	}
-
-	newMapStringAny["status"] = oldMapStringAny["status"]
-
-	if err := fromMapStringAny(newMapStringAny, new); err != nil {
-		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
-	}
-
+	reflect.ValueOf(new).Elem().FieldByName("Status").Set(
+		reflect.ValueOf(old).Elem().FieldByName("Status"))
 	return nil
 }
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1427,6 +1427,23 @@ var _ = Describe("Fake client", func() {
 		Expect(obj.Status).To(BeEquivalentTo(corev1.NodeStatus{NodeInfo: corev1.NodeSystemInfo{MachineID: "machine-id"}}))
 	})
 
+	It("should not change the status of typed objects that have a status subresource on update with omitempty fields", func() {
+		obj := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "node",
+			},
+		}
+		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
+
+		obj.Status.Config = &corev1.NodeConfigStatus{}
+		obj.Status.Config.Error = "some string"
+		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+
+		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+
+		Expect(obj.Status).To(BeEquivalentTo(corev1.NodeStatus{}))
+	})
+
 	It("should return a conflict error when an incorrect RV is used on status update", func() {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
[x] - solve for typed object Update()
[ ] - solve for unstructured object Update()