### PR TITLE
:bug: Fix returning object after status update

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -403,8 +403,9 @@ func (t versionedTracker) update(gvr schema.GroupVersionResource, obj runtime.Ob
 			if err := copyStatusFrom(obj, oldObject); err != nil {
 				return fmt.Errorf("failed to copy non-status field for object with status subresouce: %w", err)
 			}
-
-			obj = oldObject.DeepCopyObject().(client.Object)
+			passedRV := accessor.GetResourceVersion()
+			reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(oldObject.DeepCopyObject()).Elem())
+			accessor.SetResourceVersion(passedRV)
 		} else { // copy status from original object
 			if err := copyStatusFrom(oldObject, obj); err != nil {
 				return fmt.Errorf("failed to copy the status for object with status subresource: %w", err)
@@ -436,14 +437,6 @@ func (t versionedTracker) update(gvr schema.GroupVersionResource, obj runtime.Ob
 	}
 	intResourceVersion++
 	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
-
-	// obtain the current obj accessor's pointer,
-	// so we can make an update on the current obj
-	currentAccessor, err := meta.Accessor(obj)
-	if err != nil {
-		return fmt.Errorf("failed to get accessor for object: %w", err)
-	}
-	currentAccessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
 
 	if !deleting && !deletionTimestampEqual(accessor, oldAccessor) {
 		return fmt.Errorf("error: Unable to edit %s: metadata.deletionTimestamp field is immutable", accessor.GetName())

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -45,6 +45,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
+const (
+	machineIDFromStatusUpdate = "machine-id-from-status-update"
+	cidrFromStatusUpdate      = "cidr-from-status-update"
+)
+
 var _ = Describe("Fake client", func() {
 	var dep *appsv1.Deployment
 	var dep2 *appsv1.Deployment
@@ -1456,7 +1461,7 @@ var _ = Describe("Fake client", func() {
 		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
 		objOriginal := obj.DeepCopy()
 
-		obj.Spec.PodCIDR = "cidr-from-status-update"
+		obj.Spec.PodCIDR = cidrFromStatusUpdate
 		obj.Annotations = map[string]string{
 			"some-annotation-key": "some-annotation-value",
 		}
@@ -1464,7 +1469,7 @@ var _ = Describe("Fake client", func() {
 			"some-label-key": "some-label-value",
 		}
 
-		obj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
@@ -1473,7 +1478,7 @@ var _ = Describe("Fake client", func() {
 		objOriginal.APIVersion = actual.APIVersion
 		objOriginal.Kind = actual.Kind
 		objOriginal.ResourceVersion = actual.ResourceVersion
-		objOriginal.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		objOriginal.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cmp.Diff(objOriginal, actual)).To(BeEmpty())
 	})
 
@@ -1494,7 +1499,7 @@ var _ = Describe("Fake client", func() {
 		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
 		expectedObj := obj.DeepCopy()
 
-		obj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
 
 		obj.Annotations = map[string]string{
@@ -1511,7 +1516,7 @@ var _ = Describe("Fake client", func() {
 		expectedObj.APIVersion = actual.APIVersion
 		expectedObj.Kind = actual.Kind
 		expectedObj.ResourceVersion = actual.ResourceVersion
-		expectedObj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		expectedObj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cmp.Diff(expectedObj, actual)).To(BeEmpty())
 	})
 
@@ -1540,8 +1545,8 @@ var _ = Describe("Fake client", func() {
 		}
 		Expect(cl.Update(context.Background(), obj)).NotTo(HaveOccurred())
 
-		obj.Spec.PodCIDR = "cidr-from-status-update"
-		obj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		obj.Spec.PodCIDR = cidrFromStatusUpdate
+		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
@@ -1550,7 +1555,7 @@ var _ = Describe("Fake client", func() {
 		expectedObj.APIVersion = actual.APIVersion
 		expectedObj.Kind = actual.Kind
 		expectedObj.ResourceVersion = actual.ResourceVersion
-		expectedObj.Status.NodeInfo.MachineID = "machine-id-from-status-update"
+		expectedObj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
 		Expect(cmp.Diff(expectedObj, actual)).To(BeEmpty())
 	})
 
@@ -1614,7 +1619,7 @@ var _ = Describe("Fake client", func() {
 		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
 		objOriginal := obj.DeepCopy()
 
-		obj.Spec.PodCIDR = "cidr-from-status-update"
+		obj.Spec.PodCIDR = cidrFromStatusUpdate
 		obj.Status.NodeInfo.MachineID = "machine-id"
 		Expect(cl.Status().Patch(context.Background(), obj, client.MergeFrom(objOriginal))).NotTo(HaveOccurred())
 

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -142,6 +142,7 @@ type SubResourceWriter interface {
 	// Create saves the subResource object in the Kubernetes cluster. obj must be a
 	// struct pointer so that obj can be updated with the content returned by the Server.
 	Create(ctx context.Context, obj Object, subResource Object, opts ...SubResourceCreateOption) error
+
 	// Update updates the fields corresponding to the status subresource for the
 	// given obj. obj must be a struct pointer so that obj can be updated
 	// with the content returned by the Server.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Prior to this, we overwrote the passed in pointer to `obj` on status update, which means that the caller can never see the updated object after the call. This changes makes us instead overwrite the value behind the pointer, so that it gets propagated back to the caller.

@berlin-ab I like this approach more, as it seems a bit simpler and keeps the changed contained to the place that causes the need for them. WDYT?

/cc @berlin-ab @troy0820 

Superseeds https://github.com/kubernetes-sigs/controller-runtime/pull/2486
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2487
