### PR TITLE
:bug: Suppress API server warnings in the client

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -124,19 +124,15 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
-	if !options.WarningHandler.SuppressWarnings {
-		// surface warnings
-		logger := log.Log.WithName("KubeAPIWarningLogger")
-		// Set a WarningHandler, the default WarningHandler
-		// is log.KubeAPIWarningLogger with deduplication enabled.
-		// See log.KubeAPIWarningLoggerOptions for considerations
-		// regarding deduplication.
-		config.WarningHandler = log.NewKubeAPIWarningLogger(
-			logger,
-			log.KubeAPIWarningLoggerOptions{
-				Deduplicate: !options.WarningHandler.AllowDuplicateLogs,
-			},
-		)
+	// By default, we de-duplicate and surface warnings.
+	config.WarningHandler = log.NewKubeAPIWarningLogger(
+		log.Log.WithName("KubeAPIWarningLogger"),
+		log.KubeAPIWarningLoggerOptions{
+			Deduplicate: !options.WarningHandler.AllowDuplicateLogs,
+		},
+	)
+	if options.WarningHandler.SuppressWarnings {
+		config.WarningHandler = rest.NoWarnings{}
 	}
 
 	// Use the rest HTTP client for the provided config if unset

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -241,6 +241,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			tns, err = clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(tns).NotTo(BeNil())
+			defer deleteNamespace(ctx, tns)
 
 			toCreate := &pkg.ChaosPod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -267,7 +268,6 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				}
 			}
 			defer Fail("expected to find one API server warning in the client log")
-			deleteNamespace(ctx, tns)
 		})
 
 		It("should not log warnings when warning suppression is enabled", func() {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package client_test
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -224,6 +226,90 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 
 		err = clientset.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, *delOptions)
 		Expect(client.IgnoreNotFound(err)).NotTo(HaveOccurred())
+	})
+
+	Describe("WarningHandler", func() {
+		It("should log warnings when warning suppression is disabled", func() {
+			cache := &fakeReader{}
+			cl, err := client.New(cfg, client.Options{
+				WarningHandler: client.WarningHandlerOptions{SuppressWarnings: false}, Cache: &client.CacheOptions{Reader: cache, DisableFor: []client.Object{&corev1.Namespace{}}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cl).NotTo(BeNil())
+
+			tns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ws-disabled"}}
+			tns, err = clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tns).NotTo(BeNil())
+
+			toCreate := &pkg.ChaosPod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example",
+					Namespace: tns.Name,
+				},
+				// The ChaosPod CRD does not define Status, so the field is unknown to the API server,
+				// but field validation is not strict by default, so the API server returns a warning,
+				// and we need a warning to check whether suppression works.
+				Status: pkg.ChaosPodStatus{},
+			}
+			err = cl.Create(ctx, toCreate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cl).NotTo(BeNil())
+
+			scanner := bufio.NewScanner(&log)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.Contains(
+					line,
+					"unknown field \"status\"",
+				) {
+					return
+				}
+			}
+			defer Fail("expected to find one API server warning in the client log")
+			deleteNamespace(ctx, tns)
+		})
+
+		It("should not log warnings when warning suppression is enabled", func() {
+			cache := &fakeReader{}
+			cl, err := client.New(cfg, client.Options{
+				WarningHandler: client.WarningHandlerOptions{SuppressWarnings: true}, Cache: &client.CacheOptions{Reader: cache, DisableFor: []client.Object{&corev1.Namespace{}}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cl).NotTo(BeNil())
+
+			tns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "ws-enabled"}}
+			tns, err = clientset.CoreV1().Namespaces().Create(ctx, tns, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tns).NotTo(BeNil())
+
+			toCreate := &pkg.ChaosPod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example",
+					Namespace: tns.Name,
+				},
+				// The ChaosPod CRD does not define Status, so the field is unknown to the API server,
+				// but field validation is not strict by default, so the API server returns a warning,
+				// and we need a warning to check whether suppression works.
+				Status: pkg.ChaosPodStatus{},
+			}
+			err = cl.Create(ctx, toCreate)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cl).NotTo(BeNil())
+
+			scanner := bufio.NewScanner(&log)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.Contains(
+					line,
+					"unknown field \"status\"",
+				) {
+					defer Fail("expected to find zero API server warnings in the client log")
+					break
+				}
+			}
+			deleteNamespace(ctx, tns)
+		})
 	})
 
 	Describe("New", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This adds:
- Tests that verify warning suppression in the client. Note that one of the test fails, confirming the bug. These tests are meant to help us validate the fix, and avoid future regression.
- Ensures, by configuring the warning handler in client-go, that API server warnings are in fact suppressed.

<details>
<summary>Test failure</summary>

```
> Enter [BeforeEach] Client - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:153 @ 07/24/24 03:22:08.098
< Exit [BeforeEach] Client - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:153 @ 07/24/24 03:22:08.098 (0s)
> Enter [It] should not log warnings when warning suppression is enabled - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:273 @ 07/24/24 03:22:08.098
2024-07-24T03:22:08Z	INFO	klog	unknown field "spec"
2024-07-24T03:22:08Z	INFO	klog	unknown field "status"
[FAILED] expected to find zero API server warnings in the client log
In [It] at: /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:312 @ 07/24/24 03:22:08.127
< Exit [It] should not log warnings when warning suppression is enabled - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:273 @ 07/24/24 03:22:08.127 (29ms)
> Enter [AfterEach] Client - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:210 @ 07/24/24 03:22:08.127
< Exit [AfterEach] Client - /home/prow/go/src/sigs.k8s.io/controller-runtime/pkg/client/client_test.go:210 @ 07/24/24 03:22:08.138 (11ms)
```

</details>

Fixes #2886