### PR TITLE
:bug: Fakeclient: Do not consider an apply patch to be a strategic merge patch

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -947,7 +947,7 @@ func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (ru
 		if err := json.Unmarshal(modified, obj); err != nil {
 			return nil, err
 		}
-	case types.StrategicMergePatchType, types.ApplyPatchType:
+	case types.StrategicMergePatchType:
 		mergedByte, err := strategicpatch.StrategicMergePatch(old, action.GetPatch(), obj)
 		if err != nil {
 			return nil, err
@@ -955,8 +955,10 @@ func dryPatch(action testing.PatchActionImpl, tracker testing.ObjectTracker) (ru
 		if err = json.Unmarshal(mergedByte, obj); err != nil {
 			return nil, err
 		}
+	case types.ApplyPatchType:
+		return nil, errors.New("apply patches are not supported in the fake client. Follow https://github.com/kubernetes/kubernetes/issues/115598 for the current status")
 	default:
-		return nil, fmt.Errorf("PatchType is not supported")
+		return nil, fmt.Errorf("%s PatchType is not supported", action.GetPatchType())
 	}
 	return obj, nil
 }

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -359,6 +359,26 @@ var _ = Describe("Fake client", func() {
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
+		It("should reject apply patches, they are not supported in the fake client", func() {
+			By("Creating a new configmap")
+			cm := &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-test-cm",
+					Namespace: "ns2",
+				},
+			}
+			err := cl.Create(context.Background(), cm)
+			Expect(err).ToNot(HaveOccurred())
+
+			cm.Data = map[string]string{"foo": "bar"}
+			err = cl.Patch(context.Background(), cm, client.Apply, client.ForceOwnership)
+			Expect(err).To(MatchError(ContainSubstring("apply patches are not supported in the fake client")))
+		})
+
 		It("should be able to Create", func() {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{


### PR DESCRIPTION
The fakeclient currently considers an apply patch to be a strategic merge patch. This is completely wrong, those are different things and apply patches are not supported in the fakeclient, because in order to support them it would need the entire SSA logic which isn't implemented in upstream yet.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
