### PR TITLE
WIP:✨client: client.MatchingFields support multiple indexes

### DIFF
--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -247,7 +247,7 @@ func ExampleClient_deleteAllOf() {
 }
 
 // This example shows how to set up and consume a field selector over a pod's volumes' secretName field.
-func ExampleFieldIndexer_secretName() {
+func ExampleFieldIndexer_secretNameNode() {
 	// someIndexer is a FieldIndexer over a Cache
 	_ = someIndexer.IndexField(context.TODO(), &corev1.Pod{}, "spec.volumes.secret.secretName", func(o client.Object) []string {
 		var res []string
@@ -261,8 +261,20 @@ func ExampleFieldIndexer_secretName() {
 		return res
 	})
 
+	_ = someIndexer.IndexField(context.TODO(), &corev1.Pod{}, "spec.NodeName", func(o client.Object) []string {
+		nodeName := o.(*corev1.Pod).Spec.NodeName
+		if nodeName != "" {
+			return []string{nodeName}
+		}
+		return nil
+	})
+
 	// elsewhere (e.g. in your reconciler)
 	mySecretName := "someSecret" // derived from the reconcile.Request, for instance
+	myNode := "master-0"
 	var podsWithSecrets corev1.PodList
-	_ = c.List(context.Background(), &podsWithSecrets, client.MatchingFields{"spec.volumes.secret.secretName": mySecretName})
+	_ = c.List(context.Background(), &podsWithSecrets, client.MatchingFields{
+		"spec.volumes.secret.secretName": mySecretName,
+		"spec.NodeName":                  myNode,
+	})
 }

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -586,9 +586,7 @@ func (c *fakeClient) filterList(list []runtime.Object, gvk schema.GroupVersionKi
 }
 
 func (c *fakeClient) filterWithFields(list []runtime.Object, gvk schema.GroupVersionKind, fs fields.Selector) ([]runtime.Object, error) {
-	// We only allow filtering on the basis of a single field to ensure consistency with the
-	// behavior of the cache reader (which we're faking here).
-	fieldKey, fieldVal, requiresExact := selector.RequiresExactMatch(fs)
+	requires, requiresExact := selector.RequiresExactMatch(fs)
 	if !requiresExact {
 		return nil, fmt.Errorf("field selector %s is not in one of the two supported forms \"key==val\" or \"key=val\"",
 			fs)
@@ -597,15 +595,24 @@ func (c *fakeClient) filterWithFields(list []runtime.Object, gvk schema.GroupVer
 	// Field selection is mimicked via indexes, so there's no sane answer this function can give
 	// if there are no indexes registered for the GroupVersionKind of the objects in the list.
 	indexes := c.indexes[gvk]
-	if len(indexes) == 0 || indexes[fieldKey] == nil {
-		return nil, fmt.Errorf("List on GroupVersionKind %v specifies selector on field %s, but no "+
-			"index with name %s has been registered for GroupVersionKind %v", gvk, fieldKey, fieldKey, gvk)
+	for fieldKey := range requires {
+		if len(indexes) == 0 || indexes[fieldKey] == nil {
+			return nil, fmt.Errorf("List on GroupVersionKind %v specifies selector on field %s, but no "+
+				"index with name %s has been registered for GroupVersionKind %v", gvk, fieldKey, fieldKey, gvk)
+		}
 	}
 
-	indexExtractor := indexes[fieldKey]
 	filteredList := make([]runtime.Object, 0, len(list))
 	for _, obj := range list {
-		if c.objMatchesFieldSelector(obj, indexExtractor, fieldVal) {
+		ok := true
+		for fieldKey, fieldVal := range requires {
+			indexExtractor := indexes[fieldKey]
+			if !c.objMatchesFieldSelector(obj, indexExtractor, fieldVal) {
+				ok = false
+				break
+			}
+		}
+		if ok {
 			filteredList = append(filteredList, obj)
 		}
 	}

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1307,7 +1307,8 @@ var _ = Describe("Fake client", func() {
 
 		Context("client has two Indexes", func() {
 			BeforeEach(func() {
-				cl = cb.WithIndex(&appsv1.Deployment{}, "spec.strategy.type", depStrategyTypeIndexer).Build()
+				cl = cb.WithIndex(&appsv1.Deployment{}, "spec.strategy.type", depStrategyTypeIndexer).
+					WithIndex(&appsv1.Deployment{}, "spec.replicas", depReplicasIndexer).Build()
 			})
 
 			Context("behavior that doesn't use an Index", func() {
@@ -1333,14 +1334,15 @@ var _ = Describe("Fake client", func() {
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("errors when field selector uses two requirements", func() {
+				It("no error when field selector uses two requirements", func() {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.AndSelectors(
 							fields.OneTermEqualSelector("spec.replicas", "1"),
 							fields.OneTermEqualSelector("spec.strategy.type", string(appsv1.RecreateDeploymentStrategyType)),
 						)}
-					err := cl.List(context.Background(), &appsv1.DeploymentList{}, listOpts)
-					Expect(err).To(HaveOccurred())
+					list := &appsv1.DeploymentList{}
+					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(list.Items).To(ConsistOf(*dep))
 				})
 			})
 		})

--- a/pkg/internal/field/selector/utils.go
+++ b/pkg/internal/field/selector/utils.go
@@ -22,14 +22,18 @@ import (
 )
 
 // RequiresExactMatch checks if the given field selector is of the form `k=v` or `k==v`.
-func RequiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+func RequiresExactMatch(sel fields.Selector) (requires map[string]string, required bool) {
 	reqs := sel.Requirements()
-	if len(reqs) != 1 {
-		return "", "", false
+	if len(reqs) == 0 {
+		return nil, false
 	}
-	req := reqs[0]
-	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
-		return "", "", false
+
+	requires = make(map[string]string, len(reqs))
+	for _, req := range reqs {
+		if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+			return nil, false
+		}
+		requires[req.Field] = req.Value
 	}
-	return req.Field, req.Value, true
+	return requires, true
 }

--- a/pkg/internal/field/selector/utils_test.go
+++ b/pkg/internal/field/selector/utils_test.go
@@ -27,62 +27,57 @@ import (
 var _ = Describe("RequiresExactMatch function", func() {
 
 	It("Returns false when the selector matches everything", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.Everything())
+		_, requiresExactMatch := RequiresExactMatch(fields.Everything())
 		Expect(requiresExactMatch).To(BeFalse())
 	})
 
 	It("Returns false when the selector matches nothing", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.Nothing())
+		_, requiresExactMatch := RequiresExactMatch(fields.Nothing())
 		Expect(requiresExactMatch).To(BeFalse())
 	})
 
 	It("Returns false when the selector has the form key!=val", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key!=val"))
+		_, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key!=val"))
 		Expect(requiresExactMatch).To(BeFalse())
 	})
 
-	It("Returns false when the selector has the form key1==val1,key2==val2", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key1==val1,key2==val2"))
-		Expect(requiresExactMatch).To(BeFalse())
+	It("Returns true when the selector has the form key1==val1,key2==val2", func() {
+		_, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key1==val1,key2==val2"))
+		Expect(requiresExactMatch).To(BeTrue())
 	})
 
 	It("Returns true when the selector has the form key==val", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key==val"))
+		_, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key==val"))
 		Expect(requiresExactMatch).To(BeTrue())
 	})
 
 	It("Returns true when the selector has the form key=val", func() {
-		_, _, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key=val"))
+		_, requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key=val"))
 		Expect(requiresExactMatch).To(BeTrue())
 	})
 
 	It("Returns empty key and value when the selector matches everything", func() {
-		key, val, _ := RequiresExactMatch(fields.Everything())
-		Expect(key).To(Equal(""))
-		Expect(val).To(Equal(""))
+		requires, _ := RequiresExactMatch(fields.Everything())
+		Expect(requires).To(BeNil())
 	})
 
 	It("Returns empty key and value when the selector matches nothing", func() {
-		key, val, _ := RequiresExactMatch(fields.Nothing())
-		Expect(key).To(Equal(""))
-		Expect(val).To(Equal(""))
+		requires, _ := RequiresExactMatch(fields.Nothing())
+		Expect(requires).To(BeNil())
 	})
 
 	It("Returns empty key and value when the selector has the form key!=val", func() {
-		key, val, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key!=val"))
-		Expect(key).To(Equal(""))
-		Expect(val).To(Equal(""))
+		requires, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key!=val"))
+		Expect(requires).To(BeNil())
 	})
 
 	It("Returns key and value when the selector has the form key==val", func() {
-		key, val, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key==val"))
-		Expect(key).To(Equal("key"))
-		Expect(val).To(Equal("val"))
+		requires, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key==val"))
+		Expect(requires).To(HaveKeyWithValue("key", "val"))
 	})
 
 	It("Returns key and value when the selector has the form key=val", func() {
-		key, val, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key=val"))
-		Expect(key).To(Equal("key"))
-		Expect(val).To(Equal("val"))
+		requires, _ := RequiresExactMatch(fields.ParseSelectorOrDie("key=val"))
+		Expect(requires).To(HaveKeyWithValue("key", "val"))
 	})
 })


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
add support for multiple indexes when using `client.MatchingFields`

Fix https://github.com/kubernetes-sigs/controller-runtime/issues/612