### PR TITLE
🌱 Bump envtest to 1.28.0

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -28,7 +28,7 @@ kb_root_dir=$tmp_root/kubebuilder
 ${hack_dir}/verify.sh
 
 # Envtest.
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.24.2"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.28.0"}
 
 header_text "installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 tmp_bin=/tmp/cr-tests-bin

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -467,7 +467,7 @@ var _ = Describe("Eventhandler", func() {
 				{
 					Name:       "foo-parent",
 					Kind:       "HorizontalPodAutoscaler",
-					APIVersion: "autoscaling/v2beta1",
+					APIVersion: "autoscaling/v2",
 				},
 			}
 			evt := event.CreateEvent{


### PR DESCRIPTION
1.24.2 has been EOL for quite some time. There are no test binaries for 1.28.1 or 1.28.2, but 1.28.0 exists.