### PR TITLE
:sparkles: feat: allow adding new prometheus.Gatherers on top of default registry

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -72,6 +73,10 @@ type Manager interface {
 	// If the simple path -> handler mapping offered here is not enough,
 	// a new http server/listener should be added as Runnable to the manager via Add method.
 	AddMetricsServerExtraHandler(path string, handler http.Handler) error
+
+	// AddMetricsServerExtraGatherer adds an extra prometheus.Gatherer to the metrics server.
+	// This can be used to add custom metrics to the metrics server.
+	AddMetricsServerExtraGatherer(gatherer prometheus.Gatherer) error
 
 	// AddHealthzCheck allows you to add Healthz checker
 	AddHealthzCheck(name string, check healthz.Checker) error


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
In case of libraries using prebuilt prometheus registries (such as controller runtime itself), it should be possible to add the gatherer to the default metrics server so that no second handler or path has to be created for them. This allows to add metrics that are precollected/registered in something outside of the own controller runtime registry

If this is rejected the only way to merge registries is to write their own custom metrics server, which seems excessive.