### PR TITLE
✨ Add NewCache function to cache config

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -251,6 +251,8 @@ type ByObject struct {
 	UnsafeDisableDeepCopy *bool
 
 	// NewCache allows to use a custom cache creation function for the object.
+	// The Options object passed to the NewCache function is pruned to only contain
+	// the object's relevant ByObject configuration.
 	//
 	// NOTE: LOW LEVEL PRIMITIVE!
 	// Only use a custom NewCache if you know what you are doing.
@@ -322,7 +324,8 @@ func New(cfg *rest.Config, opts Options) (Cache, error) {
 
 		switch {
 		case config.NewCache != nil:
-			cache, err = config.NewCache(cfg, opts)
+			object := obj
+			cache, err = config.NewCache(cfg, byObjectOptions(object, opts, config))
 			if err != nil {
 				return nil, err
 			}
@@ -353,6 +356,13 @@ func byObjectToConfig(byObject ByObject) Config {
 		Transform:             byObject.Transform,
 		UnsafeDisableDeepCopy: byObject.UnsafeDisableDeepCopy,
 	}
+}
+
+func byObjectOptions(obj client.Object, opts Options, byObject ByObject) Options {
+	opts.ByObject = map[client.Object]ByObject{
+		obj: byObject,
+	}
+	return opts
 }
 
 type newCacheFunc func(config Config, namespace string) Cache

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -449,13 +449,27 @@ var _ = Describe("Cache with NewFunc configuration", func() {
 		opts := cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
 				&corev1.ServiceAccount{}: {
-					NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
+					UnsafeDisableDeepCopy: pointer.Bool(true),
+					NewCache: func(_ *rest.Config, opts cache.Options) (cache.Cache, error) {
+						Expect(opts.ByObject).To(HaveLen(1))
+						for obj, config := range opts.ByObject {
+							Expect(obj).To(Equal(&corev1.ServiceAccount{}))
+							Expect(config.UnsafeDisableDeepCopy).To(Equal(pointer.Bool(true)))
+						}
+
 						serviceAccountCache = true
 						return nil, nil
 					},
 				},
 				&corev1.ConfigMap{}: {
-					NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
+					Label: labels.Nothing(),
+					NewCache: func(_ *rest.Config, opts cache.Options) (cache.Cache, error) {
+						Expect(opts.ByObject).To(HaveLen(1))
+						for obj, config := range opts.ByObject {
+							Expect(obj).To(Equal(&corev1.ConfigMap{}))
+							Expect(config.Label).To(Equal(labels.Nothing()))
+						}
+
 						configMapCache = true
 						return nil, nil
 					},

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -442,6 +442,34 @@ var _ = Describe("Cache with selectors", func() {
 	})
 })
 
+var _ = Describe("Cache with NewFunc configuration", func() {
+	It("should invoke configured NewFunc functions", func() {
+		var serviceAccountCache, configMapCache bool
+
+		opts := cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.ServiceAccount{}: {
+					NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
+						serviceAccountCache = true
+						return nil, nil
+					},
+				},
+				&corev1.ConfigMap{}: {
+					NewCache: func(_ *rest.Config, _ cache.Options) (cache.Cache, error) {
+						configMapCache = true
+						return nil, nil
+					},
+				},
+			},
+		}
+
+		_, err := cache.New(cfg, opts)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serviceAccountCache).To(BeTrue())
+		Expect(configMapCache).To(BeTrue())
+	})
+})
+
 func CacheTestReaderFailOnMissingInformer(createCacheFunc func(config *rest.Config, opts cache.Options) (cache.Cache, error), opts cache.Options) {
 	Describe("Cache test with ReaderFailOnMissingInformer = true", func() {
 		var (


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

Similar to [NewCache](https://github.com/kubernetes-sigs/controller-runtime/blob/c93e2abcb28eb71fccad7dc565f0547cc07e5566/pkg/cluster/cluster.go#L118) in the `Cluster` options, this PR allows to configure a custom cache creation function per object GVK. Using a custom cache is ideally not only restricted to a global level, and using the lately introduced `ByObject` seems to be a perfect fit.
