### PR TITLE
📖 manager: fix godoc about http servers

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -382,7 +382,7 @@ func (cm *controllerManager) Start(ctx context.Context) (err error) {
 		}
 	}
 
-	// First start any HTTP servers, which includes health probes and profiling, if enabled.
+	// First start any HTTP servers, which includes health probes, metrics and profiling if enabled.
 	//
 	// WARNING: HTTPServers includes the health probes, which MUST start before any cache is populated, otherwise
 	// it would block conversion webhooks to be ready for serving which make the cache never get ready.


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes godoc comment according to 
https://github.com/kubernetes-sigs/controller-runtime/pull/2473/files#r1566017792