### PR TITLE
🌱 dependabot: remove go modules bumps, bump all actions at once

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,18 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the
-    # default location of `.github/workflows`
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: ":seedling:"
-    labels:
-      - "ok-to-test"
-
-  # Maintain dependencies for go
-  - package-ecosystem: "gomod"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: ":seedling:"
-    # Ignore K8 packages as these are done manually
-    ignore:
-      - dependency-name: "k8s.io/api"
-      - dependency-name: "k8s.io/apiextensions-apiserver"
-      - dependency-name: "k8s.io/apimachinery"
-      - dependency-name: "k8s.io/client-go"
-      - dependency-name: "k8s.io/component-base"
-    labels:
-      - "ok-to-test"
+# GitHub Actions
+- package-ecosystem: "github-actions"
+  # Workflow files stored in the
+  # default location of `.github/workflows`
+  directory: "/"
+  schedule:
+    interval: "weekly"
+  groups:
+    all-github-actions:
+      patterns: [ "*" ]
+  commit-message:
+    prefix: ":seedling:"
+  labels:
+  - "ok-to-test"


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
We recently introduce a linter which ensure that our dependencies stay in sync with k/k.
This is important so consumers of CR don't run into compile issues between transitive dependencies of CR & k/k (e.g. if we would use different prometheus versions).

Through this validation we realized that it's basically impossible to bump any dependencies without running out-of-sync in some way with k/k (e.g. even bumping ginkgo leads to a lot of out-of-sync dependencies: https://github.com/kubernetes-sigs/controller-runtime/pull/2842 / https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_controller-runtime/2842/pull-controller-runtime-test/1795194368211030016)

This PR:
* Removes the dependabot config to bump Go modules
* Optimizes the GitHub action configuration to bump all actions via a single PR (to avoid PR spam)

