### PR TITLE
 📖Update go version in setupenv-test README. Update release-notes link in RELEASE

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,9 +4,9 @@ The Kubernetes controller-runtime Project is released on an as-needed basis. The
 
 **Note:** Releases are done from the `release-MAJOR.MINOR` branches. For PATCH releases is not required
 to create a new branch you will just need to ensure that all big fixes are cherry-picked into the respective
-`release-MAJOR.MINOR` branch. To know more about versioning check https://semver.org/. 
+`release-MAJOR.MINOR` branch. To know more about versioning check https://semver.org/.
 
-## How to do a release 
+## How to do a release
 
 ### Create the new branch and the release tag
 
@@ -15,7 +15,7 @@ to create a new branch you will just need to ensure that all big fixes are cherr
 
 ### Now, let's generate the changelog
 
-1. Create the changelog from the new branch `release-<MAJOR.MINOR>` (`git checkout release-<MAJOR.MINOR>`). 
+1. Create the changelog from the new branch `release-<MAJOR.MINOR>` (`git checkout release-<MAJOR.MINOR>`).
 You will need to use the [kubebuilder-release-tools][kubebuilder-release-tools] to generate the notes. See [here][release-notes-generation]
 
 > **Note**
@@ -24,12 +24,12 @@ You will need to use the [kubebuilder-release-tools][kubebuilder-release-tools] 
 
 ### Draft a new release from GitHub
 
-1. Create a new tag with the correct version from the new `release-<MAJOR.MINOR>` branch 
+1. Create a new tag with the correct version from the new `release-<MAJOR.MINOR>` branch
 2. Add the changelog on it and publish. Now, the code source is released !
 
 ### Add a new Prow test the for the new branch release
 
-1. Create a new prow test under [github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/controller-runtime](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/controller-runtime) 
+1. Create a new prow test under [github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/controller-runtime](https://github.com/kubernetes/test-infra/tree/master/config/jobs/kubernetes-sigs/controller-runtime)
 for the new `release-<MAJOR.MINOR>` branch. (i.e. for the `0.11.0` release see the PR: https://github.com/kubernetes/test-infra/pull/25205)
 2. Ping the infra PR in the controller-runtime slack channel for reviews.
 
@@ -45,3 +45,7 @@ For more info, see the release page: https://github.com/kubernetes-sigs/controll
 ````
 
 2. An announcement email is sent to `kubebuilder@googlegroups.com` with the subject `[ANNOUNCE] Controller-Runtime $VERSION is released`
+
+[kubebuilder-release-tools]: https://github.com/kubernetes-sigs/kubebuilder-release-tools
+[release-notes-generation]: https://github.com/kubernetes-sigs/kubebuilder-release-tools/blob/master/README.md#release-notes-generation
+[release-process]: https://github.com/kubernetes-sigs/kubebuilder/blob/master/VERSIONING.md#releasing

--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -4,7 +4,7 @@ This is a small tool that manages binaries for envtest. It can be used to
 download new binaries, list currently installed and available ones, and
 clean up versions.
 
-To use it, just go-install it on 1.16+ (it's a separate, self-contained
+To use it, just go-install it on 1.19+ (it's a separate, self-contained
 module):
 
 ```shell
@@ -45,7 +45,7 @@ setup-envtest sideload 1.16.2 < downloaded-envtest.tar.gz
 ## Where does it put all those binaries?
 
 By default, binaries are stored in a subdirectory of an OS-specific data
-directory, as per the OS's conventions. 
+directory, as per the OS's conventions.
 
 On Linux, this is `$XDG_DATA_HOME`; on Windows, `%LocalAppData`; and on
 OSX, `~/Library/Application Support`.


### PR DESCRIPTION
- [x] Update go version on setupenv-test README to show what version is necessary to utilize the tool 
```bash
pkg/mod/go.uber.org/multierr@v1.10.0/error.go:224:20: undefined: atomic.Bool
note: module requires Go 1.19
```

Using `go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest` with go versions < 1.19 will complain that this can not be installed due to the above dependency needing 1.19.  To still be able to use latest, updating the documentation to show that 1.19 is needed and to use this tool with older versions of go, commit hashes from older versions can be used as setupenv-test does not have tags included with the releases. 

Resolves #2537 
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/2526