### PR TITLE
:running: Make client.MatchingLabels faster

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -514,7 +514,8 @@ type MatchingLabels map[string]string
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid reserializing this over and over?
 	if opts.LabelSelector == nil {
-		opts.LabelSelector = labels.NewSelector()
+		opts.LabelSelector = labels.SelectorFromValidatedSet(map[string]string(m))
+		return
 	}
 	// If there's already a selector, we need to AND the two together.
 	noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))


### PR DESCRIPTION
The 99% use-case of this is to set a selector, not to adjust an existing one. This change introduces a fastpath that does that with half the allocations and in a bit less than half the time.

The reason slowpath is slow is that for each label a requirement has to be constructed that is then appended to a slice, both of which cause allocations.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2522

@timflannagan can you confirm that this fixes your issue? It brings the performance for the case that the labelselector is only set through `MatchingLabels` back to what it originally was.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
