### PR TITLE
[release-0.16] :running: Make client.MatchingLabels faster

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -514,7 +514,8 @@ type MatchingLabels map[string]string
 func (m MatchingLabels) ApplyToList(opts *ListOptions) {
 	// TODO(directxman12): can we avoid reserializing this over and over?
 	if opts.LabelSelector == nil {
-		opts.LabelSelector = labels.NewSelector()
+		opts.LabelSelector = labels.SelectorFromValidatedSet(map[string]string(m))
+		return
 	}
 	// If there's already a selector, we need to AND the two together.
 	noValidSel := labels.SelectorFromValidatedSet(map[string]string(m))


### PR DESCRIPTION
Manual cherry-pick of https://github.com/kubernetes-sigs/controller-runtime/pull/2529