### PR TITLE
✨ Add support for startup probes

### DIFF
--- a/designs/component-config.md
+++ b/designs/component-config.md
@@ -1,7 +1,7 @@
 # ComponentConfig Controller Runtime Support
 Author: @christopherhein
 
-Last Updated on: 03/02/2020
+Last Updated on: 31/01/2024
 
 ## Table of Contents
 
@@ -91,6 +91,7 @@ type ManagerConfiguration interface {
 
 	GetReadinessEndpointName() string
 	GetLivenessEndpointName() string
+	GetStartupEndpointName() string
 
 	GetPort() int
 	GetHost() string
@@ -161,6 +162,7 @@ type ControllerManagerConfigurationHealth struct {
 
 	ReadinessEndpointName string `json:"readinessEndpointName,omitempty"`
 	LivenessEndpointName  string `json:"livenessEndpointName,omitempty"`
+	StartupEndpointName  string `json:"startupEndpointName,omitempty"`
 }
 ```
 

--- a/designs/move-cluster-specific-code-out-of-manager.md
+++ b/designs/move-cluster-specific-code-out-of-manager.md
@@ -116,6 +116,9 @@ type Manager interface {
 	// AddReadyzCheck allows you to add Readyz checker
 	AddReadyzCheck(name string, check healthz.Checker) error
 
+	// AddStartzCheck allows you to add Startz checker
+	AddStartzCheck(name string, check healthz.Checker) error
+
 	// Start starts all registered Controllers and blocks until the Stop channel is closed.
 	// Returns an error if there is an error starting any controller.
 	// If LeaderElection is used, the binary must be exited immediately after this returns,

--- a/pkg/config/v1alpha1/types.go
+++ b/pkg/config/v1alpha1/types.go
@@ -135,6 +135,10 @@ type ControllerHealth struct {
 	// LivenessEndpointName, defaults to "healthz"
 	// +optional
 	LivenessEndpointName string `json:"livenessEndpointName,omitempty"`
+
+	// StartupEndpointName, defaults to "startz"
+	// +optional
+	StartupEndpointName string `json:"startupEndpointName,omitempty"`
 }
 
 // ControllerWebhook defines the webhook server for the controller.

--- a/pkg/healthz/doc.go
+++ b/pkg/healthz/doc.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package healthz contains helpers from supporting liveness and readiness endpoints.
-// (often referred to as healthz and readyz, respectively).
+// Package healthz contains helpers from supporting liveness, readiness and startup endpoints.
+// (often referred to as healthz, readyz and startz, respectively).
 //
 // This package draws heavily from the apiserver's healthz package
 // ( https://github.com/kubernetes/apiserver/tree/master/pkg/server/healthz )

--- a/pkg/manager/internal/integration/manager_test.go
+++ b/pkg/manager/internal/integration/manager_test.go
@@ -158,6 +158,7 @@ var _ = Describe("manger.Manager Start", func() {
 		// Configure health probes.
 		Expect(mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker())).To(Succeed())
 		Expect(mgr.AddHealthzCheck("webhook", mgr.GetWebhookServer().StartedChecker())).To(Succeed())
+		Expect(mgr.AddStartzCheck("webhook", mgr.GetWebhookServer().StartedChecker())).To(Succeed())
 
 		// Set up Driver reconciler (using v2).
 		driverReconciler := &DriverReconciler{

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -73,6 +73,9 @@ type Manager interface {
 	// AddReadyzCheck allows you to add Readyz checker
 	AddReadyzCheck(name string, check healthz.Checker) error
 
+	// AddStartzCheck allows you to add Startz checker
+	AddStartzCheck(name string, check healthz.Checker) error
+
 	// Start starts all registered Controllers and blocks until the context is cancelled.
 	// Returns an error if there is an error starting any controller.
 	//
@@ -227,6 +230,9 @@ type Options struct {
 
 	// Liveness probe endpoint name, defaults to "healthz"
 	LivenessEndpointName string
+
+	// Startup probe endpoint name, defaults to "healthz"
+	StartupEndpointName string
 
 	// PprofBindAddress is the TCP address that the controller should bind to
 	// for serving pprof.
@@ -430,6 +436,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		healthProbeListener:           healthProbeListener,
 		readinessEndpointName:         options.ReadinessEndpointName,
 		livenessEndpointName:          options.LivenessEndpointName,
+		startupEndpointName:           options.StartupEndpointName,
 		pprofListener:                 pprofListener,
 		gracefulShutdownTimeout:       *options.GracefulShutdownTimeout,
 		internalProceduresStop:        make(chan struct{}),
@@ -478,6 +485,10 @@ func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options,
 
 	if o.LivenessEndpointName == "" && newObj.Health.LivenessEndpointName != "" {
 		o.LivenessEndpointName = newObj.Health.LivenessEndpointName
+	}
+
+	if o.StartupEndpointName == "" && newObj.Health.StartupEndpointName != "" {
+		o.StartupEndpointName = newObj.Health.StartupEndpointName
 	}
 
 	if o.WebhookServer == nil {
@@ -638,6 +649,10 @@ func setOptionsDefaults(options Options) Options {
 
 	if options.LivenessEndpointName == "" {
 		options.LivenessEndpointName = defaultLivenessEndpoint
+	}
+
+	if options.StartupEndpointName == "" {
+		options.StartupEndpointName = defaultStartupEndpoint
 	}
 
 	if options.newHealthProbeListener == nil {


### PR DESCRIPTION
This PR address this issue: https://github.com/kubernetes-sigs/controller-runtime/issues/2644, including the support for a separate endpoint for startup probe, defined in [k8s docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). Current code only support readiness and liveness probes, but doesn't include support for startup probe.