### PR TITLE
⚠Only allow sources to start once

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -79,7 +79,7 @@ var _ = Describe("controller.Controller", func() {
 
 			ctx, cancel := context.WithCancel(context.Background())
 			watchChan := make(chan event.GenericEvent, 1)
-			watch := source.Channel(watchChan, &handler.EnqueueRequestForObject{})
+			watch := source.Channel(source.NewChannelBroadcaster(watchChan), &handler.EnqueueRequestForObject{})
 			watchChan <- event.GenericEvent{Object: &corev1.Pod{}}
 
 			reconcileStarted := make(chan struct{})

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -227,7 +227,7 @@ var _ = Describe("controller", func() {
 			}
 
 			ins := source.Channel(
-				ch,
+				source.NewChannelBroadcaster(ch),
 				handler.Funcs{
 					GenericFunc: func(ctx context.Context, evt event.GenericEvent, q workqueue.RateLimitingInterface) {
 						defer GinkgoRecover()
@@ -248,7 +248,7 @@ var _ = Describe("controller", func() {
 			<-processed
 		})
 
-		It("should error when channel source is not specified", func() {
+		It("should error when ChannelBroadcaster is not specified", func() {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -257,7 +257,7 @@ var _ = Describe("controller", func() {
 
 			e := ctrl.Start(ctx)
 			Expect(e).To(HaveOccurred())
-			Expect(e.Error()).To(ContainSubstring("must specify Channel.Source"))
+			Expect(e.Error()).To(ContainSubstring("must create Channel with a non-nil broadcaster"))
 		})
 
 		It("should call Start on sources with the appropriate EventHandler, Queue, and Predicates", func() {

--- a/pkg/source/example_test.go
+++ b/pkg/source/example_test.go
@@ -44,7 +44,7 @@ func ExampleChannel() {
 
 	err := ctrl.Watch(
 		source.Channel(
-			events,
+			source.NewChannelBroadcaster(events),
 			&handler.EnqueueRequestForObject{},
 		),
 	)

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -202,7 +202,7 @@ eventloop:
 // NewChannelBroadcaster creates a new ChannelBroadcaster for the given channel.
 // A ChannelBroadcaster is a wrapper around a channel that allows multiple listeners to all
 // receive the events from the channel.
-func NewChannelBroadcaster[T any](source <-chan event.TypedGenericEvent[T]) *channelBroadcaster[T] {
+func NewChannelBroadcaster[T any](source <-chan event.TypedGenericEvent[T]) *channelBroadcaster[T] { //nolint:revive
 	return &channelBroadcaster[T]{
 		source: source,
 	}

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -191,13 +191,13 @@ var _ = Describe("Source", func() {
 			instance := source.Kind[client.Object](ic, nil, nil)
 			err := instance.Start(ctx, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil object"))
+			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil type"))
 		})
 		It("should return an error from Start if a handler was not provided", func() {
 			instance := source.Kind(ic, &corev1.Pod{}, nil)
 			err := instance.Start(ctx, nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("must create Kind with non-nil handler"))
+			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil handler"))
 		})
 
 		It("should return an error if syncing fails", func() {
@@ -295,7 +295,7 @@ var _ = Describe("Source", func() {
 
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := source.Channel(
-					ch,
+					source.NewChannelBroadcaster(ch),
 					handler.Funcs{
 						CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
@@ -337,7 +337,7 @@ var _ = Describe("Source", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				// Add a handler to get distribution blocked
 				instance := source.Channel(
-					ch,
+					source.NewChannelBroadcaster(ch),
 					handler.Funcs{
 						CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
@@ -395,7 +395,7 @@ var _ = Describe("Source", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				// Add a handler to get distribution blocked
 				instance := source.Channel(
-					ch,
+					source.NewChannelBroadcaster(ch),
 					handler.Funcs{
 						CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
@@ -438,7 +438,7 @@ var _ = Describe("Source", func() {
 				processed := make(chan struct{})
 				defer close(processed)
 				src := source.Channel(
-					ch,
+					source.NewChannelBroadcaster(ch),
 					handler.Funcs{
 						CreateFunc: func(context.Context, event.CreateEvent, workqueue.RateLimitingInterface) {
 							defer GinkgoRecover()
@@ -467,11 +467,11 @@ var _ = Describe("Source", func() {
 				Eventually(processed).Should(Receive())
 				Consistently(processed).ShouldNot(Receive())
 			})
-			It("should get error if no source specified", func() {
+			It("should get error if no Broadcaster specified", func() {
 				q := workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "test")
 				instance := source.Channel[string](nil, nil /*no source specified*/)
 				err := instance.Start(ctx, q)
-				Expect(err).To(Equal(fmt.Errorf("must specify Channel.Source")))
+				Expect(err).To(Equal(fmt.Errorf("must create Channel with a non-nil broadcaster")))
 			})
 		})
 	})


### PR DESCRIPTION
Currently, only the Informer and Channel source can be started more than once (Start function can be called twice on same object).
I do believe however that this pattern is flawed, each source should only be started once, so that the context passed to that Start function is only used to stop that one instance from running and all the properties in the source belong to that single instance. The Channel source, for example, currently stops all sources that were started from the same instance when the first context passed to Start gets canceled (see https://github.com/kubernetes-sigs/controller-runtime/pull/2686#discussion_r1575306403).

For the Channel source, allowing the source to start only once, requires the API to be altered, since we want to make it possible to listen to the same channel using multiple Channel sources (matching the current behavior). This requires a new Channel Broadcaster to be introduced.