### PR TITLE
:bug: CreateOrPatch fails to update status when creating object

### DIFF
--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -834,7 +834,7 @@ var _ = Describe("Controllerutil", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("returning OperationResultUpdatedStatus")
-			Expect(op).To(BeEquivalentTo(controllerutil.OperationResultCreated))
+			Expect(op).To(BeEquivalentTo(controllerutil.OperationResultCreatedStatus))
 
 			By("setting the spec")
 			Expect(*deploy.Spec.Replicas).To(Equal(replicas))


### PR DESCRIPTION
The `CreateOrPatch` code directly exits after creating an object, it does not consider whether the status was modified or not.
This means that any change made to the status will be discarded.

Since the code correctly takes care of the status in the resource update case, I’ve updated the code to also do it in the create code path. I’ve tried to re-use as much as possible the existing code.

I’ve introduced a new operation result value (`OperationResultCreatedStatus` to indicate an object was created and its status updated as well) but we might want to hold on that since that could create issues with existing users of the method and keep returning the `OperationResultCreated` code to maintain backward compatibility.

I also included a non regression test to validate the change is working as expected.

Fixes #2627