### PR TITLE
:warning: Deprecate client.Options.WarningHandler

### DIFF
--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/rest"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -42,6 +43,24 @@ var (
 
 func ExampleNew() {
 	cl, err := client.New(config.GetConfigOrDie(), client.Options{})
+	if err != nil {
+		fmt.Println("failed to create client")
+		os.Exit(1)
+	}
+
+	podList := &corev1.PodList{}
+
+	err = cl.List(context.Background(), podList, client.InNamespace("default"))
+	if err != nil {
+		fmt.Printf("failed to list pods in namespace default: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func ExampleNew_suppress_warnings() {
+	cfg := config.GetConfigOrDie()
+	cfg.WarningHandler = rest.NoWarnings{}
+	cl, err := client.New(cfg, client.Options{})
 	if err != nil {
 		fmt.Println("failed to create client")
 		os.Exit(1)


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
As a follow-up to #2887, and the conversation in https://github.com/kubernetes-sigs/controller-runtime/pull/2887#discussion_r1692085803, this deprecates `client.Options.WarningHandler`.

Instead of using `client.Options.WarningHandler` users define `config.WarningHandler`. This change
1. Reduces the number of "sources" of warning handler configuration from two to one, and thereby reduces confusion.
1. Allows users to define custom warning handlers, and thereby increases flexibility. 

Deprecation and future removal does not change the default behavior, which is to de-duplicate and surface warnings.