### PR TITLE
[release-0.15] :bug Revert "hasLabels and matchingLabels step on each other"

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -513,15 +513,8 @@ type MatchingLabels map[string]string
 // ApplyToList applies this configuration to the given list options.
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid reserializing this over and over?
-	if opts.LabelSelector == nil {
-		opts.LabelSelector = labels.NewSelector()
-	}
-	// If there's already a selector, we need to AND the two together.
-	noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))
-	reqs, _ := noValidSel.Requirements()
-	for _, req := range reqs {
-		opts.LabelSelector = opts.LabelSelector.Add(req)
-	}
+	sel := labels.SelectorFromValidatedSet(map[string]string(m))
+	opts.LabelSelector = sel
 }
 
 // ApplyToDeleteAllOf applies this configuration to the given an List options.
@@ -535,17 +528,14 @@ type HasLabels []string
 
 // ApplyToList applies this configuration to the given list options.
 func (m HasLabels) ApplyToList(opts *ListOptions) {
-	if opts.LabelSelector == nil {
-		opts.LabelSelector = labels.NewSelector()
-	}
-	// TODO: ignore invalid labels will result in an empty selector.
-	// This is inconsistent to the that of MatchingLabels.
+	sel := labels.NewSelector()
 	for _, label := range m {
 		r, err := labels.NewRequirement(label, selection.Exists, nil)
 		if err == nil {
-			opts.LabelSelector = opts.LabelSelector.Add(*r)
+			sel = sel.Add(*r)
 		}
 	}
+	opts.LabelSelector = sel
 }
 
 // ApplyToDeleteAllOf applies this configuration to the given an List options.

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -237,19 +237,6 @@ var _ = Describe("MatchingLabels", func() {
 		expectedErrMsg := `values[0][k]: Invalid value: "axahm2EJ8Phiephe2eixohbee9eGeiyees1thuozi1xoh0GiuH3diewi8iem7Nui": must be no more than 63 characters`
 		Expect(err.Error()).To(Equal(expectedErrMsg))
 	})
-
-	It("Should add matchingLabels to existing selector", func() {
-		listOpts := &client.ListOptions{}
-
-		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
-		matchingLabels2 := client.MatchingLabels(map[string]string{"k2": "v2"})
-
-		matchingLabels.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.String()).To(Equal("k=v"))
-
-		matchingLabels2.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,k2=v2"))
-	})
 })
 
 var _ = Describe("FieldOwner", func() {
@@ -303,37 +290,5 @@ var _ = Describe("ForceOwnership", func() {
 		t := client.ForceOwnership
 		t.ApplyToSubResourcePatch(o)
 		Expect(*o.Force).To(Equal(true))
-	})
-})
-
-var _ = Describe("HasLabels", func() {
-	It("Should produce hasLabels in given order", func() {
-		listOpts := &client.ListOptions{}
-
-		hasLabels := client.HasLabels([]string{"labelApe", "labelFox"})
-		hasLabels.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
-	})
-
-	It("Should add hasLabels to existing hasLabels selector", func() {
-		listOpts := &client.ListOptions{}
-
-		hasLabel := client.HasLabels([]string{"labelApe"})
-		hasLabel.ApplyToList(listOpts)
-
-		hasOtherLabel := client.HasLabels([]string{"labelFox"})
-		hasOtherLabel.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.String()).To(Equal("labelApe,labelFox"))
-	})
-
-	It("Should add hasLabels to existing matchingLabels", func() {
-		listOpts := &client.ListOptions{}
-
-		matchingLabels := client.MatchingLabels(map[string]string{"k": "v"})
-		matchingLabels.ApplyToList(listOpts)
-
-		hasLabel := client.HasLabels([]string{"labelApe"})
-		hasLabel.ApplyToList(listOpts)
-		Expect(listOpts.LabelSelector.String()).To(Equal("k=v,labelApe"))
 	})
 })


### PR DESCRIPTION
This reverts commit 0e372174d255599738c91c830998a5869e9b81a3.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
