### PR TITLE
:warning: Deprecate admission.Validator and admission.Defaulter

### DIFF
--- a/pkg/builder/example_webhook_test.go
+++ b/pkg/builder/example_webhook_test.go
@@ -24,15 +24,9 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	examplegroup "sigs.k8s.io/controller-runtime/examples/crd/pkg"
 )
-
-// examplegroup.ChaosPod has implemented both admission.Defaulter and
-// admission.Validator interfaces.
-var _ admission.Defaulter = &examplegroup.ChaosPod{}
-var _ admission.Validator = &examplegroup.ChaosPod{}
 
 // This example use webhook builder to create a simple webhook that is managed
 // by a manager for CRD ChaosPod. And then start the manager.

--- a/pkg/webhook/admission/defaulter.go
+++ b/pkg/webhook/admission/defaulter.go
@@ -27,12 +27,14 @@ import (
 )
 
 // Defaulter defines functions for setting defaults on resources.
+// Deprecated: Ue CustomDefaulter instead.
 type Defaulter interface {
 	runtime.Object
 	Default()
 }
 
 // DefaultingWebhookFor creates a new Webhook for Defaulting the provided type.
+// Deprecated: Use WithCustomDefaulter instead.
 func DefaultingWebhookFor(scheme *runtime.Scheme, defaulter Defaulter) *Webhook {
 	return &Webhook{
 		Handler: &mutatingHandler{defaulter: defaulter, decoder: NewDecoder(scheme)},

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -33,6 +33,7 @@ type Warnings []string
 // Validator defines functions for validating an operation.
 // The custom resource kind which implements this interface can validate itself.
 // To validate the custom resource with another specific struct, use CustomValidator instead.
+// Deprecated: Use CustomValidator instead.
 type Validator interface {
 	runtime.Object
 
@@ -53,6 +54,7 @@ type Validator interface {
 }
 
 // ValidatingWebhookFor creates a new Webhook for validating the provided type.
+// Deprecated: Use WithCustomValidator instead.
 func ValidatingWebhookFor(scheme *runtime.Scheme, validator Validator) *Webhook {
 	return &Webhook{
 		Handler: &validatingHandler{validator: validator, decoder: NewDecoder(scheme)},

--- a/pkg/webhook/admission/validator_custom.go
+++ b/pkg/webhook/admission/validator_custom.go
@@ -30,7 +30,6 @@ import (
 // CustomValidator defines functions for validating an operation.
 // The object to be validated is passed into methods as a parameter.
 type CustomValidator interface {
-
 	// ValidateCreate validates the object on creation.
 	// The optional warnings will be added to the response as warning messages.
 	// Return an error if the object is invalid.

--- a/pkg/webhook/alias.go
+++ b/pkg/webhook/alias.go
@@ -24,9 +24,11 @@ import (
 // define some aliases for common bits of the webhook functionality
 
 // Defaulter defines functions for setting defaults on resources.
+// Deprecated: Use CustomDefaulter instead.
 type Defaulter = admission.Defaulter
 
 // Validator defines functions for validating an operation.
+// Deprecated: Use CustomValidator instead.
 type Validator = admission.Validator
 
 // CustomDefaulter defines functions for setting defaults on resources.


### PR DESCRIPTION
`admission.Validator/Defaulter` require to import controller-runtime into api packages. This is not recommended, as api packages should themselves not have any dependencies except to other api packages in order to make importing them easy without dependency issues and possibly incompatibilities.

This change marks the two as deprecated. We are not going to remove them yet to give folks some time to migrate off them.

Closes https://github.com/kubernetes-sigs/controller-runtime/issues/2596
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
