### PR TITLE
:bug: Cache: Fix label defaulting of byObject when namespaces are configured

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1630,6 +1630,26 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}},
 					expectedPods: []string{"test-pod-4"},
 				}),
+				Entry("namespaces configured, type-level label selector matches everything, overrides global selector", selectorsTestCase{
+					options: cache.Options{
+						DefaultNamespaces: map[string]cache.Config{testNamespaceOne: {}},
+						ByObject: map[client.Object]cache.ByObject{
+							&corev1.Pod{}: {Label: labels.Everything()},
+						},
+						DefaultLabelSelector: labels.SelectorFromSet(map[string]string{"does-not": "match-anything"}),
+					},
+					expectedPods: []string{"test-pod-1", "test-pod-5"},
+				}),
+				Entry("namespaces configured, global selector is used", selectorsTestCase{
+					options: cache.Options{
+						DefaultNamespaces: map[string]cache.Config{testNamespaceTwo: {}},
+						ByObject: map[client.Object]cache.ByObject{
+							&corev1.Pod{}: {},
+						},
+						DefaultLabelSelector: labels.SelectorFromSet(map[string]string{"common-label": "common"}),
+					},
+					expectedPods: []string{"test-pod-3"},
+				}),
 				Entry("global label selector matches one pod", selectorsTestCase{
 					options: cache.Options{
 						DefaultLabelSelector: labels.SelectorFromSet(map[string]string{


### PR DESCRIPTION
Currently, if there are global namespaces configured and no per-object namesapces, while there is both a global and a per-object labelSelector, we will:
1. Default the namespaces labelSelector from `DefaultLabelSelector`
2. Copy the namespaces including config into `byObject.Namespaces`

And thus end up with the global labelSelector overriding the per-object one, this change fixes that by swapping step 1 and 2.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2804

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
