### PR TITLE
✨Add flowcontrol api v1 for Kubernetes v1.29.0

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1254,6 +1254,8 @@ func inTreeResourcesWithStatus() []schema.GroupVersionKind {
 
 		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "FlowSchema"},
 		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1beta2", Kind: "PriorityLevelConfiguration"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "FlowSchema"},
+		{Group: "flowcontrol.apiserver.k8s.io", Version: "v1", Kind: "PriorityLevelConfiguration"},
 	}
 }
 


### PR DESCRIPTION
Kubernetes released [v1.29.0](https://kubernetes.io/blog/2023/12/13/kubernetes-v1-29-release/#removal-of-the-v1beta2-flow-control-api-group) and with that release was the deprecation and removal of flowcontrol v1beta2.  

This PR changes the fake client to not serve that for v1.29.0 when controller-runtime v0.17 gets released 

- [x] Change v1beta2 => v1 in flowcontrol in `inTreeResourcesWithStatus()` function
