### PR TITLE
✨ Add reconcile.ObjectReconciler

### DIFF
--- a/pkg/reconcile/reconcile.go
+++ b/pkg/reconcile/reconcile.go
@@ -19,9 +19,11 @@ package reconcile
 import (
 	"context"
 	"errors"
+	"reflect"
 	"time"
 
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Result contains the result of a Reconciler invocation.
@@ -109,6 +111,36 @@ var _ Reconciler = Func(nil)
 
 // Reconcile implements Reconciler.
 func (r Func) Reconcile(ctx context.Context, o Request) (Result, error) { return r(ctx, o) }
+
+// ObjectReconciler is a specialized version of Reconciler that acts on instances of client.Object. Each reconciliation
+// event gets the associated object from Kubernetes before passing it to Reconcile. An ObjectReconciler can be used in
+// Builder.Complete by calling AsReconciler. See Reconciler for more details.
+type ObjectReconciler[T client.Object] interface {
+	Reconcile(context.Context, T) (Result, error)
+}
+
+// AsReconciler creates a Reconciler based on the given ObjectReconciler.
+func AsReconciler[T client.Object](client client.Client, rec ObjectReconciler[T]) Reconciler {
+	return &objectReconcilerAdapter[T]{
+		objReconciler: rec,
+		client:        client,
+	}
+}
+
+type objectReconcilerAdapter[T client.Object] struct {
+	objReconciler ObjectReconciler[T]
+	client        client.Client
+}
+
+// Reconcile implements Reconciler.
+func (a *objectReconcilerAdapter[T]) Reconcile(ctx context.Context, req Request) (Result, error) {
+	o := reflect.New(reflect.TypeOf(*new(T)).Elem()).Interface().(T)
+	if err := a.client.Get(ctx, req.NamespacedName, o); err != nil {
+		return Result{}, client.IgnoreNotFound(err)
+	}
+
+	return a.objReconciler.Reconcile(ctx, o)
+}
 
 // TerminalError is an error that will not be retried but still be logged
 // and recorded in metrics.

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -151,7 +151,7 @@ var _ = Describe("reconcile", func() {
 
 			It("should Get the object and call the ObjectReconciler", func() {
 				var actual *corev1.ConfigMap
-				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
+				reconciler := reconcile.AsReconciler[*corev1.ConfigMap](testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
 						actual = cm
 						return reconcile.Result{}, nil
@@ -170,7 +170,7 @@ var _ = Describe("reconcile", func() {
 		Context("with an object that doesn't exist", func() {
 			It("should not call the ObjectReconciler", func() {
 				called := false
-				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
+				reconciler := reconcile.AsReconciler[*corev1.ConfigMap](testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
 						called = true
 						return reconcile.Result{}, nil

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -151,7 +151,7 @@ var _ = Describe("reconcile", func() {
 
 			It("should Get the object and call the ObjectReconciler", func() {
 				var actual *corev1.ConfigMap
-				reconciler := reconcile.AsReconciler[*corev1.ConfigMap](testClient, &mockObjectReconciler{
+				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
 						actual = cm
 						return reconcile.Result{}, nil
@@ -170,7 +170,7 @@ var _ = Describe("reconcile", func() {
 		Context("with an object that doesn't exist", func() {
 			It("should not call the ObjectReconciler", func() {
 				called := false
-				reconciler := reconcile.AsReconciler[*corev1.ConfigMap](testClient, &mockObjectReconciler{
+				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
 						called = true
 						return reconcile.Result{}, nil


### PR DESCRIPTION
Part of #2582.
Fixes #2221.

This PR adds a new `reconcile.ObjectReconciler` interface to eliminate the following common boilerplate.

```go
func (r *MyReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
	example := &examplev1.Example{}
	if err := r.Get(ctx, req.NamespacedName, example); err != nil {
		return ctrl.Result{}, client.IgnoreNotFound(err)
	}

	// Do business logic…
}
```

`ObjectReconciler` leverages generics to write reconcilers in terms of deserialized instances of `client.Object`. It does not replace the existing `reconcile.Reconciler` interface.

Developers can create a controller with an `ObjectReconciler` by calling the `AsReconciler` function.

```go
builder.ControllerManagedBy(manager).
	For(&corev1.ConfigMap{}).
	Complete(reconcile.AsReconciler(client, &MyObjectReconciler{}))
```