### PR TITLE
📖  Mark Typed Handlers as experimental

### DIFF
--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -42,6 +42,8 @@ type EnqueueRequestForObject = TypedEnqueueRequestForObject[client.Object]
 // TypedEnqueueRequestForObject enqueues a Request containing the Name and Namespace of the object that is the source of the Event.
 // (e.g. the created / deleted / updated objects Name and Namespace).  handler.TypedEnqueueRequestForObject is used by almost all
 // Controllers that have associated Resources (e.g. CRDs) to reconcile the associated Resource.
+//
+// TypedEnqueueRequestForObject is experimental and subject to future change.
 type TypedEnqueueRequestForObject[T client.Object] struct{}
 
 // Create implements EventHandler.

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -31,6 +31,8 @@ type MapFunc = TypedMapFunc[client.Object]
 
 // TypedMapFunc is the signature required for enqueueing requests from a generic function.
 // This type is usually used with EnqueueRequestsFromTypedMapFunc when registering an event handler.
+//
+// TypedMapFunc is experimental and subject to future change.
 type TypedMapFunc[T any] func(context.Context, T) []reconcile.Request
 
 // EnqueueRequestsFromMapFunc enqueues Requests by running a transformation function that outputs a collection
@@ -57,6 +59,8 @@ func EnqueueRequestsFromMapFunc(fn MapFunc) EventHandler {
 //
 // For TypedUpdateEvents which contain both a new and old object, the transformation function is run on both
 // objects and both sets of Requests are enqueue.
+//
+// TypedEnqueueRequestsFromMapFunc is experimental and subject to future change.
 func TypedEnqueueRequestsFromMapFunc[T any](fn TypedMapFunc[T]) TypedEventHandler[T] {
 	return &enqueueRequestsFromMapFunc[T]{
 		toRequests: fn,

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -59,6 +59,8 @@ func EnqueueRequestForOwner(scheme *runtime.Scheme, mapper meta.RESTMapper, owne
 // - a source.Kind Source with Type of Pod.
 //
 // - a handler.typedEnqueueRequestForOwner EventHandler with an OwnerType of ReplicaSet and OnlyControllerOwner set to true.
+//
+// TypedEnqueueRequestForOwner is experimental and subject to future change.
 func TypedEnqueueRequestForOwner[T client.Object](scheme *runtime.Scheme, mapper meta.RESTMapper, ownerType client.Object, opts ...OwnerOption) TypedEventHandler[T] {
 	e := &enqueueRequestForOwner[T]{
 		ownerType: ownerType,

--- a/pkg/handler/eventhandler.go
+++ b/pkg/handler/eventhandler.go
@@ -62,6 +62,8 @@ type EventHandler TypedEventHandler[client.Object]
 //
 // Unless you are implementing your own TypedEventHandler, you can ignore the functions on the TypedEventHandler interface.
 // Most users shouldn't need to implement their own TypedEventHandler.
+//
+// TypedEventHandler is experimental and subject to future change.
 type TypedEventHandler[T any] interface {
 	// Create is called in response to a create event - e.g. Pod Creation.
 	Create(context.Context, event.TypedCreateEvent[T], workqueue.RateLimitingInterface)
@@ -83,6 +85,8 @@ var _ EventHandler = Funcs{}
 type Funcs = TypedFuncs[client.Object]
 
 // TypedFuncs implements eventhandler.
+//
+// TypedFuncs is experimental and subject to future change.
 type TypedFuncs[T any] struct {
 	// Create is called in response to an add event.  Defaults to no-op.
 	// RateLimitingInterface is used to enqueue reconcile.Requests.


### PR DESCRIPTION
We will need to break them if we want to introduce a generic reconciler with a generic workqueue so mark them as experimental.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
