### PR TITLE
✨ Add UserAgentID option to the manager

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -299,6 +299,16 @@ var _ = Describe("manger.Manager", func() {
 			Expect(isCustomWebhook).To(BeTrue())
 		})
 
+		It("should allow passing custom useragent id", func() {
+			m, err := New(cfg, Options{UserAgentID: "custom"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(m).NotTo(BeNil())
+
+			managerConfig := m.GetConfig()
+			Expect(managerConfig).NotTo(BeNil())
+			Expect(managerConfig.UserAgent).To(HavePrefix("custom/"))
+		})
+
 		Context("with leader election enabled", func() {
 			It("should only cancel the leader election after all runnables are done", func() {
 				m, err := New(cfg, Options{
@@ -730,25 +740,6 @@ var _ = Describe("manger.Manager", func() {
 
 				<-m.Elected()
 				wgRunnableStarted.Wait()
-			})
-
-			It("should not manipulate the provided config", func() {
-				// strip WrapTransport, cause func values are PartialEq, not Eq --
-				// specifically, for reflect.DeepEqual, for all functions F,
-				// F != nil implies F != F, which means no full equivalence relation.
-				cfg := rest.CopyConfig(cfg)
-				cfg.WrapTransport = nil
-				originalCfg := rest.CopyConfig(cfg)
-				// The options object is shared by multiple tests, copy it
-				// into our scope so we manipulate it for this testcase only
-				options := options
-				options.newResourceLock = nil
-				m, err := New(cfg, options)
-				Expect(err).NotTo(HaveOccurred())
-				for _, cb := range callbacks {
-					cb(m)
-				}
-				Expect(m.GetConfig()).To(Equal(originalCfg))
 			})
 
 			It("should stop when context is cancelled", func() {


### PR DESCRIPTION
The PR is intended to solve issue #1215, allowing passing the new `Option` to the controller-manager constructor to override the first part of the UserAgent (as it was suggested in https://github.com/kubernetes-sigs/controller-runtime/issues/1215#issuecomment-707181082)

The solution is pretty safe as it does not change the `UserAgent` if it was already set in the `rest.Config` provided, but override it only when `rest.DefaultKubernetesUserAgent()` is used (which is always `manager/<version> ...`)

Manipulation of UserAgent broke the test, initially created as part of https://github.com/kubernetes-sigs/controller-runtime/pull/1401, but the test does not make sense anymore as:
1. LeaderElectionConfig is created as the copy of `rest.Config`
2. We manipulate UserAgent always if it is empty, it was done after the original config was assigned to the `cluster.New()`.
