### PR TITLE
🐛 Return error if more than one For() is used on webhook builder

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -44,6 +44,7 @@ type WebhookBuilder struct {
 	config          *rest.Config
 	recoverPanic    bool
 	logConstructor  func(base logr.Logger, req *admission.Request) logr.Logger
+	err             error
 }
 
 // WebhookManagedBy returns a new webhook builder.
@@ -57,6 +58,9 @@ func WebhookManagedBy(m manager.Manager) *WebhookBuilder {
 // If the given object implements the admission.Defaulter interface, a MutatingWebhook will be wired for this type.
 // If the given object implements the admission.Validator interface, a ValidatingWebhook will be wired for this type.
 func (blder *WebhookBuilder) For(apiType runtime.Object) *WebhookBuilder {
+	if blder.apiType != nil {
+		blder.err = errors.New("For(...) should only be called once, could not assign multiple objects for webhook registration")
+	}
 	blder.apiType = apiType
 	return blder
 }
@@ -142,7 +146,7 @@ func (blder *WebhookBuilder) registerWebhooks() error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return blder.err
 }
 
 // registerDefaultingWebhook registers a defaulting webhook if necessary.

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -662,6 +662,24 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Body).To(ContainSubstring(`"allowed":true`))
 		ExpectWithOffset(1, w.Body).To(ContainSubstring(`"code":200`))
 	})
+
+	It("should send an error when trying to register a webhook with more than one For", func() {
+		By("creating a controller manager")
+		m, err := manager.New(cfg, manager.Options{})
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		By("registering the type in the Scheme")
+		builder := scheme.Builder{GroupVersion: testDefaulterGVK.GroupVersion()}
+		builder.Register(&TestDefaulter{}, &TestDefaulterList{})
+		err = builder.AddToScheme(m.GetScheme())
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+
+		err = WebhookManagedBy(m).
+			For(&TestDefaulter{}).
+			For(&TestDefaulter{}).
+			Complete()
+		Expect(err).To(HaveOccurred())
+	})
 }
 
 // TestDefaulter.


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2739

Adds an error to be returned if the `For()` was done multiple times on a webhook builder instead of accepting the last apiType.  This mimics the behavior expected when dealing with the reconciler builder.  Reference issue above and issue https://github.com/kubernetes-sigs/controller-runtime/issues/1173