### PR TITLE
⚠ admission.Decoder is now an interface

### DIFF
--- a/pkg/webhook/admission/decode_test.go
+++ b/pkg/webhook/admission/decode_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var _ = Describe("Admission Webhook Decoder", func() {
-	var decoder *Decoder
+	var decoder Decoder
 	BeforeEach(func() {
 		By("creating a new decoder for a scheme")
 		decoder = NewDecoder(scheme.Scheme)

--- a/pkg/webhook/admission/defaulter.go
+++ b/pkg/webhook/admission/defaulter.go
@@ -43,7 +43,7 @@ func DefaultingWebhookFor(scheme *runtime.Scheme, defaulter Defaulter) *Webhook 
 
 type mutatingHandler struct {
 	defaulter Defaulter
-	decoder   *Decoder
+	decoder   Decoder
 }
 
 // Handle handles admission requests.

--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -43,7 +43,7 @@ func WithCustomDefaulter(scheme *runtime.Scheme, obj runtime.Object, defaulter C
 type defaulterForType struct {
 	defaulter CustomDefaulter
 	object    runtime.Object
-	decoder   *Decoder
+	decoder   Decoder
 }
 
 // Handle handles admission requests.

--- a/pkg/webhook/admission/validator.go
+++ b/pkg/webhook/admission/validator.go
@@ -63,7 +63,7 @@ func ValidatingWebhookFor(scheme *runtime.Scheme, validator Validator) *Webhook 
 
 type validatingHandler struct {
 	validator Validator
-	decoder   *Decoder
+	decoder   Decoder
 }
 
 // Handle handles admission requests.

--- a/pkg/webhook/admission/validator_custom.go
+++ b/pkg/webhook/admission/validator_custom.go
@@ -56,7 +56,7 @@ func WithCustomValidator(scheme *runtime.Scheme, obj runtime.Object, validator C
 type validatorForType struct {
 	validator CustomValidator
 	object    runtime.Object
-	decoder   *Decoder
+	decoder   Decoder
 }
 
 // Handle handles admission requests.

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -153,7 +153,7 @@ var _ = Describe("Webhook", func() {
 })
 
 type rejectingValidator struct {
-	d *admission.Decoder
+	d admission.Decoder
 }
 
 func (v *rejectingValidator) Handle(ctx context.Context, req admission.Request) admission.Response {


### PR DESCRIPTION
The current implementation allows to create a decoder without a scheme/codecs by just referencing the struct `&admission.Decoder{}` given that codecs is private. The field was filled in before with the inject package which has been removed. This change retains the Decoder definition and makes it an interface, `admission.NewDecoder(scheme)` is now the only way to instantiate our default decoder.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes #2695
