### PR TITLE
🐛 prevent leader election when shutting down a non-elected manager

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -518,6 +518,8 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 
 		// Stop all the leader election runnables, which includes reconcilers.
 		cm.logger.Info("Stopping and waiting for leader election runnables")
+		// Prevent leader election when shutting down a non-elected manager
+		cm.runnables.LeaderElection.startOnce.Do(func() {})
 		cm.runnables.LeaderElection.StopAndWait(cm.shutdownCtx)
 
 		// Stop the caches before the leader election runnables, this is an important


### PR DESCRIPTION
## Context

This PR should address a bug where the runnable group for Leader Election would start while shutting down the manager: https://github.com/kubernetes-sigs/controller-runtime/issues/2719

What's happening?
- https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L344
- https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L521
- https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L521
- Causes the side-effect of starting the runnableGroup: https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/runnable_group.go#L277

However when leader election is enabled, a non-leader manager will never start the LeaderElection runnable group. Thus, the sync.Once allow starting a new election during shutdown. The change in this PR ensures `Start` is ineffective during shutdown.
- This func calls the `manager.LeaderElection`'s `runnableGroup.Start()` https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L557
- Which is obviously only called when a member becomes leader:  https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L568
- In the case leader election is enabled: https://github.com/kubernetes-sigs/controller-runtime/blob/395cfc7486e652d19fe1b544a436f9852ba26e4f/pkg/manager/internal.go#L429

## Changes

- On shutdown, perform a noop call to the `sync.Once` func associated with the LeaderElection `runnableGroup` to prevent it from starting a new leader election.

