### PR TITLE
✨ client: Add client-wide fieldManager

### DIFF
--- a/pkg/client/fieldmanager_test.go
+++ b/pkg/client/fieldmanager_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestWithFieldOwner(t *testing.T) {
+	calls := 0
+	fakeClient := testClient(t, "custom-field-mgr", func() { calls++ })
+	wrappedClient := client.WithFieldOwner(fakeClient, "custom-field-mgr")
+
+	ctx := context.Background()
+	dummyObj := &corev1.Namespace{}
+
+	_ = wrappedClient.Create(ctx, dummyObj)
+	_ = wrappedClient.Update(ctx, dummyObj)
+	_ = wrappedClient.Patch(ctx, dummyObj, nil)
+	_ = wrappedClient.Status().Create(ctx, dummyObj, dummyObj)
+	_ = wrappedClient.Status().Update(ctx, dummyObj)
+	_ = wrappedClient.Status().Patch(ctx, dummyObj, nil)
+	_ = wrappedClient.SubResource("some-subresource").Create(ctx, dummyObj, dummyObj)
+	_ = wrappedClient.SubResource("some-subresource").Update(ctx, dummyObj)
+	_ = wrappedClient.SubResource("some-subresource").Patch(ctx, dummyObj, nil)
+
+	if expectedCalls := 9; calls != expectedCalls {
+		t.Fatalf("wrong number of calls to assertions: expected=%d; got=%d", expectedCalls, calls)
+	}
+}
+
+func TestWithFieldOwnerOverridden(t *testing.T) {
+	calls := 0
+
+	fakeClient := testClient(t, "new-field-manager", func() { calls++ })
+	wrappedClient := client.WithFieldOwner(fakeClient, "old-field-manager")
+
+	ctx := context.Background()
+	dummyObj := &corev1.Namespace{}
+
+	_ = wrappedClient.Create(ctx, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.Update(ctx, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.Patch(ctx, dummyObj, nil, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.Status().Create(ctx, dummyObj, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.Status().Update(ctx, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.Status().Patch(ctx, dummyObj, nil, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.SubResource("some-subresource").Create(ctx, dummyObj, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.SubResource("some-subresource").Update(ctx, dummyObj, client.FieldOwner("new-field-manager"))
+	_ = wrappedClient.SubResource("some-subresource").Patch(ctx, dummyObj, nil, client.FieldOwner("new-field-manager"))
+
+	if expectedCalls := 9; calls != expectedCalls {
+		t.Fatalf("wrong number of calls to assertions: expected=%d; got=%d", expectedCalls, calls)
+	}
+}
+
+// testClient is a helper function that checks if calls have the expected field manager,
+// and calls the callback function on each intercepted call.
+func testClient(t *testing.T, expectedFieldManager string, callback func()) client.Client {
+	// TODO: we could use the dummyClient in interceptor pkg if we move it to an internal pkg
+	return fake.NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			callback()
+			out := &client.CreateOptions{}
+			for _, f := range opts {
+				f.ApplyToCreate(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			callback()
+			out := &client.UpdateOptions{}
+			for _, f := range opts {
+				f.ApplyToUpdate(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+		Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+			callback()
+			out := &client.PatchOptions{}
+			for _, f := range opts {
+				f.ApplyToPatch(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+		SubResourceCreate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+			callback()
+			out := &client.SubResourceCreateOptions{}
+			for _, f := range opts {
+				f.ApplyToSubResourceCreate(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			callback()
+			out := &client.SubResourceUpdateOptions{}
+			for _, f := range opts {
+				f.ApplyToSubResourceUpdate(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+		SubResourcePatch: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+			callback()
+			out := &client.SubResourcePatchOptions{}
+			for _, f := range opts {
+				f.ApplyToSubResourcePatch(out)
+			}
+			if got := out.FieldManager; expectedFieldManager != got {
+				t.Fatalf("wrong field manager: expected=%q; got=%q", expectedFieldManager, got)
+			}
+			return nil
+		},
+	}).Build()
+}

--- a/pkg/client/fieldowner.go
+++ b/pkg/client/fieldowner.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// WithFieldOwner wraps a Client and adds the fieldOwner as the field
+// manager to all write requests from this client. If additional [FieldOwner]
+// options are specified on methods of this client, the value specified here
+// will be overridden.
+func WithFieldOwner(c Client, fieldOwner string) Client {
+	return &clientWithFieldManager{
+		manager: fieldOwner,
+		c:       c,
+		Reader:  c,
+	}
+}
+
+type clientWithFieldManager struct {
+	manager string
+	c       Client
+	Reader
+}
+
+func (f *clientWithFieldManager) Create(ctx context.Context, obj Object, opts ...CreateOption) error {
+	return f.c.Create(ctx, obj, append([]CreateOption{FieldOwner(f.manager)}, opts...)...)
+}
+
+func (f *clientWithFieldManager) Update(ctx context.Context, obj Object, opts ...UpdateOption) error {
+	return f.c.Update(ctx, obj, append([]UpdateOption{FieldOwner(f.manager)}, opts...)...)
+}
+
+func (f *clientWithFieldManager) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
+	return f.c.Patch(ctx, obj, patch, append([]PatchOption{FieldOwner(f.manager)}, opts...)...)
+}
+
+func (f *clientWithFieldManager) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
+	return f.c.Delete(ctx, obj, opts...)
+}
+
+func (f *clientWithFieldManager) DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error {
+	return f.c.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (f *clientWithFieldManager) Scheme() *runtime.Scheme     { return f.c.Scheme() }
+func (f *clientWithFieldManager) RESTMapper() meta.RESTMapper { return f.c.RESTMapper() }
+func (f *clientWithFieldManager) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
+	return f.c.GroupVersionKindFor(obj)
+}
+func (f *clientWithFieldManager) IsObjectNamespaced(obj runtime.Object) (bool, error) {
+	return f.c.IsObjectNamespaced(obj)
+}
+
+func (f *clientWithFieldManager) Status() StatusWriter {
+	return &subresourceClientWithFieldOwner{
+		owner:             f.manager,
+		subresourceWriter: f.c.Status(),
+	}
+}
+
+func (f *clientWithFieldManager) SubResource(subresource string) SubResourceClient {
+	c := f.c.SubResource(subresource)
+	return &subresourceClientWithFieldOwner{
+		owner:             f.manager,
+		subresourceWriter: c,
+		SubResourceReader: c,
+	}
+}
+
+type subresourceClientWithFieldOwner struct {
+	owner             string
+	subresourceWriter SubResourceWriter
+	SubResourceReader
+}
+
+func (f *subresourceClientWithFieldOwner) Create(ctx context.Context, obj Object, subresource Object, opts ...SubResourceCreateOption) error {
+	return f.subresourceWriter.Create(ctx, obj, subresource, append([]SubResourceCreateOption{FieldOwner(f.owner)}, opts...)...)
+}
+
+func (f *subresourceClientWithFieldOwner) Update(ctx context.Context, obj Object, opts ...SubResourceUpdateOption) error {
+	return f.subresourceWriter.Update(ctx, obj, append([]SubResourceUpdateOption{FieldOwner(f.owner)}, opts...)...)
+}
+
+func (f *subresourceClientWithFieldOwner) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
+	return f.subresourceWriter.Patch(ctx, obj, patch, append([]SubResourcePatchOption{FieldOwner(f.owner)}, opts...)...)
+}


### PR DESCRIPTION
## Summary

This PR adds a new `client` function `WithFieldOwner` that wraps a `client.Client` and adds a `client.FieldOwner` option to all writes from this client. If additional FieldOwner options are specified on methods of this client, the value specified here will be overridden.

## Why do we need it?

I have found myself trying to distinguish between different reconcilers in the same controller-manager process for both troubleshooting purposes (i.e having `managedFields` show the specific controller) and prevent colocated reconcilers from managing the same field.

The alternative was to add `client.FieldManager` to each individual call, which is tedious and error-prone. Instead, I would prefer to have the client use the same fieldManager across all its write calls.
 