### PR TITLE
:seedling: WaitForDefaultNamespace while starting up envtest

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -17,15 +17,20 @@ limitations under the License.
 package envtest
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
@@ -265,6 +270,12 @@ func (te *Environment) Start() (*rest.Config, error) {
 		te.Scheme = scheme.Scheme
 	}
 
+	// If we are bringing etcd up for the first time, it can take some time for the
+	// default namespace to actually be created and seen as available to the apiserver
+	if err := te.waitForDefaultNamespace(te.Config); err != nil {
+		return nil, fmt.Errorf("default namespace didn't register within deadline: %w", err)
+	}
+
 	// Call PrepWithoutInstalling to setup certificates first
 	// and have them available to patch CRD conversion webhook as well.
 	if err := te.WebhookInstallOptions.PrepWithoutInstalling(); err != nil {
@@ -320,6 +331,20 @@ func (te *Environment) startControlPlane() error {
 		return fmt.Errorf("failed to start the controlplane. retried %d times: %w", numTries, err)
 	}
 	return nil
+}
+
+func (te *Environment) waitForDefaultNamespace(config *rest.Config) error {
+	cs, err := client.New(config, client.Options{})
+	if err != nil {
+		return fmt.Errorf("unable to create client: %w", err)
+	}
+	// It shouldn't take longer than 5s for the default namespace to be brought up in etcd
+	return wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*500, time.Second*5, true, func(ctx context.Context) (bool, error) {
+		if err = cs.Get(ctx, types.NamespacedName{Name: "default"}, &corev1.Namespace{}); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		return true, nil
+	})
 }
 
 func (te *Environment) defaultTimeouts() error {

--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -339,7 +339,7 @@ func (te *Environment) waitForDefaultNamespace(config *rest.Config) error {
 		return fmt.Errorf("unable to create client: %w", err)
 	}
 	// It shouldn't take longer than 5s for the default namespace to be brought up in etcd
-	return wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*500, time.Second*5, true, func(ctx context.Context) (bool, error) {
+	return wait.PollUntilContextTimeout(context.TODO(), time.Millisecond*50, time.Second*5, true, func(ctx context.Context) (bool, error) {
 		if err = cs.Get(ctx, types.NamespacedName{Name: "default"}, &corev1.Namespace{}); err != nil {
 			return false, nil //nolint:nilerr
 		}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes #2626

This change adds a `waitForDefaultNamespace` call which polls the apiserver for the existence of the default namespace immediately after control plane startup. This is needed because we've seen that there can be flakes when leveraging `envtest` if you expect the `default` namespace to be there immediately after startup but the namespace hasn't actually propagated so that the apiserver can see it. 