### PR TITLE
:book: Improve godocs for source

### DIFF
--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -53,8 +53,8 @@ type Source = TypedSource[reconcile.Request]
 //
 // Users may build their own Source implementations.
 type TypedSource[request comparable] interface {
-	// Start is internal and should be called only by the Controller to register an EventHandler with the Informer
-	// to enqueue reconcile.Requests.
+	// Start is internal and should be called only by the Controller to start the source.
+	// Start must be non-blocking.
 	Start(context.Context, workqueue.TypedRateLimitingInterface[request]) error
 }
 


### PR DESCRIPTION
The godoc for `Start()` talked about an eventhander, this info is out of date. Also mention that `Start()` must not block.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
