### PR TITLE
⚠️  RESTMapper: don't treat non-existing GroupVersions as errors

### DIFF
--- a/pkg/client/apiutil/restmapper_test.go
+++ b/pkg/client/apiutil/restmapper_test.go
@@ -18,19 +18,22 @@ package apiutil_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-
 	_ "github.com/onsi/ginkgo/v2"
 	gmg "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+	gomegatypes "github.com/onsi/gomega/types"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -303,6 +306,10 @@ func TestLazyRestMapperProvider(t *testing.T) {
 		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
 		g.Expect(err).NotTo(gmg.HaveOccurred())
 
+		// A version is specified but the group doesn't exist.
+		// For each group, we expect 1 call to the version-specific discovery endpoint:
+		// 	#1: GET https://host/apis/<group>/<version>
+
 		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID1"}, "v1")
 		g.Expect(err).To(gmg.HaveOccurred())
 		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
@@ -332,6 +339,35 @@ func TestLazyRestMapperProvider(t *testing.T) {
 		g.Expect(err).To(gmg.HaveOccurred())
 		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
 		g.Expect(crt.GetRequestCount()).To(gmg.Equal(6))
+
+		// No version is specified but the group doesn't exist.
+		// For each group, we expect 2 calls to discover all group versions:
+		// 	#1: GET https://host/api
+		// 	#2: GET https://host/apis
+
+		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID7"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(8))
+
+		_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "INVALID8"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(10))
+
+		_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "INVALID9"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(12))
+
+		_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "INVALID10"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(14))
+
+		_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "INVALID11"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(16))
+
+		_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "INVALID12"})
+		g.Expect(err).To(beNoMatchError())
+		g.Expect(crt.GetRequestCount()).To(gmg.Equal(18))
 	})
 
 	t.Run("LazyRESTMapper should return an error if a resource doesn't exist", func(t *testing.T) {
@@ -528,4 +564,36 @@ func TestLazyRestMapperProvider(t *testing.T) {
 		g.Expect(err).NotTo(gmg.HaveOccurred())
 		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("rider"))
 	})
+}
+
+func beNoMatchError() gomegatypes.GomegaMatcher {
+	return &errorMatcher{
+		checkFunc: meta.IsNoMatchError,
+		message:   "NoMatch",
+	}
+}
+
+type errorMatcher struct {
+	checkFunc func(error) bool
+	message   string
+}
+
+func (e *errorMatcher) Match(actual interface{}) (success bool, err error) {
+	if actual == nil {
+		return false, nil
+	}
+
+	actualErr, actualOk := actual.(error)
+	if !actualOk {
+		return false, fmt.Errorf("expected an error-type. got:\n%s", format.Object(actual, 1))
+	}
+
+	return e.checkFunc(actualErr), nil
+}
+
+func (e *errorMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("to be %s error", e.message))
+}
+func (e *errorMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, fmt.Sprintf("not to be %s error", e.message))
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
/kind bug

This PR fixes the new RESTMapper implementation to properly handle cases where an API Group / GroupVersion is not present in the system. Clients expect No{Kind,Resource}MatchErrors in this case.

The first commit increases the accuracy of the RESTMapper tests to verify the described expectations.
The second commit implements the actual fix.

The changes are from @timebertt PR https://github.com/kubernetes-sigs/controller-runtime/pull/2425. 
The PR #2425 is still needed as with non existing CRDs  we are getting `failed to find API group` error.
