### PR TITLE
🐛 Default namespace only for namespaced object

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -427,7 +427,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 		byObject.Transform = defaultedConfig.Transform
 		byObject.UnsafeDisableDeepCopy = defaultedConfig.UnsafeDisableDeepCopy
 
-		if byObject.Namespaces == nil {
+		if isNamespaced && byObject.Namespaces == nil {
 			byObject.Namespaces = opts.DefaultNamespaces
 		}
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Previously `byObject.Namespaces` was always defaulted to `DefaultNamespaces` if `byObject.Namespaces` was nil independent of object is namespaced or not. This PR fixes it so  `byObject.Namespaces` is defaulted to `DefaultNamespaces` only for namespaces object.
