### PR TITLE
🌱 Make event handler type aware

### DIFF
--- a/pkg/internal/source/event_handler.go
+++ b/pkg/internal/source/event_handler.go
@@ -33,8 +33,8 @@ import (
 var log = logf.RuntimeLog.WithName("source").WithName("EventHandler")
 
 // NewEventHandler creates a new EventHandler.
-func NewEventHandler(ctx context.Context, queue workqueue.RateLimitingInterface, handler handler.EventHandler, predicates []predicate.Predicate) *EventHandler {
-	return &EventHandler{
+func NewEventHandler[T client.Object](ctx context.Context, queue workqueue.RateLimitingInterface, handler handler.EventHandler, predicates []predicate.Predicate) *EventHandler[T] {
+	return &EventHandler[T]{
 		ctx:        ctx,
 		handler:    handler,
 		queue:      queue,
@@ -43,7 +43,7 @@ func NewEventHandler(ctx context.Context, queue workqueue.RateLimitingInterface,
 }
 
 // EventHandler adapts a handler.EventHandler interface to a cache.ResourceEventHandler interface.
-type EventHandler struct {
+type EventHandler[T client.Object] struct {
 	// ctx stores the context that created the event handler
 	// that is used to propagate cancellation signals to each handler function.
 	ctx context.Context
@@ -55,7 +55,7 @@ type EventHandler struct {
 
 // HandlerFuncs converts EventHandler to a ResourceEventHandlerFuncs
 // TODO: switch to ResourceEventHandlerDetailedFuncs with client-go 1.27
-func (e *EventHandler) HandlerFuncs() cache.ResourceEventHandlerFuncs {
+func (e *EventHandler[T]) HandlerFuncs() cache.ResourceEventHandlerFuncs {
 	return cache.ResourceEventHandlerFuncs{
 		AddFunc:    e.OnAdd,
 		UpdateFunc: e.OnUpdate,
@@ -64,11 +64,11 @@ func (e *EventHandler) HandlerFuncs() cache.ResourceEventHandlerFuncs {
 }
 
 // OnAdd creates CreateEvent and calls Create on EventHandler.
-func (e *EventHandler) OnAdd(obj interface{}) {
+func (e *EventHandler[T]) OnAdd(obj interface{}) {
 	c := event.CreateEvent{}
 
 	// Pull Object out of the object
-	if o, ok := obj.(client.Object); ok {
+	if o, ok := obj.(T); ok {
 		c.Object = o
 	} else {
 		log.Error(nil, "OnAdd missing Object",
@@ -89,10 +89,10 @@ func (e *EventHandler) OnAdd(obj interface{}) {
 }
 
 // OnUpdate creates UpdateEvent and calls Update on EventHandler.
-func (e *EventHandler) OnUpdate(oldObj, newObj interface{}) {
+func (e *EventHandler[T]) OnUpdate(oldObj, newObj interface{}) {
 	u := event.UpdateEvent{}
 
-	if o, ok := oldObj.(client.Object); ok {
+	if o, ok := oldObj.(T); ok {
 		u.ObjectOld = o
 	} else {
 		log.Error(nil, "OnUpdate missing ObjectOld",
@@ -101,7 +101,7 @@ func (e *EventHandler) OnUpdate(oldObj, newObj interface{}) {
 	}
 
 	// Pull Object out of the object
-	if o, ok := newObj.(client.Object); ok {
+	if o, ok := newObj.(T); ok {
 		u.ObjectNew = o
 	} else {
 		log.Error(nil, "OnUpdate missing ObjectNew",
@@ -122,7 +122,7 @@ func (e *EventHandler) OnUpdate(oldObj, newObj interface{}) {
 }
 
 // OnDelete creates DeleteEvent and calls Delete on EventHandler.
-func (e *EventHandler) OnDelete(obj interface{}) {
+func (e *EventHandler[T]) OnDelete(obj interface{}) {
 	d := event.DeleteEvent{}
 
 	// Deal with tombstone events by pulling the object out.  Tombstone events wrap the object in a
@@ -131,7 +131,7 @@ func (e *EventHandler) OnDelete(obj interface{}) {
 	// This should never happen if we aren't missing events, which we have concluded that we are not
 	// and made decisions off of this belief.  Maybe this shouldn't be here?
 	var ok bool
-	if _, ok = obj.(client.Object); !ok {
+	if _, ok = obj.(T); !ok {
 		// If the object doesn't have Metadata, assume it is a tombstone object of type DeletedFinalStateUnknown
 		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
 		if !ok {
@@ -149,7 +149,7 @@ func (e *EventHandler) OnDelete(obj interface{}) {
 	}
 
 	// Pull Object out of the object
-	if o, ok := obj.(client.Object); ok {
+	if o, ok := obj.(T); ok {
 		d.Object = o
 	} else {
 		log.Error(nil, "OnDelete missing Object",

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -59,7 +59,12 @@ type SyncingSource interface {
 
 // Kind creates a KindSource with the given cache provider.
 func Kind(cache cache.Cache, object client.Object) SyncingSource {
-	return &internal.Kind{Type: object, Cache: cache}
+	return &internal.Kind[client.Object]{Type: object, Cache: cache}
+}
+
+// ObjectKind creates a typed KindSource with the given cache provider.
+func ObjectKind[T client.Object](cache cache.Cache, object T) SyncingSource {
+	return &internal.Kind[T]{Type: object, Cache: cache}
 }
 
 var _ Source = &Channel{}
@@ -198,7 +203,7 @@ func (is *Informer) Start(ctx context.Context, handler handler.EventHandler, que
 		return fmt.Errorf("must specify Informer.Informer")
 	}
 
-	_, err := is.Informer.AddEventHandler(internal.NewEventHandler(ctx, queue, handler, prct).HandlerFuncs())
+	_, err := is.Informer.AddEventHandler(internal.NewEventHandler[client.Object](ctx, queue, handler, prct).HandlerFuncs())
 	if err != nil {
 		return err
 	}

--- a/pkg/source/source_test.go
+++ b/pkg/source/source_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -186,8 +187,22 @@ var _ = Describe("Source", func() {
 			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil cache"))
 		})
 
+		It("should return an error from Start cache was not provided", func() {
+			instance := source.ObjectKind(nil, &corev1.Pod{})
+			err := instance.Start(ctx, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil cache"))
+		})
+
 		It("should return an error from Start if a type was not provided", func() {
 			instance := source.Kind(ic, nil)
+			err := instance.Start(ctx, nil, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil object"))
+		})
+
+		It("should return an error from Start if a type was not provided", func() {
+			instance := source.ObjectKind[client.Object](ic, nil)
 			err := instance.Start(ctx, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must create Kind with a non-nil object"))


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This ensures that type casting check executed inside `source.Kind` logic guaranties type safety for propagated objects.

Currently the change will only have effect in `builder.WatchesRawSource`, when the source.Kind is constructed externally.

For such (raw) typed source, `OnlyMetadata` option is no longer doing anything, so this forces user to pass a fully qualified partial object metadata type during construction. This also supposed to be correct way to do it:
```go
pod := &metav1.PartialObjectMetadata{}
pod.SetGroupVersionKind(schema.GroupVersionKind{
	Group:   "",
	Version: "v1",
	Kind:    "Pod",
})
builder.WatchesRawSource(source.Kind(cache, pod), eventHandler, opts...)
```