### PR TITLE
🐛 fix go versions in go modules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // Using v4 to match upstream

--- a/tools/setup-envtest/go.mod
+++ b/tools/setup-envtest/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime/tools/setup-envtest
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/go-logr/logr v1.2.4


### PR DESCRIPTION
Related to https://github.com/kubernetes-sigs/controller-runtime/issues/2720.

I have tried `go get` locally and I was getting the following errors before:

```
invalid go version '1.22.0': must match format 1.23
```

With this change, this is solved.

To provide more context on to why this happens:

I have a local setup where I use go 1.20 but however was installing `envtest` using the latest reference.

After opening this PR, as a mean of trying out, I upgraded my local Go version to 1.22, and `go get` worked with the current HEAD version. And if I execute it with this PR's state, it even changed it to `1.22.0` again:

```
go get .
go: upgraded go 1.22 => 1.22.0
go: added toolchain go1.22.1
```

Now, for whomever has older Go versions, using the current main will not work, but on the other hand, if we merge this, it will always modify the go.mod for people with newer go versions. I'll defer to the maintainers on what's the wanted approach here.

As I said, in my project I switched from `@latest` to `@release-0.16` and I can move on.