### PR TITLE
:book: Add more examples in documentation

### DIFF
--- a/pkg/builder/example_test.go
+++ b/pkg/builder/example_test.go
@@ -38,7 +38,7 @@ import (
 func ExampleBuilder_metadata_only() {
 	logf.SetLogger(zap.New())
 
-	var log = logf.Log.WithName("builder-examples")
+	log := logf.Log.WithName("builder-examples")
 
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {
@@ -95,7 +95,7 @@ func ExampleBuilder_metadata_only() {
 func ExampleBuilder() {
 	logf.SetLogger(zap.New())
 
-	var log = logf.Log.WithName("builder-examples")
+	log := logf.Log.WithName("builder-examples")
 
 	mgr, err := manager.New(config.GetConfigOrDie(), manager.Options{})
 	if err != nil {

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -192,6 +192,8 @@ func ExampleClient_patch() {
 }
 
 // This example shows how to use the client with unstructured objects to create/patch objects using Server Side Apply,
+// "k8s.io/apimachinery/pkg/runtime".DefaultUnstructuredConverter.ToUnstructured is used to convert an object into map[string]any representation,
+// which is then set as an "Object" field in *unstructured.Unstructured struct, which implements client.Object.
 func ExampleClient_apply() {
 	// Using a typed object.
 	configMap := corev1ac.ConfigMap("name", "namespace").WithData(map[string]string{"key": "value"})

--- a/pkg/handler/example_test.go
+++ b/pkg/handler/example_test.go
@@ -32,8 +32,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-var mgr manager.Manager
-var c controller.Controller
+var (
+	mgr manager.Manager
+	c   controller.Controller
+)
 
 // This example watches Pods and enqueues Requests with the Name and Namespace of the Pod from
 // the Event (i.e. change caused by a Create, Update, Delete).


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->

- Adds an example showing how to use [Server Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/) with controller-runtime client and structs from _k8s.io/client-go/applyconfigurations/*_
- Adds an example how to watch any resource and map its changes to main reconciled resource