### PR TITLE
🐛 Quiet context.Canceled errors during shutdown

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -507,8 +507,8 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 				cm.internalCancel()
 			})
 			select {
-			case err, ok := <-cm.errChan:
-				if ok {
+			case err := <-cm.errChan:
+				if !errors.Is(err, context.Canceled) {
 					cm.logger.Error(err, "error received after stop sequence was engaged")
 				}
 			case <-stopComplete:


### PR DESCRIPTION
Runnable implementations that return ctx.Err() cause a spurious "error received after stop" log message.

Fixes #1927 
