### PR TITLE
✨ Add a separate registry for workqueue metrics

### DIFF
--- a/pkg/metrics/workqueue.go
+++ b/pkg/metrics/workqueue.go
@@ -87,14 +87,18 @@ var (
 	}, []string{"name"})
 )
 
+var WorkqueueRegistry = prometheus.NewRegistry()
+
 func init() {
-	Registry.MustRegister(depth)
-	Registry.MustRegister(adds)
-	Registry.MustRegister(latency)
-	Registry.MustRegister(workDuration)
-	Registry.MustRegister(unfinished)
-	Registry.MustRegister(longestRunningProcessor)
-	Registry.MustRegister(retries)
+	WorkqueueRegistry.MustRegister(depth)
+	WorkqueueRegistry.MustRegister(adds)
+	WorkqueueRegistry.MustRegister(latency)
+	WorkqueueRegistry.MustRegister(workDuration)
+	WorkqueueRegistry.MustRegister(unfinished)
+	WorkqueueRegistry.MustRegister(longestRunningProcessor)
+	WorkqueueRegistry.MustRegister(retries)
+
+	Registry.Register(WorkqueueRegistry)
 
 	workqueue.SetProvider(workqueueMetricsProvider{})
 }


### PR DESCRIPTION
This PR addresses #2670 

A separate registry has been created for work queue metrics, so that we can import just this registry directly as `metrics.WorkqueueRegistry` without getting loads of other unrelated metrics.
This retains the previous behaviour as all the metrics are still available in the main `Registry`.
