### PR TITLE
⚠️ Remove apiutil.NewDiscoveryRESTMapper, use DynamicRESTMapper by default for cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -412,7 +412,7 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 	// Construct a new Mapper if unset
 	if opts.Mapper == nil {
 		var err error
-		opts.Mapper, err = apiutil.NewDiscoveryRESTMapper(config, opts.HTTPClient)
+		opts.Mapper, err = apiutil.NewDynamicRESTMapper(config, opts.HTTPClient)
 		if err != nil {
 			return Options{}, fmt.Errorf("could not create RESTMapper from config: %w", err)
 		}

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -31,11 +31,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 )
 
 var (
@@ -58,25 +56,6 @@ func AddToProtobufScheme(addToScheme func(*runtime.Scheme) error) error {
 	protobufSchemeLock.Lock()
 	defer protobufSchemeLock.Unlock()
 	return addToScheme(protobufScheme)
-}
-
-// NewDiscoveryRESTMapper constructs a new RESTMapper based on discovery
-// information fetched by a new client with the given config.
-func NewDiscoveryRESTMapper(c *rest.Config, httpClient *http.Client) (meta.RESTMapper, error) {
-	if httpClient == nil {
-		return nil, fmt.Errorf("httpClient must not be nil, consider using rest.HTTPClientFor(c) to create a client")
-	}
-
-	// Get a mapper
-	dc, err := discovery.NewDiscoveryClientForConfigAndClient(c, httpClient)
-	if err != nil {
-		return nil, err
-	}
-	gr, err := restmapper.GetAPIGroupResources(dc)
-	if err != nil {
-		return nil, err
-	}
-	return restmapper.NewDiscoveryRESTMapper(gr), nil
 }
 
 // IsObjectNamespaced returns true if the object is namespace scoped.

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Eventhandler", func() {
 
 		httpClient, err := rest.HTTPClientFor(cfg)
 		Expect(err).ShouldNot(HaveOccurred())
-		mapper, err = apiutil.NewDiscoveryRESTMapper(cfg, httpClient)
+		mapper, err = apiutil.NewDynamicRESTMapper(cfg, httpClient)
 		Expect(err).ShouldNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
The discovery restmapper was unused except for two places that we missed (when creating a cache directly as opposed through the manager and in a test). The discovery restmapper only ever loads mappings once during startup and is unable to reload them if they change. It also isn't lazy and we don't want anyone using it.

Instead, the `DynamicRESTMapper` should be used.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
