### PR TITLE
🌱 Add function RemoveControllerReference and HasControllerReference 

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -152,6 +152,28 @@ func RemoveOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) e
 	return nil
 }
 
+// HasControllerReference returns true if the object
+// has an owner ref with controller equal to true
+func HasControllerReference(object metav1.Object) bool {
+	owners := object.GetOwnerReferences()
+	for _, owner := range owners {
+		isTrue := owner.Controller
+		if owner.Controller != nil && *isTrue {
+			return true
+		}
+	}
+	return false
+}
+
+// RemoveControllerReference removes an owner reference where the controller
+// equals true
+func RemoveControllerReference(owner, object metav1.Object, scheme *runtime.Scheme) error {
+	if ok := HasControllerReference(object); !ok {
+		return fmt.Errorf("%T does not have a owner reference with controller equals true", object)
+	}
+	return RemoveOwnerReference(owner, object, scheme)
+}
+
 func upsertOwnerRef(ref metav1.OwnerReference, object metav1.Object) {
 	owners := object.GetOwnerReferences()
 	if idx := indexOwnerRef(owners, ref); idx == -1 {

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -195,6 +195,51 @@ var _ = Describe("Controllerutil", func() {
 			Expect(controllerutil.RemoveOwnerReference(dep2, rs, scheme.Scheme)).To(HaveOccurred())
 			Expect(rs.GetOwnerReferences()).To(HaveLen(1))
 		})
+
+		It("should return true when HasControllerReference evaluates owner reference set by SetControllerReference", func() {
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid-2"},
+			}
+			Expect(controllerutil.SetControllerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.HasControllerReference(rs)).To(BeTrue())
+		})
+
+		It("should return false when HasControllerReference evaluates owner reference set by SetOwnerReference", func() {
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid-2"},
+			}
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.HasControllerReference(rs)).To(BeFalse())
+		})
+
+		It("should error when RemoveControllerReference owner's controller is set to false", func() {
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid-2"},
+			}
+			Expect(controllerutil.SetOwnerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.RemoveControllerReference(dep, rs, scheme.Scheme)).To(HaveOccurred())
+		})
+
+		It("should not error when RemoveControllerReference owner's controller is set to true", func() {
+			rs := &appsv1.ReplicaSet{
+				ObjectMeta: metav1.ObjectMeta{},
+			}
+			dep := &extensionsv1beta1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", UID: "foo-uid-2"},
+			}
+			Expect(controllerutil.SetControllerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(controllerutil.RemoveControllerReference(dep, rs, scheme.Scheme)).ToNot(HaveOccurred())
+			Expect(rs.GetOwnerReferences()).To(BeEmpty())
+		})
 	})
 
 	Describe("SetControllerReference", func() {


### PR DESCRIPTION
- [x] Add function `RemoveControllerReference` to controllerutil
- [x] Add function `HasControllerReference` to controllerutil 
- [x] Add tests for functions 

When creating https://github.com/kubernetes-sigs/controller-runtime/pull/2462 it was discussed that to achieve the ask of the issue #2381 two functions can help remove ControllerReferences to get around the errors of it not being able to be overwritten. 

These two functions  _(and not to be confused with the original PR that allows removal of any owner reference)_, allows the caller to see if the owner reference they want to remove in fact is a "ControllerReference" _(controller = true)_

This functionality is present with finalizers and will be helpful when trying to mitigate issues with trying to overwrite the owner reference on an object. 