### PR TITLE
🐛 Do not update anything but status when using subresource client 

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -950,46 +950,6 @@ func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (ru
 	return obj, nil
 }
 
-//lint:ignore U1000 function is causing errors with status updates
-func copyNonStatusFrom(old, new runtime.Object) error {
-	newClientObject, ok := new.(client.Object)
-	if !ok {
-		return fmt.Errorf("%T is not a client.Object", new)
-	}
-	// The only thing other than status we have to retain
-	rv := newClientObject.GetResourceVersion()
-
-	oldMapStringAny, err := toMapStringAny(old)
-	if err != nil {
-		return fmt.Errorf("failed to convert old to *unstructured.Unstructured: %w", err)
-	}
-	newMapStringAny, err := toMapStringAny(new)
-	if err != nil {
-		return fmt.Errorf("failed to convert new to *unststructured.Unstructured: %w", err)
-	}
-
-	// delete everything other than status in case it has fields that were not present in
-	// the old object
-	for k := range newMapStringAny {
-		if k != "status" {
-			delete(newMapStringAny, k)
-		}
-	}
-	// copy everything other than status from the old object
-	for k := range oldMapStringAny {
-		if k != "status" {
-			newMapStringAny[k] = oldMapStringAny[k]
-		}
-	}
-
-	if err := fromMapStringAny(newMapStringAny, new); err != nil {
-		return fmt.Errorf("failed to convert back from map[string]any: %w", err)
-	}
-	newClientObject.SetResourceVersion(rv)
-
-	return nil
-}
-
 // copyStatusFrom copies the status from old into new
 func copyStatusFrom(old, new runtime.Object) error {
 	oldMapStringAny, err := toMapStringAny(old)

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1460,6 +1460,13 @@ var _ = Describe("Fake client", func() {
 		objOriginal := obj.DeepCopy()
 
 		obj.Spec.PodCIDR = "cidr-from-status-update"
+		obj.Annotations = map[string]string{
+			"some-annotation-key": "some-annotation-value",
+		}
+		obj.Labels = map[string]string{
+			"some-label-key": "some-label-value",
+		}
+
 		obj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
 		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1479,7 +1479,7 @@ var _ = Describe("Fake client", func() {
 		objOriginal.Status.NodeInfo.MachineID = "machine-id-from-status-update"
 		Expect(cmp.Diff(objOriginal, actual)).To(BeEmpty())
 	})
-	It("should not overwrite status fields of typed objects that have a status subresource on status update", func() {
+	It("Should only override status fields of typed objects that have a status subresource on status update", func() {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",


### PR DESCRIPTION
During updating with the status client, it is shown that the metadata/labels will come with the subresource client.  To mitigate this, updating the method to only use the old object in the tracker, will allow the status to be copied from the new object and put in the update chain to the fake client tracker. 


Resolves: https://github.com/kubernetes-sigs/controller-runtime/issues/2474


- [x] Update fake client subreresource client method update to only copy status before passing to tracker.
- [x] Include test from issue to show this is working properly  cc @berlin-ab _(cherry-picked from draft PR)_
- [x] Create test case to show other status fields do not get written over.