### PR TITLE
⚠️ Use limited reader in webhooks

### DIFF
--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -50,6 +50,8 @@ var admissionCodecs = serializer.NewCodecFactory(admissionScheme)
 // be at most 3MB in size. For the rest of the request, we can assume that
 // it will be less than 1MB in size. Therefore, we can set the max request
 // size to 7MB.
+// If your use case requires larger max request sizes, please
+// open an issue (https://github.com/kubernetes-sigs/controller-runtime/issues/new).
 var maxRequestSize = int64(7 * 1024 * 1024)
 
 func init() {

--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -52,7 +52,7 @@ var admissionCodecs = serializer.NewCodecFactory(admissionScheme)
 // size to 7MB.
 // If your use case requires larger max request sizes, please
 // open an issue (https://github.com/kubernetes-sigs/controller-runtime/issues/new).
-var maxRequestSize = int64(7 * 1024 * 1024)
+const maxRequestSize = int64(7 * 1024 * 1024)
 
 func init() {
 	utilruntime.Must(v1.AddToScheme(admissionScheme))

--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -83,7 +83,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if limitedReader.N <= 0 {
 		err := fmt.Errorf("request entity is too large; limit is %d bytes", maxRequestSize)
 		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request; limit reached")
-		wh.writeResponse(w, Errored(http.StatusBadRequest, err))
+		wh.writeResponse(w, Errored(http.StatusRequestEntityTooLarge, err))
 		return
 	}
 

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Admission Webhooks", func() {
 				Body:   nopCloser{Reader: rand.Reader},
 			}
 
-			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request entity is too large; limit is 3145728 bytes","code":400}}}
+			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request entity is too large; limit is 7340032 bytes","code":400}}}
 `
 			webhook.ServeHTTP(respRecorder, req)
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -19,6 +19,7 @@ package admission
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -92,6 +93,19 @@ var _ = Describe("Admission Webhooks", func() {
 			}
 
 			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request body is empty","code":400}}}
+`
+			webhook.ServeHTTP(respRecorder, req)
+			Expect(respRecorder.Body.String()).To(Equal(expected))
+		})
+
+		It("should error when given an infinite body", func() {
+			req := &http.Request{
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Method: http.MethodPost,
+				Body:   nopCloser{Reader: rand.Reader},
+			}
+
+			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request entity is too large; limit is 3145728 bytes","code":400}}}
 `
 			webhook.ServeHTTP(respRecorder, req)
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Admission Webhooks", func() {
 				Body:   nopCloser{Reader: rand.Reader},
 			}
 
-			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request entity is too large; limit is 7340032 bytes","code":400}}}
+			expected := `{"response":{"uid":"","allowed":false,"status":{"metadata":{},"message":"request entity is too large; limit is 7340032 bytes","code":413}}}
 `
 			webhook.ServeHTTP(respRecorder, req)
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/authentication/http.go
+++ b/pkg/webhook/authentication/http.go
@@ -34,6 +34,9 @@ import (
 var authenticationScheme = runtime.NewScheme()
 var authenticationCodecs = serializer.NewCodecFactory(authenticationScheme)
 
+// based on https://github.com/kubernetes/kubernetes/blob/c28c2009181fcc44c5f6b47e10e62dacf53e4da0/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+var maxRequestSize = int64(3 * 1024 * 1024)
+
 func init() {
 	utilruntime.Must(authenticationv1.AddToScheme(authenticationScheme))
 	utilruntime.Must(authenticationv1beta1.AddToScheme(authenticationScheme))
@@ -55,9 +58,16 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close()
-	body, err := io.ReadAll(r.Body)
+	limitedReader := &io.LimitedReader{R: r.Body, N: maxRequestSize}
+	body, err := io.ReadAll(limitedReader)
 	if err != nil {
 		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request")
+		wh.writeResponse(w, Errored(err))
+		return
+	}
+	if limitedReader.N <= 0 {
+		err := fmt.Errorf("request entity is too large; limit is %d bytes", maxRequestSize)
+		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request; limit reached")
 		wh.writeResponse(w, Errored(err))
 		return
 	}

--- a/pkg/webhook/authentication/http.go
+++ b/pkg/webhook/authentication/http.go
@@ -34,19 +34,12 @@ import (
 var authenticationScheme = runtime.NewScheme()
 var authenticationCodecs = serializer.NewCodecFactory(authenticationScheme)
 
-// adapted from https://github.com/kubernetes/kubernetes/blob/c28c2009181fcc44c5f6b47e10e62dacf53e4da0/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
-//
-// From https://github.com/kubernetes/apiserver/blob/d6876a0600de06fef75968c4641c64d7da499f25/pkg/server/config.go#L433-L442C5:
-//
-//	     1.5MB is the recommended client request size in byte
-//		 the etcd server should accept. See
-//		 https://github.com/etcd-io/etcd/blob/release-3.4/embed/config.go#L56.
-//		 A request body might be encoded in json, and is converted to
-//		 proto when persisted in etcd, so we allow 2x as the largest request
-//		 body size to be accepted and decoded in a write request.
-//
-// For the TokenReview request, we can assume that it too will be less than 3MB in size.
-var maxRequestSize = int64(3 * 1024 * 1024)
+// The TokenReview resource mostly contains a bearer token which
+// at most should have a few KB's of size, so we picked 1 MB to
+// have plenty of buffer.
+// If your use case requires larger max request sizes, please
+// open an issue (https://github.com/kubernetes-sigs/controller-runtime/issues/new).
+var maxRequestSize = int64(1 * 1024 * 1024)
 
 func init() {
 	utilruntime.Must(authenticationv1.AddToScheme(authenticationScheme))

--- a/pkg/webhook/authentication/http.go
+++ b/pkg/webhook/authentication/http.go
@@ -39,7 +39,7 @@ var authenticationCodecs = serializer.NewCodecFactory(authenticationScheme)
 // have plenty of buffer.
 // If your use case requires larger max request sizes, please
 // open an issue (https://github.com/kubernetes-sigs/controller-runtime/issues/new).
-var maxRequestSize = int64(1 * 1024 * 1024)
+const maxRequestSize = int64(1 * 1024 * 1024)
 
 func init() {
 	utilruntime.Must(authenticationv1.AddToScheme(authenticationScheme))

--- a/pkg/webhook/authentication/http.go
+++ b/pkg/webhook/authentication/http.go
@@ -34,7 +34,18 @@ import (
 var authenticationScheme = runtime.NewScheme()
 var authenticationCodecs = serializer.NewCodecFactory(authenticationScheme)
 
-// based on https://github.com/kubernetes/kubernetes/blob/c28c2009181fcc44c5f6b47e10e62dacf53e4da0/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+// adapted from https://github.com/kubernetes/kubernetes/blob/c28c2009181fcc44c5f6b47e10e62dacf53e4da0/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go
+//
+// From https://github.com/kubernetes/apiserver/blob/d6876a0600de06fef75968c4641c64d7da499f25/pkg/server/config.go#L433-L442C5:
+//
+//	     1.5MB is the recommended client request size in byte
+//		 the etcd server should accept. See
+//		 https://github.com/etcd-io/etcd/blob/release-3.4/embed/config.go#L56.
+//		 A request body might be encoded in json, and is converted to
+//		 proto when persisted in etcd, so we allow 2x as the largest request
+//		 body size to be accepted and decoded in a write request.
+//
+// For the TokenReview request, we can assume that it too will be less than 3MB in size.
 var maxRequestSize = int64(3 * 1024 * 1024)
 
 func init() {

--- a/pkg/webhook/authentication/http_test.go
+++ b/pkg/webhook/authentication/http_test.go
@@ -19,6 +19,7 @@ package authentication
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"fmt"
 	"io"
 	"net/http"
@@ -102,6 +103,19 @@ var _ = Describe("Authentication Webhooks", func() {
 			}
 
 			expected := `{"metadata":{"creationTimestamp":null},"spec":{},"status":{"user":{},"error":"request body is empty"}}
+`
+			webhook.ServeHTTP(respRecorder, req)
+			Expect(respRecorder.Body.String()).To(Equal(expected))
+		})
+
+		It("should error when given an infinite body", func() {
+			req := &http.Request{
+				Header: http.Header{"Content-Type": []string{"application/json"}},
+				Method: http.MethodPost,
+				Body:   nopCloser{Reader: rand.Reader},
+			}
+
+			expected := `{"metadata":{"creationTimestamp":null},"spec":{},"status":{"user":{},"error":"request entity is too large; limit is 3145728 bytes"}}
 `
 			webhook.ServeHTTP(respRecorder, req)
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/authentication/http_test.go
+++ b/pkg/webhook/authentication/http_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Authentication Webhooks", func() {
 				Body:   nopCloser{Reader: rand.Reader},
 			}
 
-			expected := `{"metadata":{"creationTimestamp":null},"spec":{},"status":{"user":{},"error":"request entity is too large; limit is 3145728 bytes"}}
+			expected := `{"metadata":{"creationTimestamp":null},"spec":{},"status":{"user":{},"error":"request entity is too large; limit is 1048576 bytes"}}
 `
 			webhook.ServeHTTP(respRecorder, req)
 			Expect(respRecorder.Body.String()).To(Equal(expected))


### PR DESCRIPTION
This PR adds a LimitedReader which prevents DOS attacks due to OOM caused by the `io.ReadAll` function.

Depends on https://github.com/kubernetes-sigs/controller-runtime/pull/2604.

Code is based on https://github.com/kubernetes/kubernetes/blob/c28c2009181fcc44c5f6b47e10e62dacf53e4da0/staging/src/k8s.io/pod-security-admission/cmd/webhook/server/server.go