### PR TITLE
✨ Allow users to create custom registries

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -84,3 +84,12 @@ func init() {
 		collectors.NewGoCollector(),
 	)
 }
+
+func RegisterReconciliationMetrics(customRegistry metrics.RegistererGatherer) {
+	customRegistry.MustRegister(ReconcileTotal,
+		ReconcileErrors,
+		TerminalReconcileErrors,
+		ReconcileTime,
+		WorkerCount,
+		ActiveWorkers)
+}

--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -85,11 +85,14 @@ func init() {
 	)
 }
 
+// register the metrics with the passed registry
 func RegisterReconciliationMetrics(customRegistry metrics.RegistererGatherer) {
-	customRegistry.MustRegister(ReconcileTotal,
+	customRegistry.MustRegister(
+		ReconcileTotal,
 		ReconcileErrors,
 		TerminalReconcileErrors,
 		ReconcileTime,
 		WorkerCount,
-		ActiveWorkers)
+		ActiveWorkers,
+	)
 }

--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -43,6 +43,11 @@ func init() {
 	registerClientMetrics()
 }
 
+// register the metrics with the passed registry
+func RegisterClientMetrics(customRegistry RegistererGatherer) {
+	customRegistry.MustRegister(requestResult)
+}
+
 // registerClientMetrics sets up the client latency metrics from client-go.
 func registerClientMetrics() {
 	// register the metrics with our registry

--- a/pkg/metrics/leaderelection.go
+++ b/pkg/metrics/leaderelection.go
@@ -21,6 +21,11 @@ func init() {
 	leaderelection.SetProvider(leaderelectionMetricsProvider{})
 }
 
+// register the metrics with the passed registry
+func RegisterLeaderElection(customRegistry RegistererGatherer) {
+	customRegistry.MustRegister(leaderGauge)
+}
+
 type leaderelectionMetricsProvider struct{}
 
 func (leaderelectionMetricsProvider) NewLeaderMetric() leaderelection.SwitchMetric {

--- a/pkg/metrics/workqueue.go
+++ b/pkg/metrics/workqueue.go
@@ -101,7 +101,15 @@ func init() {
 
 // register the metrics with the passed registry
 func RegisterWorkqueueMetrics(customRegistry RegistererGatherer) {
-	customRegistry.MustRegister(depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries)
+	customRegistry.MustRegister(
+		depth,
+		adds,
+		latency,
+		workDuration,
+		unfinished,
+		longestRunningProcessor,
+		retries,
+	)
 }
 
 type workqueueMetricsProvider struct{}

--- a/pkg/metrics/workqueue.go
+++ b/pkg/metrics/workqueue.go
@@ -99,6 +99,11 @@ func init() {
 	workqueue.SetProvider(workqueueMetricsProvider{})
 }
 
+// register the metrics with the passed registry
+func RegisterWorkqueueMetrics(customRegistry RegistererGatherer) {
+	customRegistry.MustRegister(depth, adds, latency, workDuration, unfinished, longestRunningProcessor, retries)
+}
+
 type workqueueMetricsProvider struct{}
 
 func (workqueueMetricsProvider) NewDepthMetric(name string) workqueue.GaugeMetric {

--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -63,6 +63,11 @@ func init() {
 	metrics.Registry.MustRegister(RequestLatency, RequestTotal, RequestInFlight)
 }
 
+// register the metrics with the passed registry
+func RegisterRequestMetrics(customRegistry metrics.RegistererGatherer) {
+	customRegistry.MustRegister(RequestLatency, RequestTotal, RequestInFlight)
+}
+
 // InstrumentedHook adds some instrumentation on top of the given webhook.
 func InstrumentedHook(path string, hookRaw http.Handler) http.Handler {
 	lbl := prometheus.Labels{"webhook": path}

--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -65,7 +65,11 @@ func init() {
 
 // register the metrics with the passed registry
 func RegisterRequestMetrics(customRegistry metrics.RegistererGatherer) {
-	customRegistry.MustRegister(RequestLatency, RequestTotal, RequestInFlight)
+	customRegistry.MustRegister(
+		RequestLatency,
+		RequestTotal,
+		RequestInFlight,
+	)
 }
 
 // InstrumentedHook adds some instrumentation on top of the given webhook.


### PR DESCRIPTION
This PR addresses https://github.com/kubernetes-sigs/controller-runtime/issues/2670

Currently, when users import the `Registry` that the controller-runtime provides, they get a whole lot of metrics which might not be relevant to them.
This PR aims at allowing users to pass a custom registry of their own and register only those metrics that are relevant.

Thus if a user needs only the work queue and controller metrics, they just need to do:
```
customRegistry := prometheus.NewRegistry()
metrics.RegisterWorkqueueMetrics(customRegistry)
metrics.RegisterReconciliationMetrics(customRegistry)
```