### PR TITLE
:bug: fix(controllerutil): avoid panic when the MutateFn is nil

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -310,9 +310,12 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f M
 		if !apierrors.IsNotFound(err) {
 			return OperationResultNone, err
 		}
-		if err := mutate(f, key, obj); err != nil {
-			return OperationResultNone, err
+		if f != nil {
+			if err := mutate(f, key, obj); err != nil {
+				return OperationResultNone, err
+			}
 		}
+
 		if err := c.Create(ctx, obj); err != nil {
 			return OperationResultNone, err
 		}
@@ -320,8 +323,10 @@ func CreateOrUpdate(ctx context.Context, c client.Client, obj client.Object, f M
 	}
 
 	existing := obj.DeepCopyObject()
-	if err := mutate(f, key, obj); err != nil {
-		return OperationResultNone, err
+	if f != nil {
+		if err := mutate(f, key, obj); err != nil {
+			return OperationResultNone, err
+		}
 	}
 
 	if equality.Semantic.DeepEqual(existing, obj) {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
I checked the `CreateOrPatch` function and it checked if `MutateFn` is nil, but `CreateOrUpdate` did not check.

Or is it possible to modify the `mutate` function directly and execute `MutateFn` only when `MutateFn` is not nil?
https://github.com/kubernetes-sigs/controller-runtime/blob/5dcea7e94b7158e410d22f4a1eed16780497fe66/pkg/controller/controllerutil/controllerutil.go#L425