### PR TITLE
:bug: fix description for SetupSignalHandler() in alias.go

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -122,8 +122,8 @@ var (
 	// there is another OwnerReference with Controller flag set.
 	SetControllerReference = controllerutil.SetControllerReference
 
-	// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
-	// which is closed on one of these signals. If a second signal is caught, the program
+	// SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+	// which is canceled on one of these signals. If a second signal is caught, the program
 	// is terminated with exit code 1.
 	SetupSignalHandler = signals.SetupSignalHandler
 


### PR DESCRIPTION
fix description for SetupSignalHandler() in alias.go to match actual behaviour of returning a context (instead of a channel)

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
