### PR TITLE
:book: Document that indexes can be added after Informer was started

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -117,8 +117,8 @@ type Informer interface {
 	// This function is guaranteed to be idempotent and thread-safe.
 	RemoveEventHandler(handle toolscache.ResourceEventHandlerRegistration) error
 
-	// AddIndexers adds indexers to this store. If this is called after there is already data
-	// in the store, the results are undefined.
+	// AddIndexers adds indexers to this store. It is valid to add indexers
+	// after an informer was started.
 	AddIndexers(indexers toolscache.Indexers) error
 
 	// HasSynced return true if the informers underlying store has synced.


### PR DESCRIPTION
The comment is outdated, support for it was added in Kube 1.30, ref https://github.com/kubernetes/kubernetes/pull/117046

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
