### PR TITLE
🐛 correct kind source type

### DIFF
--- a/pkg/internal/source/internal_test.go
+++ b/pkg/internal/source/internal_test.go
@@ -286,6 +286,15 @@ var _ = Describe("Internal", func() {
 			instance.OnDelete(Foo{})
 		})
 	})
+
+	Describe("Kind", func() {
+		It("should return kind source type", func() {
+			kind := internal.Kind[*corev1.Pod]{
+				Type: &corev1.Pod{},
+			}
+			Expect(kind.String()).Should(Equal("kind source: *v1.Pod"))
+		})
+	})
 })
 
 type Foo struct{}

--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -103,7 +103,7 @@ func (ks *Kind[T]) Start(ctx context.Context, queue workqueue.RateLimitingInterf
 }
 
 func (ks *Kind[T]) String() string {
-	if isNil(ks.Type) {
+	if !isNil(ks.Type) {
 		return fmt.Sprintf("kind source: %T", ks.Type)
 	}
 	return "kind source: unknown type"


### PR DESCRIPTION
Reverse the nil check in the String function of the internal Kind source to print the type when known.

Fixes: 2add01e7 ("Event, source, handler, predicates: Use generics")

<!-- What does this do, and why do we need it? -->
