### PR TITLE
✨ Add ListenerConfig for metrics server options

### DIFF
--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -310,7 +310,7 @@ func (s *defaultServer) createListener(ctx context.Context, log logr.Logger) (ne
 		return nil, err
 	}
 
-	return tls.NewListener(l, cfg), err
+	return tls.NewListener(l, cfg), nil
 }
 
 func (s *defaultServer) GetBindAddr() string {

--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -103,8 +103,7 @@ type Options struct {
 	TLSOpts []func(*tls.Config)
 
 	// ListenConfig contains options for listening to an address on the metric server.
-	// Note: This does not work with SecureServing=true
-	ListenConfig net.ListenConfig
+	ListenConfig *net.ListenConfig
 }
 
 // Filter is a func that is added around metrics and extra handlers on the metrics server.
@@ -253,7 +252,11 @@ func (s *defaultServer) Start(ctx context.Context) error {
 
 func (s *defaultServer) createListener(ctx context.Context, log logr.Logger) (net.Listener, error) {
 	if !s.options.SecureServing {
-		return s.options.ListenConfig.Listen(context.Background(), "tcp", s.options.BindAddress)
+		if s.options.ListenConfig == nil {
+			return net.Listen("tcp", s.options.BindAddress)
+		} else {
+			return s.options.ListenConfig.Listen(context.Background(), "tcp", s.options.BindAddress)
+		}
 	}
 
 	cfg := &tls.Config{ //nolint:gosec
@@ -306,7 +309,16 @@ func (s *defaultServer) createListener(ctx context.Context, log logr.Logger) (ne
 		cfg.Certificates = []tls.Certificate{keyPair}
 	}
 
-	return tls.Listen("tcp", s.options.BindAddress, cfg)
+	var l net.Listener
+	var err error
+
+	if s.options.ListenConfig == nil {
+		l, err = net.Listen("tcp", s.options.BindAddress)
+	} else {
+		l, err = s.options.ListenConfig.Listen(context.Background(), "tcp", s.options.BindAddress)
+	}
+
+	return tls.NewListener(l, cfg), err
 }
 
 func (s *defaultServer) GetBindAddr() string {

--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -306,6 +306,9 @@ func (s *defaultServer) createListener(ctx context.Context, log logr.Logger) (ne
 	}
 
 	l, err := s.options.ListenConfig.Listen(ctx, "tcp", s.options.BindAddress)
+	if err != nil {
+		return nil, err
+	}
 
 	return tls.NewListener(l, cfg), err
 }


### PR DESCRIPTION
The reason for this change is having the ability to set a custom ListenConfig on the metric server listener.

The reason I need (my company needs) it is that it will allow us to set unix.SO_REUSEPORT flag which works around an edge case when a port is ever leaked and you are using the host network for your controller.
