### PR TITLE
✨ Fix go directive version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/controller-runtime
 
-go 1.22.0
+go 1.22
 
 require (
 	github.com/evanphx/json-patch v4.12.0+incompatible // Using v4 to match upstream


### PR DESCRIPTION
According to the official Go Modules Reference https://go.dev/ref/mod#go-mod-file-go, it's better for the go directive to not include a minor version number.
