### PR TITLE
✨ Add namespace validation

### DIFF
--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/uuid"
 	coordinationv1client "k8s.io/client-go/kubernetes/typed/coordination/v1"
@@ -123,5 +124,5 @@ func getInClusterNamespace() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("error reading namespace file: %w", err)
 	}
-	return string(namespace), nil
+	return strings.TrimSuffix(string(namespace), "\n"), nil
 }


### PR DESCRIPTION
**What does this do:**
When reading a namespace from a file, validate if the last character is '\n'

**why do we need it:**
When creating namespaces incorrectly, there can be invisible line breaks(such as echo without -n option), so validation can help prevent these human errors.

**details:**
This PR filters out errors like this;
`E1108 08:01:19.373391       1 leaderelection.go:334] error initially creating leader election record: namespaces "kube-system\n" not found`