### PR TITLE
:book: Fix komega godoc examples

### DIFF
--- a/pkg/envtest/komega/default.go
+++ b/pkg/envtest/komega/default.go
@@ -53,9 +53,8 @@ func List(list client.ObjectList, opts ...client.ListOption) func() error {
 // It can be used with gomega.Eventually() like this:
 //
 //	deployment := appsv1.Deployment{ ... }
-//	gomega.Eventually(k.Update(&deployment, func (o client.Object) {
+//	gomega.Eventually(k.Update(&deployment, func() {
 //	  deployment.Spec.Replicas = 3
-//	  return &deployment
 //	})).To(gomega.Succeed())
 //
 // By calling the returned function directly it can also be used as gomega.Expect(k.Update(...)()).To(...)
@@ -68,9 +67,8 @@ func Update(obj client.Object, f func(), opts ...client.UpdateOption) func() err
 // It can be used with gomega.Eventually() like this:
 //
 //	deployment := appsv1.Deployment{ ... }
-//	gomega.Eventually(k.UpdateStatus(&deployment, func (o client.Object) {
+//	gomega.Eventually(k.UpdateStatus(&deployment, func() {
 //	  deployment.Status.AvailableReplicas = 1
-//	  return &deployment
 //	})).To(gomega.Succeed())
 //
 // By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)

--- a/pkg/envtest/komega/interfaces.go
+++ b/pkg/envtest/komega/interfaces.go
@@ -42,9 +42,8 @@ type Komega interface {
 	// Update returns a function that fetches a resource, applies the provided update function and then updates the resource.
 	// It can be used with gomega.Eventually() like this:
 	//   deployment := appsv1.Deployment{ ... }
-	//   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
+	//   gomega.Eventually(k.Update(&deployment, func() {
 	//     deployment.Spec.Replicas = 3
-	//     return &deployment
 	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.Update(...)()).To(...)
 	Update(client.Object, func(), ...client.UpdateOption) func() error
@@ -52,9 +51,8 @@ type Komega interface {
 	// UpdateStatus returns a function that fetches a resource, applies the provided update function and then updates the resource's status.
 	// It can be used with gomega.Eventually() like this:
 	//   deployment := appsv1.Deployment{ ... }
-	//   gomega.Eventually(k.Update(&deployment, func (o client.Object) {
+	//   gomega.Eventually(k.Update(&deployment, func() {
 	//     deployment.Status.AvailableReplicas = 1
-	//     return &deployment
 	//   })).To(gomega.Succeed())
 	// By calling the returned function directly it can also be used as gomega.Expect(k.UpdateStatus(...)()).To(...)
 	UpdateStatus(client.Object, func(), ...client.SubResourceUpdateOption) func() error


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This fixes the komega `Update` and `UpdateStatus`  godoc examples. I wanted to use these functions in a project and got confused by the godoc (examples).