### PR TITLE
Draft: Test that an object is updatable after updating its status.

### DIFF
--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -142,6 +142,7 @@ type SubResourceWriter interface {
 	// Create saves the subResource object in the Kubernetes cluster. obj must be a
 	// struct pointer so that obj can be updated with the content returned by the Server.
 	Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error
+
 	// Update updates the fields corresponding to the status subresource for the
 	// given obj. obj must be a struct pointer so that obj can be updated
 	// with the content returned by the Server.


### PR DESCRIPTION
Test fails at:

```
  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc0005ac000>: 
      Operation cannot be fulfilled on nodes "node": object was modified
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Operation cannot be fulfilled on nodes \"node\": object was modified",
              Reason: "Conflict",
              Details: {Name: "node", Group: "", Kind: "nodes", UID: "", Causes: nil, RetryAfterSeconds: 0},
              Code: 409,
          },
      }
      
  occurred
  In [It] at: /Users/aberlin/workspace/controller-runtime/pkg/client/fake/client_test.go:1506 @ 09/09/23 20:52:18.056
```