### PR TITLE
🐛 Recreate watcher if the file unlinked and replaced

### DIFF
--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -173,14 +173,14 @@ func (cw *CertWatcher) ReadCertificate() error {
 
 func (cw *CertWatcher) handleEvent(event fsnotify.Event) {
 	// Only care about events which may modify the contents of the file.
-	if !(isWrite(event) || isRemove(event) || isCreate(event)) {
+	if !(isWrite(event) || isRemove(event) || isCreate(event) || isChmod(event)) {
 		return
 	}
 
 	log.V(1).Info("certificate event", "event", event)
 
-	// If the file was removed, re-add the watch.
-	if isRemove(event) {
+	// If the file was removed or renamed, re-add the watch to the previous name
+	if isRemove(event) || isChmod(event) {
 		if err := cw.watcher.Add(event.Name); err != nil {
 			log.Error(err, "error re-watching file")
 		}
@@ -201,4 +201,8 @@ func isCreate(event fsnotify.Event) bool {
 
 func isRemove(event fsnotify.Event) bool {
 	return event.Op.Has(fsnotify.Remove)
+}
+
+func isChmod(event fsnotify.Event) bool {
+	return event.Op.Has(fsnotify.Chmod)
 }

--- a/pkg/certwatcher/certwatcher_suite_test.go
+++ b/pkg/certwatcher/certwatcher_suite_test.go
@@ -41,7 +41,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	for _, file := range []string{certPath, keyPath} {
+	for _, file := range []string{certPath, keyPath, certPath + ".new", keyPath + ".new", certPath + ".old", keyPath + ".old"} {
 		_ = os.Remove(file)
 	}
 })

--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -189,17 +189,18 @@ var _ = Describe("CertWatcher", func() {
 
 				Expect(os.Remove(keyPath)).To(Succeed())
 
+				// Note, we are checking two errors here, because os.Remove generates two fsnotify events: Chmod + Remove
 				Eventually(func() error {
 					readCertificateTotalAfter := testutil.ToFloat64(metrics.ReadCertificateTotal)
-					if readCertificateTotalAfter != readCertificateTotalBefore+1.0 {
-						return fmt.Errorf("metric read certificate total expected: %v and got: %v", readCertificateTotalBefore+1.0, readCertificateTotalAfter)
+					if readCertificateTotalAfter != readCertificateTotalBefore+2.0 {
+						return fmt.Errorf("metric read certificate total expected: %v and got: %v", readCertificateTotalBefore+2.0, readCertificateTotalAfter)
 					}
 					return nil
 				}, "4s").Should(Succeed())
 				Eventually(func() error {
 					readCertificateErrorsAfter := testutil.ToFloat64(metrics.ReadCertificateErrors)
-					if readCertificateErrorsAfter != readCertificateErrorsBefore+1.0 {
-						return fmt.Errorf("metric read certificate errors expected: %v and got: %v", readCertificateErrorsBefore+1.0, readCertificateErrorsAfter)
+					if readCertificateErrorsAfter != readCertificateErrorsBefore+2.0 {
+						return fmt.Errorf("metric read certificate errors expected: %v and got: %v", readCertificateErrorsBefore+2.0, readCertificateErrorsAfter)
 					}
 					return nil
 				}, "4s").Should(Succeed())


### PR DESCRIPTION
The current certwatcher misses some events, so if the certificate is maintained in a failsafe-backup way it cannot be watched and fails to get any updates.

For example, when it started with `certwartcher.New("app.crt", "app.key")` and someone does:

```console
curl -O app.crt.new example.com/cert
curl -O app.key.new example.com/key
diff app.crt.new app.crt || (echo "No change"; exit 0)
ln app.crt app.crt.old
ln app.key app.key.old
mv app.crt.new app.crt
mv app.key.new app.key
```

The FD of the file gets these inotify events and stops being watched.
```
# Diff
app.crt OPEN
app.crt CLOSE_NOWRITE,CLOSE
# Move
app.crt ATTRIB
app.crt MOVE_SELF
app.crt ATTRIB
app.crt DELETE_SELF
```

Please take a look at the added test for the implementation of failsafe cert replacement.
The problem is that in this stage because of hardlink the certwatcher continues to watch `app.crt.old` and `app.key.old` inodes until they are removed. If they are removed properly - it gets a REMOVE fsnotify event and recreates the watch, but if they use something like `unlink` and still have open FD or another watch - they would be watched forever.

The case is already mentioned in fsnotify library comments: https://github.com/fsnotify/fsnotify/blob/c1467c02fba575afdb5f4201072ab8403bbf00f4/fsnotify.go#L40-L48
```go
// # Linux notes
//
// When a file is removed a Remove event won't be emitted until all file
// descriptors are closed, and deletes will always emit a Chmod. For example:
//
//      fp := os.Open("file")
//      os.Remove("file")        // Triggers Chmod
//      fp.Close()               // Triggers Remove
//
```
and https://github.com/fsnotify/fsnotify/blob/c1467c02fba575afdb5f4201072ab8403bbf00f4/fsnotify.go#L135-L139
```go
        //   fsnotify.Chmod     Attributes were changed. On Linux this is also sent
        //                      when a file is removed (or more accurately, when a
        //                      link to an inode is removed). On kqueue it's sent
        //                      when a file is truncated. On Windows it's never
        //                      sent.
```


So the PR adds `fsnotify.Chmod` event to be treated equally to `fsnotify.Remove` in case someone still looks at the old inode, because for certiwatcher the important data are in the filename, not inode.

Note, there is no harm in recreating the watch for a file that is already monitored (in case Chmod was thrown for any other reason) as watcher would just reuse the existing: https://github.com/fsnotify/fsnotify/blob/c1467c02fba575afdb5f4201072ab8403bbf00f4/fsnotify.go#L277-L312
```go
// A path can only be watched once; watching it more than once is a no-op and will
// not return an error. Paths that do not yet exist on the filesystem cannot be
// watched.
//
// A watch will be automatically removed if the watched path is deleted or
// renamed. The exception is the Windows backend, which doesn't remove the
// watcher on renames.
```