### PR TITLE
✨ allow setting watchTimeoutPeriod when creating informers

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -392,7 +392,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				WatchErrorHandler:     opts.DefaultWatchErrorHandler,
 				UnsafeDisableDeepCopy: ptr.Deref(config.UnsafeDisableDeepCopy, false),
 				NewInformer:           opts.newInformer,
-				MinWatchTimeoutPeriod: opts.MinRewatchPeriod,
+				MinWatchTimeout:       opts.MinRewatchPeriod,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -170,6 +170,12 @@ type Options struct {
 	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
+	// WatchTimeoutPeriod is the timeout for the watch request. If the watch request
+	// times out, the cache will close the watch and reconnect.
+	//
+	// Defaults to a random duration between 5 and 10 minutes if unset.
+	WatchTimeoutPeriod *time.Duration
+
 	// ReaderFailOnMissingInformer configures the cache to return a ErrResourceNotCached error when a user
 	// requests, using Get() and List(), a resource the cache does not already have an informer for.
 	//
@@ -383,6 +389,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				WatchErrorHandler:     opts.DefaultWatchErrorHandler,
 				UnsafeDisableDeepCopy: ptr.Deref(config.UnsafeDisableDeepCopy, false),
 				NewInformer:           opts.newInformer,
+				WatchTimeoutPeriod:    opts.WatchTimeoutPeriod,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -170,11 +170,14 @@ type Options struct {
 	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
-	// RewatchPeriod is the timeout for the watch request. If the watch request
+	// MinRewatchPeriod is the mininum rewatch period. If the watch request
 	// times out, the cache will close the watch and reconnect.
 	//
-	// Defaults to a random duration between 5 and 10 minutes if unset.
-	RewatchPeriod *time.Duration
+	// We try to spread the load on apiserver by setting timeouts for
+	// watch requests - it is random in [MinRewatchPeriod, 2*MinRewatchPeriod].
+	//
+	// Defaults to 5 minutes if unset.
+	MinRewatchPeriod *time.Duration
 
 	// ReaderFailOnMissingInformer configures the cache to return a ErrResourceNotCached error when a user
 	// requests, using Get() and List(), a resource the cache does not already have an informer for.
@@ -389,7 +392,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				WatchErrorHandler:     opts.DefaultWatchErrorHandler,
 				UnsafeDisableDeepCopy: ptr.Deref(config.UnsafeDisableDeepCopy, false),
 				NewInformer:           opts.newInformer,
-				WatchTimeoutPeriod:    opts.RewatchPeriod,
+				MinWatchTimeoutPeriod: opts.MinRewatchPeriod,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -170,11 +170,11 @@ type Options struct {
 	// instead of `reconcile.Result{}`.
 	SyncPeriod *time.Duration
 
-	// WatchTimeoutPeriod is the timeout for the watch request. If the watch request
+	// RewatchPeriod is the timeout for the watch request. If the watch request
 	// times out, the cache will close the watch and reconnect.
 	//
 	// Defaults to a random duration between 5 and 10 minutes if unset.
-	WatchTimeoutPeriod *time.Duration
+	RewatchPeriod *time.Duration
 
 	// ReaderFailOnMissingInformer configures the cache to return a ErrResourceNotCached error when a user
 	// requests, using Get() and List(), a resource the cache does not already have an informer for.
@@ -389,7 +389,7 @@ func newCache(restConfig *rest.Config, opts Options) newCacheFunc {
 				WatchErrorHandler:     opts.DefaultWatchErrorHandler,
 				UnsafeDisableDeepCopy: ptr.Deref(config.UnsafeDisableDeepCopy, false),
 				NewInformer:           opts.newInformer,
-				WatchTimeoutPeriod:    opts.WatchTimeoutPeriod,
+				WatchTimeoutPeriod:    opts.RewatchPeriod,
 			}),
 			readerFailOnMissingInformer: opts.ReaderFailOnMissingInformer,
 		}

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/client-go/metadata"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/internal/syncs"
 )
@@ -52,7 +51,7 @@ type InformersOpts struct {
 	Transform             cache.TransformFunc
 	UnsafeDisableDeepCopy bool
 	WatchErrorHandler     cache.WatchErrorHandler
-	WatchTimeoutPeriod    *time.Duration
+	MinWatchTimeoutPeriod *time.Duration
 }
 
 // NewInformers creates a new InformersMap that can create informers under the hood.
@@ -81,7 +80,7 @@ func NewInformers(config *rest.Config, options *InformersOpts) *Informers {
 		unsafeDisableDeepCopy: options.UnsafeDisableDeepCopy,
 		newInformer:           newInformer,
 		watchErrorHandler:     options.WatchErrorHandler,
-		watchTimeoutPeriod:    options.WatchTimeoutPeriod,
+		minWatchTimeoutPeriod: options.MinWatchTimeoutPeriod,
 	}
 }
 
@@ -150,8 +149,8 @@ type Informers struct {
 	// so that all informers will not send list requests simultaneously.
 	resync time.Duration
 
-	// watchTimeoutPeriod is the timeout period for watch requests
-	watchTimeoutPeriod *time.Duration
+	// minWatchTimeoutPeriod is the timeout period for watch requests
+	minWatchTimeoutPeriod *time.Duration
 
 	// mu guards access to the map
 	mu sync.RWMutex
@@ -360,8 +359,9 @@ func (ip *Informers) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.O
 		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
 			ip.selector.ApplyToList(&opts)
 			opts.Watch = true // Watch needs to be set to true separately
-			if ip.watchTimeoutPeriod != nil {
-				opts.TimeoutSeconds = ptr.To(int64(ip.watchTimeoutPeriod.Seconds()))
+			if ip.minWatchTimeoutPeriod != nil {
+				watchTimeoutSeconds := int64(ip.minWatchTimeoutPeriod.Seconds() * (rand.Float64() + 1.0))
+				opts.TimeoutSeconds = &watchTimeoutSeconds
 			}
 			return listWatcher.WatchFunc(opts)
 		},

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -362,7 +362,7 @@ func (ip *Informers) addInformerToMap(gvk schema.GroupVersionKind, obj runtime.O
 			ip.selector.ApplyToList(&opts)
 			opts.Watch = true // Watch needs to be set to true separately
 			if ip.minWatchTimeout != nil {
-				watchTimeoutSeconds := int64(ip.minWatchTimeout.Seconds() * (rand.Float64() + 1.0))
+				watchTimeoutSeconds := int64(ip.minWatchTimeout.Seconds() * (rand.Float64() + 1.0)) //nolint:gosec
 				opts.TimeoutSeconds = &watchTimeoutSeconds
 			}
 			return listWatcher.WatchFunc(opts)


### PR DESCRIPTION
We use kubebuilder to create operators. These operators watch a lot of resources. The default watch timeout is a random number between 5 and 10 minutes, which triggers a re-watch every 7.5 minutes on average. However, this behavior causes a log of QPS to our k8s API server. We want to increase the watch timeout to reduce the overhead of the API server, thus this PR makes it configurable.