### PR TITLE
:bug: fix: goroutine leak

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -409,7 +409,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, fmt.Errorf("failed to new pprof listener: %w", err)
 	}
 
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	runnables := newRunnables(options.BaseContext, errChan)
 	return &controllerManager{
 		stopProcedureEngaged:          pointer.Int64(0),


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
The `errChan` is an unbuffered channel, and if the context of the `Start` function ends, it may cause the `goroutine` writing to the `errChan` to not exit properly.

https://github.com/kubernetes-sigs/controller-runtime/blob/5771399a8ce5c84b11a543bb35f10646537602d5/pkg/manager/internal.go#L430