### PR TITLE
:book: Add setup-envtest Instructions for Go < 1.22

### DIFF
--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -4,11 +4,17 @@ This is a small tool that manages binaries for envtest. It can be used to
 download new binaries, list currently installed and available ones, and
 clean up versions.
 
-To use it, just go-install it on 1.19+ (it's a separate, self-contained
+To use it, just go-install it with Golang 1.22+ (it's a separate, self-contained
 module):
 
 ```shell
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+```
+
+If you are using Golang 1.20 or 1.21, use the `release-0.17` branch instead:
+
+```shell
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
 ```
 
 For full documentation, run it with the `--help` flag, but here are some


### PR DESCRIPTION
Starting with 0.18, setup-envtest requires golang 1.22. This change updates the README to clarify the required golang version. It also provides an alternative install instruction for developers using golang 1.20 and 1.21.

Indirectly relates to #2744 - though from the issue discussion this is tracking release process changes for setup-envtest.

Fixes #2824 