### PR TITLE
:sparkles: Use aggregated discovery if available

### DIFF
--- a/pkg/client/apiutil/apimachinery_test.go
+++ b/pkg/client/apiutil/apimachinery_test.go
@@ -18,6 +18,7 @@ package apiutil_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	gmg "github.com/onsi/gomega"
@@ -32,127 +33,130 @@ import (
 )
 
 func TestApiMachinery(t *testing.T) {
-	restCfg, tearDownFn := setupEnvtest(t)
-	defer tearDownFn(t)
+	for _, aggregatedDiscovery := range []bool{true, false} {
+		t.Run("aggregatedDiscovery="+strconv.FormatBool(aggregatedDiscovery), func(t *testing.T) {
+			restCfg := setupEnvtest(t, !aggregatedDiscovery)
 
-	// Details of the GVK registered at initialization.
-	initialGvk := metav1.GroupVersionKind{
-		Group:   "crew.example.com",
-		Version: "v1",
-		Kind:    "Driver",
-	}
-
-	// A set of GVKs to register at runtime with varying properties.
-	runtimeGvks := []struct {
-		name   string
-		gvk    metav1.GroupVersionKind
-		plural string
-	}{
-		{
-			name: "new Kind and Version added to existing Group",
-			gvk: metav1.GroupVersionKind{
-				Group:   "crew.example.com",
-				Version: "v1alpha1",
-				Kind:    "Passenger",
-			},
-			plural: "passengers",
-		},
-		{
-			name: "new Kind added to existing Group and Version",
-			gvk: metav1.GroupVersionKind{
+			// Details of the GVK registered at initialization.
+			initialGvk := metav1.GroupVersionKind{
 				Group:   "crew.example.com",
 				Version: "v1",
-				Kind:    "Garage",
-			},
-			plural: "garages",
-		},
-		{
-			name: "new GVK",
-			gvk: metav1.GroupVersionKind{
-				Group:   "inventory.example.com",
-				Version: "v1",
-				Kind:    "Taxi",
-			},
-			plural: "taxis",
-		},
-	}
+				Kind:    "Driver",
+			}
 
-	t.Run("IsGVKNamespaced should report scope for GVK registered at initialization", func(t *testing.T) {
-		g := gmg.NewWithT(t)
+			// A set of GVKs to register at runtime with varying properties.
+			runtimeGvks := []struct {
+				name   string
+				gvk    metav1.GroupVersionKind
+				plural string
+			}{
+				{
+					name: "new Kind and Version added to existing Group",
+					gvk: metav1.GroupVersionKind{
+						Group:   "crew.example.com",
+						Version: "v1alpha1",
+						Kind:    "Passenger",
+					},
+					plural: "passengers",
+				},
+				{
+					name: "new Kind added to existing Group and Version",
+					gvk: metav1.GroupVersionKind{
+						Group:   "crew.example.com",
+						Version: "v1",
+						Kind:    "Garage",
+					},
+					plural: "garages",
+				},
+				{
+					name: "new GVK",
+					gvk: metav1.GroupVersionKind{
+						Group:   "inventory.example.com",
+						Version: "v1",
+						Kind:    "Taxi",
+					},
+					plural: "taxis",
+				},
+			}
 
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
+			t.Run("IsGVKNamespaced should report scope for GVK registered at initialization", func(t *testing.T) {
+				g := gmg.NewWithT(t)
 
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
 
-		s := scheme.Scheme
-		err = apiextensionsv1.AddToScheme(s)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
 
-		// Query the scope of a GVK that was registered at initialization.
-		scope, err := apiutil.IsGVKNamespaced(
-			schema.GroupVersionKind(initialGvk),
-			lazyRestMapper,
-		)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(scope).To(gmg.BeTrue())
-	})
+				s := scheme.Scheme
+				err = apiextensionsv1.AddToScheme(s)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
 
-	for _, runtimeGvk := range runtimeGvks {
-		t.Run("IsGVKNamespaced should report scope for "+runtimeGvk.name, func(t *testing.T) {
-			g := gmg.NewWithT(t)
-			ctx := context.Background()
-
-			httpClient, err := rest.HTTPClientFor(restCfg)
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-
-			lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-
-			s := scheme.Scheme
-			err = apiextensionsv1.AddToScheme(s)
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-
-			c, err := client.New(restCfg, client.Options{Scheme: s})
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-
-			// Run a valid query to initialize cache.
-			scope, err := apiutil.IsGVKNamespaced(
-				schema.GroupVersionKind(initialGvk),
-				lazyRestMapper,
-			)
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-			g.Expect(scope).To(gmg.BeTrue())
-
-			// Register a new CRD at runtime.
-			crd := newCRD(ctx, g, c, runtimeGvk.gvk.Group, runtimeGvk.gvk.Kind, runtimeGvk.plural)
-			version := crd.Spec.Versions[0]
-			version.Name = runtimeGvk.gvk.Version
-			version.Storage = true
-			version.Served = true
-			crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{version}
-			crd.Spec.Scope = apiextensionsv1.NamespaceScoped
-
-			g.Expect(c.Create(ctx, crd)).To(gmg.Succeed())
-			t.Cleanup(func() {
-				g.Expect(c.Delete(ctx, crd)).To(gmg.Succeed())
+				// Query the scope of a GVK that was registered at initialization.
+				scope, err := apiutil.IsGVKNamespaced(
+					schema.GroupVersionKind(initialGvk),
+					lazyRestMapper,
+				)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(scope).To(gmg.BeTrue())
 			})
 
-			// Wait until the CRD is registered.
-			g.Eventually(func(g gmg.Gomega) {
-				isRegistered, err := isCrdRegistered(restCfg, runtimeGvk.gvk)
-				g.Expect(err).NotTo(gmg.HaveOccurred())
-				g.Expect(isRegistered).To(gmg.BeTrue())
-			}).Should(gmg.Succeed(), "GVK should be available")
+			for _, runtimeGvk := range runtimeGvks {
+				t.Run("IsGVKNamespaced should report scope for "+runtimeGvk.name, func(t *testing.T) {
+					g := gmg.NewWithT(t)
+					ctx := context.Background()
 
-			// Query the scope of the GVK registered at runtime.
-			scope, err = apiutil.IsGVKNamespaced(
-				schema.GroupVersionKind(runtimeGvk.gvk),
-				lazyRestMapper,
-			)
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-			g.Expect(scope).To(gmg.BeTrue())
+					httpClient, err := rest.HTTPClientFor(restCfg)
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+
+					lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+
+					s := scheme.Scheme
+					err = apiextensionsv1.AddToScheme(s)
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+
+					c, err := client.New(restCfg, client.Options{Scheme: s})
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+
+					// Run a valid query to initialize cache.
+					scope, err := apiutil.IsGVKNamespaced(
+						schema.GroupVersionKind(initialGvk),
+						lazyRestMapper,
+					)
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+					g.Expect(scope).To(gmg.BeTrue())
+
+					// Register a new CRD at runtime.
+					crd := newCRD(ctx, g, c, runtimeGvk.gvk.Group, runtimeGvk.gvk.Kind, runtimeGvk.plural)
+					version := crd.Spec.Versions[0]
+					version.Name = runtimeGvk.gvk.Version
+					version.Storage = true
+					version.Served = true
+					crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{version}
+					crd.Spec.Scope = apiextensionsv1.NamespaceScoped
+
+					g.Expect(c.Create(ctx, crd)).To(gmg.Succeed())
+					t.Cleanup(func() {
+						g.Expect(c.Delete(ctx, crd)).To(gmg.Succeed())
+					})
+
+					// Wait until the CRD is registered.
+					g.Eventually(func(g gmg.Gomega) {
+						isRegistered, err := isCrdRegistered(restCfg, runtimeGvk.gvk)
+						g.Expect(err).NotTo(gmg.HaveOccurred())
+						g.Expect(isRegistered).To(gmg.BeTrue())
+					}).Should(gmg.Succeed(), "GVK should be available")
+
+					// Query the scope of the GVK registered at runtime.
+					scope, err = apiutil.IsGVKNamespaced(
+						schema.GroupVersionKind(runtimeGvk.gvk),
+						lazyRestMapper,
+					)
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+					g.Expect(scope).To(gmg.BeTrue())
+				})
+			}
 		})
 	}
 }

--- a/pkg/client/apiutil/restmapper.go
+++ b/pkg/client/apiutil/restmapper.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
+	"k8s.io/utils/ptr"
 )
 
 // NewDynamicRESTMapper returns a dynamic RESTMapper for cfg. The dynamic
@@ -41,6 +42,7 @@ func NewDynamicRESTMapper(cfg *rest.Config, httpClient *http.Client) (meta.RESTM
 	if err != nil {
 		return nil, err
 	}
+
 	return &mapper{
 		mapper:      restmapper.NewDiscoveryRESTMapper([]*restmapper.APIGroupResources{}),
 		client:      client,
@@ -53,11 +55,15 @@ func NewDynamicRESTMapper(cfg *rest.Config, httpClient *http.Client) (meta.RESTM
 // client for discovery information to do REST mappings.
 type mapper struct {
 	mapper      meta.RESTMapper
-	client      discovery.DiscoveryInterface
+	client      discovery.AggregatedDiscoveryInterface
 	knownGroups map[string]*restmapper.APIGroupResources
 	apiGroups   map[string]*metav1.APIGroup
 
+	initialDiscoveryDone bool
+
 	// mutex to provide thread-safe mapper reloading.
+	// It protects all fields in the mapper as well as methods
+	// that have the `Locked` suffix.
 	mu sync.RWMutex
 }
 
@@ -159,28 +165,42 @@ func (m *mapper) addKnownGroupAndReload(groupName string, versions ...string) er
 		versions = nil
 	}
 
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	// If no specific versions are set by user, we will scan all available ones for the API group.
 	// This operation requires 2 requests: /api and /apis, but only once. For all subsequent calls
 	// this data will be taken from cache.
-	if len(versions) == 0 {
-		apiGroup, err := m.findAPIGroupByName(groupName)
+	//
+	// We always run this once, because if the server supports aggregated discovery, this will
+	// load everything with two api calls which we assume is overall cheaper.
+	if len(versions) == 0 || !m.initialDiscoveryDone {
+		apiGroup, didAggregatedDiscovery, err := m.findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked(groupName)
 		if err != nil {
 			return err
 		}
-		if apiGroup != nil {
+		if apiGroup != nil && len(versions) == 0 {
 			for _, version := range apiGroup.Versions {
 				versions = append(versions, version.Version)
 			}
 		}
-	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Create or fetch group resources from cache.
-	groupResources := &restmapper.APIGroupResources{
-		Group:              metav1.APIGroup{Name: groupName},
-		VersionedResources: make(map[string][]metav1.APIResource),
+		// No need to do anything further if aggregatedDiscovery is supported and we did a lookup
+		if didAggregatedDiscovery {
+			failedGroups := make(map[schema.GroupVersion]error)
+			for _, version := range versions {
+				if m.knownGroups[groupName] == nil || m.knownGroups[groupName].VersionedResources[version] == nil {
+					failedGroups[schema.GroupVersion{Group: groupName, Version: version}] = &meta.NoResourceMatchError{
+						PartialResource: schema.GroupVersionResource{
+							Group:   groupName,
+							Version: version,
+						}}
+				}
+			}
+			if len(failedGroups) > 0 {
+				return ptr.To(ErrResourceDiscoveryFailed(failedGroups))
+			}
+			return nil
+		}
 	}
 
 	// Update information for group resources about versioned resources.
@@ -194,13 +214,26 @@ func (m *mapper) addKnownGroupAndReload(groupName string, versions ...string) er
 		return fmt.Errorf("failed to get API group resources: %w", err)
 	}
 
-	if _, ok := m.knownGroups[groupName]; ok {
-		groupResources = m.knownGroups[groupName]
-	}
+	m.addGroupVersionResourcesToCacheAndReloadLocked(groupVersionResources)
+	return nil
+}
 
+// addGroupVersionResourcesToCacheAndReloadLocked does what the name suggests. The mutex must be held when
+// calling it.
+func (m *mapper) addGroupVersionResourcesToCacheAndReloadLocked(gvr map[schema.GroupVersion]*metav1.APIResourceList) {
 	// Update information for group resources about the API group by adding new versions.
-	// Ignore the versions that are already registered.
-	for groupVersion, resources := range groupVersionResources {
+	// Ignore the versions that are already registered
+	for groupVersion, resources := range gvr {
+		var groupResources *restmapper.APIGroupResources
+		if _, ok := m.knownGroups[groupVersion.Group]; ok {
+			groupResources = m.knownGroups[groupVersion.Group]
+		} else {
+			groupResources = &restmapper.APIGroupResources{
+				Group:              metav1.APIGroup{Name: groupVersion.Group},
+				VersionedResources: make(map[string][]metav1.APIResource),
+			}
+		}
+
 		version := groupVersion.Version
 
 		groupResources.VersionedResources[version] = resources.APIResources
@@ -214,60 +247,56 @@ func (m *mapper) addKnownGroupAndReload(groupName string, versions ...string) er
 
 		if !found {
 			groupResources.Group.Versions = append(groupResources.Group.Versions, metav1.GroupVersionForDiscovery{
-				GroupVersion: metav1.GroupVersion{Group: groupName, Version: version}.String(),
+				GroupVersion: metav1.GroupVersion{Group: groupVersion.Group, Version: version}.String(),
 				Version:      version,
 			})
 		}
+
+		// Update data in the cache.
+		m.knownGroups[groupVersion.Group] = groupResources
 	}
 
-	// Update data in the cache.
-	m.knownGroups[groupName] = groupResources
-
-	// Finally, update the group with received information and regenerate the mapper.
+	// Finally, reload the mapper.
 	updatedGroupResources := make([]*restmapper.APIGroupResources, 0, len(m.knownGroups))
 	for _, agr := range m.knownGroups {
 		updatedGroupResources = append(updatedGroupResources, agr)
 	}
 
 	m.mapper = restmapper.NewDiscoveryRESTMapper(updatedGroupResources)
-	return nil
 }
 
-// findAPIGroupByNameLocked returns API group by its name.
-func (m *mapper) findAPIGroupByName(groupName string) (*metav1.APIGroup, error) {
-	// Looking in the cache first.
-	{
-		m.mu.RLock()
-		group, ok := m.apiGroups[groupName]
-		m.mu.RUnlock()
-		if ok {
-			return group, nil
-		}
+// findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked tries to find the passed apiGroup.
+// If the server supports aggregated discovery, it will always perform that.
+func (m *mapper) findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked(groupName string) (_ *metav1.APIGroup, didAggregatedDiscovery bool, _ error) {
+	// Looking in the cache first
+	group, ok := m.apiGroups[groupName]
+	if ok {
+		return group, false, nil
 	}
 
 	// Update the cache if nothing was found.
-	apiGroups, err := m.client.ServerGroups()
+	apiGroups, maybeResources, _, err := m.client.GroupsAndMaybeResources()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get server groups: %w", err)
+		return nil, false, fmt.Errorf("failed to get server groups: %w", err)
 	}
 	if len(apiGroups.Groups) == 0 {
-		return nil, fmt.Errorf("received an empty API groups list")
+		return nil, false, fmt.Errorf("received an empty API groups list")
 	}
 
-	m.mu.Lock()
+	m.initialDiscoveryDone = true
+	if len(maybeResources) > 0 {
+		didAggregatedDiscovery = true
+		m.addGroupVersionResourcesToCacheAndReloadLocked(maybeResources)
+	}
 	for i := range apiGroups.Groups {
 		group := &apiGroups.Groups[i]
 		m.apiGroups[group.Name] = group
 	}
-	m.mu.Unlock()
 
 	// Looking in the cache again.
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
 	// Don't return an error here if the API group is not present.
 	// The reloaded RESTMapper will take care of returning a NoMatchError.
-	return m.apiGroups[groupName], nil
+	return m.apiGroups[groupName], didAggregatedDiscovery, nil
 }
 
 // fetchGroupVersionResourcesLocked fetches the resources for the specified group and its versions.
@@ -283,10 +312,10 @@ func (m *mapper) fetchGroupVersionResourcesLocked(groupName string, versions ...
 		if apierrors.IsNotFound(err) {
 			// If the version is not found, we remove the group from the cache
 			// so it gets refreshed on the next call.
-			if m.isAPIGroupCached(groupVersion) {
+			if m.isAPIGroupCachedLocked(groupVersion) {
 				delete(m.apiGroups, groupName)
 			}
-			if m.isGroupVersionCached(groupVersion) {
+			if m.isGroupVersionCachedLocked(groupVersion) {
 				delete(m.knownGroups, groupName)
 			}
 			continue
@@ -308,8 +337,8 @@ func (m *mapper) fetchGroupVersionResourcesLocked(groupName string, versions ...
 	return groupVersionResources, nil
 }
 
-// isGroupVersionCached checks if a version for a group is cached in the known groups cache.
-func (m *mapper) isGroupVersionCached(gv schema.GroupVersion) bool {
+// isGroupVersionCachedLocked checks if a version for a group is cached in the known groups cache.
+func (m *mapper) isGroupVersionCachedLocked(gv schema.GroupVersion) bool {
 	if cachedGroup, ok := m.knownGroups[gv.Group]; ok {
 		_, cached := cachedGroup.VersionedResources[gv.Version]
 		return cached
@@ -318,8 +347,8 @@ func (m *mapper) isGroupVersionCached(gv schema.GroupVersion) bool {
 	return false
 }
 
-// isAPIGroupCached checks if a version for a group is cached in the api groups cache.
-func (m *mapper) isAPIGroupCached(gv schema.GroupVersion) bool {
+// isAPIGroupCachedLocked checks if a version for a group is cached in the api groups cache.
+func (m *mapper) isAPIGroupCachedLocked(gv schema.GroupVersion) bool {
 	cachedGroup, ok := m.apiGroups[gv.Group]
 	if !ok {
 		return false

--- a/pkg/client/apiutil/restmapper_test.go
+++ b/pkg/client/apiutil/restmapper_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
 
 	_ "github.com/onsi/ginkgo/v2"
@@ -68,607 +69,674 @@ func (crt *countingRoundTripper) Reset() {
 	crt.requestCount = 0
 }
 
-func setupEnvtest(t *testing.T) (*rest.Config, func(t *testing.T)) {
+func setupEnvtest(t *testing.T, disableAggregatedDiscovery bool) *rest.Config {
 	t.Log("Setup envtest")
 
 	g := gmg.NewWithT(t)
 	testEnv := &envtest.Environment{
 		CRDDirectoryPaths: []string{"testdata"},
 	}
+	if disableAggregatedDiscovery {
+		testEnv.ControlPlane.GetAPIServer().Configure().Append("feature-gates", "AggregatedDiscoveryEndpoint=false")
+	}
 
 	cfg, err := testEnv.Start()
 	g.Expect(err).NotTo(gmg.HaveOccurred())
 	g.Expect(cfg).NotTo(gmg.BeNil())
 
-	teardownFunc := func(t *testing.T) {
+	t.Cleanup(func() {
 		t.Log("Stop envtest")
 		g.Expect(testEnv.Stop()).To(gmg.Succeed())
-	}
+	})
 
-	return cfg, teardownFunc
+	return cfg
 }
 
 func TestLazyRestMapperProvider(t *testing.T) {
-	restCfg, tearDownFn := setupEnvtest(t)
-	defer tearDownFn(t)
-
-	t.Run("LazyRESTMapper should fetch data based on the request", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		// For each new group it performs just one request to the API server:
-		// GET https://host/apis/<group>/<version>
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		// There are no requests before any call
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"}, "v1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		mappings, err := lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "pod"}, "v1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mappings).To(gmg.HaveLen(1))
-		g.Expect(mappings[0].GroupVersionKind.Kind).To(gmg.Equal("pod"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		kind, err := lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kind.Kind).To(gmg.Equal("Ingress"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		kinds, err := lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kinds).To(gmg.HaveLen(1))
-		g.Expect(kinds[0].Kind).To(gmg.Equal("TokenReview"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		resource, err := lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(resource.Resource).To(gmg.Equal("priorityclasses"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
-
-		resources, err := lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(resources).To(gmg.HaveLen(1))
-		g.Expect(resources[0].Resource).To(gmg.Equal("poddisruptionbudgets"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(6))
-	})
-
-	t.Run("LazyRESTMapper should cache fetched data and doesn't perform any additional requests", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		// Data taken from cache - there are no more additional requests.
-
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		kind, err := lazyRestMapper.KindFor((schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"}))
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kind.Kind).To(gmg.Equal("Deployment"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		resource, err := lazyRestMapper.ResourceFor((schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"}))
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(resource.Resource).To(gmg.Equal("deployments"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-	})
-
-	t.Run("LazyRESTMapper should work correctly with empty versions list", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// crew.example.com has 2 versions: v1 and v2
-
-		// If no versions were provided by user, we fetch all of them.
-		// Here we expect 4 calls.
-		// To initialize:
-		// 	#1: GET https://host/api
-		// 	#2: GET https://host/apis
-		// Then, for each version it performs one request to the API server:
-		// 	#3: GET https://host/apis/crew.example.com/v1
-		//	#4: GET https://host/apis/crew.example.com/v2
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		// All subsequent calls won't send requests to the server.
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-	})
-
-	t.Run("LazyRESTMapper should work correctly with multiple API group versions", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// We explicitly ask for 2 versions: v1 and v2.
-		// For each version it performs one request to the API server:
-		// 	#1: GET https://host/apis/crew.example.com/v1
-		//	#2: GET https://host/apis/crew.example.com/v2
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1", "v2")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		// All subsequent calls won't send requests to the server as everything is stored in the cache.
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-	})
-
-	t.Run("LazyRESTMapper should work correctly with different API group versions", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// Now we want resources for crew.example.com/v1 version only.
-		// Here we expect 1 call:
-		// #1: GET https://host/apis/crew.example.com/v1
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		// Get additional resources from v2.
-		// It sends another request:
-		// #2: GET https://host/apis/crew.example.com/v2
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v2")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		// No subsequent calls require additional API requests.
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1", "v2")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-	})
-
-	t.Run("LazyRESTMapper should return an error if the group doesn't exist", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		// After initialization for each invalid group the mapper performs just 1 request to the API server.
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		// A version is specified but the group doesn't exist.
-		// For each group, we expect 1 call to the version-specific discovery endpoint:
-		// 	#1: GET https://host/apis/<group>/<version>
-
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID1"}, "v1")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "INVALID2"}, "v1")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "INVALID3", Version: "v1"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "INVALID4", Version: "v1"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "INVALID5", Version: "v1"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
-
-		_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "INVALID6", Version: "v1"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(6))
-
-		// No version is specified but the group doesn't exist.
-		// For each group, we expect 2 calls to discover all group versions:
-		// 	#1: GET https://host/api
-		// 	#2: GET https://host/apis
-
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID7"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(8))
-
-		_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "INVALID8"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(10))
-
-		_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "INVALID9"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(12))
-
-		_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "INVALID10"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(14))
-
-		_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "INVALID11"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(16))
-
-		_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "INVALID12"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(18))
-	})
-
-	t.Run("LazyRESTMapper should return an error if a resource doesn't exist", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		// For each invalid resource the mapper performs just 1 request to the API server.
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "INVALID"}, "v1")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "INVALID"}, "v1")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "INVALID"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "INVALID"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "INVALID"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
-
-		_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "INVALID"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(6))
-	})
-
-	t.Run("LazyRESTMapper should return an error if the version doesn't exist", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		// After initialization, for each invalid resource mapper performs 1 requests to the API server.
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"}, "INVALID")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "pod"}, "INVALID")
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-
-		_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "INVALID", Resource: "ingresses"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
-
-		_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "INVALID", Resource: "tokenreviews"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "INVALID", Resource: "priorityclasses"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
-
-		_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "INVALID", Resource: "poddisruptionbudgets"})
-		g.Expect(err).To(gmg.HaveOccurred())
-		g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(6))
-	})
-
-	t.Run("LazyRESTMapper should work correctly if the version isn't specified", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		kind, err := lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Resource: "ingress"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kind.Version).ToNot(gmg.BeEmpty())
-
-		kinds, err := lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Resource: "tokenreviews"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kinds).ToNot(gmg.BeEmpty())
-		g.Expect(kinds[0].Version).ToNot(gmg.BeEmpty())
-
-		resorce, err := lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Resource: "priorityclasses"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(resorce.Version).ToNot(gmg.BeEmpty())
-
-		resorces, err := lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Resource: "poddisruptionbudgets"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(kinds).ToNot(gmg.BeEmpty())
-		g.Expect(resorces[0].Version).ToNot(gmg.BeEmpty())
-	})
-
-	t.Run("LazyRESTMapper can fetch CRDs if they were created at runtime", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-
-		// To fetch all versions mapper does 2 requests:
-		// GET https://host/api
-		// GET https://host/apis
-		// Then, for each version it performs just one request to the API server as usual:
-		// GET https://host/apis/<group>/<version>
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		// There are no requests before any call
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// Since we don't specify what version we expect, restmapper will fetch them all and search there.
-		// To fetch a list of available versions
-		//  #1: GET https://host/api
-		//  #2: GET https://host/apis
-		// Then, for each currently registered version:
-		// 	#3: GET https://host/apis/crew.example.com/v1
-		//	#4: GET https://host/apis/crew.example.com/v2
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-
-		s := scheme.Scheme
-		err = apiextensionsv1.AddToScheme(s)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		c, err := client.New(restCfg, client.Options{Scheme: s})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		// Register another CRD in runtime - "riders.crew.example.com".
-		createNewCRD(context.TODO(), g, c, "crew.example.com", "Rider", "riders")
-
-		// Wait a bit until the CRD is registered.
-		g.Eventually(func() error {
-			_, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
-			return err
-		}).Should(gmg.Succeed())
-
-		// Since we don't specify what version we expect, restmapper will fetch them all and search there.
-		// To fetch a list of available versions
-		//  #1: GET https://host/api
-		//  #2: GET https://host/apis
-		// Then, for each currently registered version:
-		// 	#3: GET https://host/apis/crew.example.com/v1
-		//	#4: GET https://host/apis/crew.example.com/v2
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("rider"))
-	})
-
-	t.Run("LazyRESTMapper should invalidate the group cache if a version is not found", func(t *testing.T) {
-		g := gmg.NewWithT(t)
-		ctx := context.Background()
-
-		httpClient, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		crt := newCountingRoundTripper(httpClient.Transport)
-		httpClient.Transport = crt
-
-		lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		s := scheme.Scheme
-		err = apiextensionsv1.AddToScheme(s)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		c, err := client.New(restCfg, client.Options{Scheme: s})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-
-		// Register a new CRD ina  new group to avoid collisions when deleting versions - "taxis.inventory.example.com".
-		group := "inventory.example.com"
-		kind := "Taxi"
-		plural := "taxis"
-		crdName := plural + "." + group
-		// Create a CRD with two versions: v1alpha1 and v1 where both are served and
-		// v1 is the storage version so we can easily remove v1alpha1 later.
-		crd := newCRD(ctx, g, c, group, kind, plural)
-		v1alpha1 := crd.Spec.Versions[0]
-		v1alpha1.Name = "v1alpha1"
-		v1alpha1.Storage = false
-		v1alpha1.Served = true
-		v1 := crd.Spec.Versions[0]
-		v1.Name = "v1"
-		v1.Storage = true
-		v1.Served = true
-		crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{v1alpha1, v1}
-		g.Expect(c.Create(ctx, crd)).To(gmg.Succeed())
-		t.Cleanup(func() {
-			g.Expect(c.Delete(ctx, crd)).To(gmg.Succeed())
+	for _, aggregatedDiscovery := range []bool{true, false} {
+		t.Run("aggregatedDiscovery="+strconv.FormatBool(aggregatedDiscovery), func(t *testing.T) {
+			restCfg := setupEnvtest(t, !aggregatedDiscovery)
+
+			t.Run("LazyRESTMapper should fetch data based on the request", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				// For each new group it performs just one request to the API server:
+				// GET https://host/apis/<group>/<version>
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				// There are no requests before any call
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"}, "v1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				mappings, err := lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "pod"}, "v1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mappings).To(gmg.HaveLen(1))
+				g.Expect(mappings[0].GroupVersionKind.Kind).To(gmg.Equal("pod"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				kind, err := lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "ingresses"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kind.Kind).To(gmg.Equal("Ingress"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				kinds, err := lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "tokenreviews"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kinds).To(gmg.HaveLen(1))
+				g.Expect(kinds[0].Kind).To(gmg.Equal("TokenReview"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				resource, err := lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(resource.Resource).To(gmg.Equal("priorityclasses"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				resources, err := lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(resources).To(gmg.HaveLen(1))
+				g.Expect(resources[0].Resource).To(gmg.Equal("poddisruptionbudgets"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+			})
+
+			t.Run("LazyRESTMapper should cache fetched data and doesn't perform any additional requests", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				// Data taken from cache - there are no more additional requests.
+
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("deployment"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				kind, err := lazyRestMapper.KindFor((schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"}))
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kind.Kind).To(gmg.Equal("Deployment"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				resource, err := lazyRestMapper.ResourceFor((schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployment"}))
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(resource.Resource).To(gmg.Equal("deployments"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+			})
+
+			t.Run("LazyRESTMapper should work correctly with empty versions list", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// crew.example.com has 2 versions: v1 and v2
+
+				// If no versions were provided by user, we fetch all of them.
+				// Here we expect 4 calls.
+				// To initialize:
+				// 	#1: GET https://host/api
+				// 	#2: GET https://host/apis
+				// Then, for each version it performs one request to the API server:
+				// 	#3: GET https://host/apis/crew.example.com/v1
+				//	#4: GET https://host/apis/crew.example.com/v2
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				expectedAPIRequestCount := 4
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				// All subsequent calls won't send requests to the server.
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+			})
+
+			t.Run("LazyRESTMapper should work correctly with multiple API group versions", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// We explicitly ask for 2 versions: v1 and v2.
+				// For each version it performs one request to the API server:
+				// 	#1: GET https://host/apis/crew.example.com/v1
+				//	#2: GET https://host/apis/crew.example.com/v2
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1", "v2")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				expectedAPIRequestCount := 4
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				// All subsequent calls won't send requests to the server as everything is stored in the cache.
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+			})
+
+			t.Run("LazyRESTMapper should work correctly with different API group versions", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// Now we want resources for crew.example.com/v1 version only.
+				// Here we expect 1 call:
+				// #1: GET https://host/apis/crew.example.com/v1
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				// Get additional resources from v2.
+				// It sends another request:
+				// #2: GET https://host/apis/crew.example.com/v2
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v2")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				if !aggregatedDiscovery {
+					expectedAPIRequestCount++
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				// No subsequent calls require additional API requests.
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"}, "v1", "v2")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+			})
+
+			t.Run("LazyRESTMapper should return an error if the group doesn't exist", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				// After initialization for each invalid group the mapper performs just 1 request to the API server.
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				// A version is specified but the group doesn't exist.
+				// For each group, we expect 1 call to the version-specific discovery endpoint:
+				// 	#1: GET https://host/apis/<group>/<version>
+
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID1"}, "v1")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+				crt.Reset()
+
+				_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "INVALID2"}, "v1")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
+
+				_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "INVALID3", Version: "v1", Resource: "invalid"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
+
+				_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "INVALID4", Version: "v1", Resource: "invalid"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
+
+				_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "INVALID5", Version: "v1", Resource: "invalid"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
+
+				_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "INVALID6", Version: "v1", Resource: "invalid"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
+
+				// No version is specified but the group doesn't exist.
+				// For each group, we expect 2 calls to discover all group versions:
+				// 	#1: GET https://host/api
+				// 	#2: GET https://host/apis
+
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "INVALID7"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(7))
+
+				_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "INVALID8"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(9))
+
+				_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "INVALID9", Resource: "invalid"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(11))
+
+				_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "INVALID10", Resource: "invalid"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(13))
+
+				_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "INVALID11", Resource: "invalid"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(15))
+
+				_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "INVALID12", Resource: "invalid"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(17))
+			})
+
+			t.Run("LazyRESTMapper should return an error if a resource doesn't exist", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				// For each invalid resource the mapper performs just 1 request to the API server.
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "INVALID"}, "v1")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+				crt.Reset()
+
+				_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "INVALID"}, "v1")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
+
+				_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "v1", Resource: "INVALID"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
+
+				_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "v1", Resource: "INVALID"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
+
+				_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "v1", Resource: "INVALID"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
+
+				_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "INVALID"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
+			})
+
+			t.Run("LazyRESTMapper should return an error if the version doesn't exist", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				// After initialization, for each invalid resource mapper performs 1 requests to the API server.
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "apps", Kind: "deployment"}, "INVALID")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				expectedAPIRequestCount := 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+				crt.Reset()
+
+				_, err = lazyRestMapper.RESTMappings(schema.GroupKind{Group: "", Kind: "pod"}, "INVALID")
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
+
+				_, err = lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Version: "INVALID", Resource: "ingresses"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
+
+				_, err = lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Version: "INVALID", Resource: "tokenreviews"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(3))
+
+				_, err = lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Version: "INVALID", Resource: "priorityclasses"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
+
+				_, err = lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Version: "INVALID", Resource: "poddisruptionbudgets"})
+				g.Expect(err).To(gmg.HaveOccurred())
+				g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(5))
+			})
+
+			t.Run("LazyRESTMapper should work correctly if the version isn't specified", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				kind, err := lazyRestMapper.KindFor(schema.GroupVersionResource{Group: "networking.k8s.io", Resource: "ingress"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kind.Version).ToNot(gmg.BeEmpty())
+
+				kinds, err := lazyRestMapper.KindsFor(schema.GroupVersionResource{Group: "authentication.k8s.io", Resource: "tokenreviews"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kinds).ToNot(gmg.BeEmpty())
+				g.Expect(kinds[0].Version).ToNot(gmg.BeEmpty())
+
+				resorce, err := lazyRestMapper.ResourceFor(schema.GroupVersionResource{Group: "scheduling.k8s.io", Resource: "priorityclasses"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(resorce.Version).ToNot(gmg.BeEmpty())
+
+				resorces, err := lazyRestMapper.ResourcesFor(schema.GroupVersionResource{Group: "policy", Resource: "poddisruptionbudgets"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(kinds).ToNot(gmg.BeEmpty())
+				g.Expect(resorces[0].Version).ToNot(gmg.BeEmpty())
+			})
+
+			t.Run("LazyRESTMapper can fetch CRDs if they were created at runtime", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+
+				// To fetch all versions mapper does 2 requests:
+				// GET https://host/api
+				// GET https://host/apis
+				// Then, for each version it performs just one request to the API server as usual:
+				// GET https://host/apis/<group>/<version>
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				// There are no requests before any call
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// Since we don't specify what version we expect, restmapper will fetch them all and search there.
+				// To fetch a list of available versions
+				//  #1: GET https://host/api
+				//  #2: GET https://host/apis
+				// Then, for each currently registered version:
+				// 	#3: GET https://host/apis/crew.example.com/v1
+				//	#4: GET https://host/apis/crew.example.com/v2
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "driver"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("driver"))
+				expectedAPIRequestCount := 4
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+
+				s := scheme.Scheme
+				err = apiextensionsv1.AddToScheme(s)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				c, err := client.New(restCfg, client.Options{Scheme: s})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				// Register another CRD in runtime - "riders.crew.example.com".
+				createNewCRD(context.TODO(), g, c, "crew.example.com", "Rider", "riders")
+
+				// Wait a bit until the CRD is registered.
+				g.Eventually(func() error {
+					_, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
+					return err
+				}).Should(gmg.Succeed())
+
+				// Since we don't specify what version we expect, restmapper will fetch them all and search there.
+				// To fetch a list of available versions
+				//  #1: GET https://host/api
+				//  #2: GET https://host/apis
+				// Then, for each currently registered version:
+				// 	#3: GET https://host/apis/crew.example.com/v1
+				//	#4: GET https://host/apis/crew.example.com/v2
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("rider"))
+			})
+
+			t.Run("LazyRESTMapper should invalidate the group cache if a version is not found", func(t *testing.T) {
+				g := gmg.NewWithT(t)
+				ctx := context.Background()
+
+				httpClient, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				crt := newCountingRoundTripper(httpClient.Transport)
+				httpClient.Transport = crt
+
+				lazyRestMapper, err := apiutil.NewDynamicRESTMapper(restCfg, httpClient)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				s := scheme.Scheme
+				err = apiextensionsv1.AddToScheme(s)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				c, err := client.New(restCfg, client.Options{Scheme: s})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+
+				// Register a new CRD ina  new group to avoid collisions when deleting versions - "taxis.inventory.example.com".
+				group := "inventory.example.com"
+				kind := "Taxi"
+				plural := "taxis"
+				crdName := plural + "." + group
+				// Create a CRD with two versions: v1alpha1 and v1 where both are served and
+				// v1 is the storage version so we can easily remove v1alpha1 later.
+				crd := newCRD(ctx, g, c, group, kind, plural)
+				v1alpha1 := crd.Spec.Versions[0]
+				v1alpha1.Name = "v1alpha1"
+				v1alpha1.Storage = false
+				v1alpha1.Served = true
+				v1 := crd.Spec.Versions[0]
+				v1.Name = "v1"
+				v1.Storage = true
+				v1.Served = true
+				crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{v1alpha1, v1}
+				g.Expect(c.Create(ctx, crd)).To(gmg.Succeed())
+				t.Cleanup(func() {
+					g.Expect(c.Delete(ctx, crd)).To(gmg.Succeed())
+				})
+
+				// Wait until the CRD is registered.
+				discHTTP, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				discClient, err := discovery.NewDiscoveryClientForConfigAndClient(restCfg, discHTTP)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Eventually(func(g gmg.Gomega) {
+					_, err = discClient.ServerResourcesForGroupVersion(group + "/v1")
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+				}).Should(gmg.Succeed(), "v1 should be available")
+
+				// There are no requests before any call
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// Since we don't specify what version we expect, restmapper will fetch them all and search there.
+				// To fetch a list of available versions
+				//  #1: GET https://host/api
+				//  #2: GET https://host/apis
+				// Then, for all available versions:
+				// 	#3: GET https://host/apis/inventory.example.com/v1alpha1
+				//	#4: GET https://host/apis/inventory.example.com/v1
+				// This should fill the cache for apiGroups and versions.
+				mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal(kind))
+				expectedAPIRequestCount := 4
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
+				crt.Reset() // We reset the counter to check how many additional requests are made later.
+
+				// At this point v1alpha1 should be cached
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// We update the CRD to only have v1 version.
+				g.Expect(c.Get(ctx, types.NamespacedName{Name: crdName}, crd)).To(gmg.Succeed())
+				for _, version := range crd.Spec.Versions {
+					if version.Name == "v1" {
+						v1 = version
+						break
+					}
+				}
+				crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{v1}
+				g.Expect(c.Update(ctx, crd)).To(gmg.Succeed())
+
+				// We wait until v1alpha1 is not available anymore.
+				g.Eventually(func(g gmg.Gomega) {
+					_, err = discClient.ServerResourcesForGroupVersion(group + "/v1alpha1")
+					g.Expect(apierrors.IsNotFound(err)).To(gmg.BeTrue(), "v1alpha1 should not be available anymore")
+				}).Should(gmg.Succeed())
+
+				// Although v1alpha1 is not available anymore, the cache is not invalidated yet so it should return a mapping.
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
+
+				// We request Limo, which is not in the mapper because it doesn't exist.
+				// This will trigger a reload of the lazy mapper cache.
+				// Reloading the cache will read v2 again and since it's not available anymore, it should invalidate the cache.
+				// 	#1: GET https://host/apis/inventory.example.com/v1alpha1
+				// 	#2: GET https://host/apis/inventory.example.com/v1
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: "Limo"})
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
+				crt.Reset()
+
+				// Now we request v1alpha1 again and it should return an error since the cache was invalidated.
+				// 	#1: GET https://host/apis/inventory.example.com/v1alpha1
+				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
+				g.Expect(err).To(beNoMatchError())
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
+
+				// Verify that when requesting the mapping without a version, it doesn't error
+				// and it returns v1.
+				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind})
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				g.Expect(mapping.Resource.Version).To(gmg.Equal("v1"))
+			})
 		})
-
-		// Wait until the CRD is registered.
-		discHTTP, err := rest.HTTPClientFor(restCfg)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		discClient, err := discovery.NewDiscoveryClientForConfigAndClient(restCfg, discHTTP)
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Eventually(func(g gmg.Gomega) {
-			_, err = discClient.ServerResourcesForGroupVersion(group + "/v1")
-			g.Expect(err).NotTo(gmg.HaveOccurred())
-		}).Should(gmg.Succeed(), "v1 should be available")
-
-		// There are no requests before any call
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// Since we don't specify what version we expect, restmapper will fetch them all and search there.
-		// To fetch a list of available versions
-		//  #1: GET https://host/api
-		//  #2: GET https://host/apis
-		// Then, for all available versions:
-		// 	#3: GET https://host/apis/inventory.example.com/v1alpha1
-		//	#4: GET https://host/apis/inventory.example.com/v1
-		// This should fill the cache for apiGroups and versions.
-		mapping, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal(kind))
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(4))
-		crt.Reset() // We reset the counter to check how many additional requests are made later.
-
-		// At this point v1alpha1 should be cached
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// We update the CRD to only have v1 version.
-		g.Expect(c.Get(ctx, types.NamespacedName{Name: crdName}, crd)).To(gmg.Succeed())
-		for _, version := range crd.Spec.Versions {
-			if version.Name == "v1" {
-				v1 = version
-				break
-			}
-		}
-		crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{v1}
-		g.Expect(c.Update(ctx, crd)).To(gmg.Succeed())
-
-		// We wait until v1alpha1 is not available anymore.
-		g.Eventually(func(g gmg.Gomega) {
-			_, err = discClient.ServerResourcesForGroupVersion(group + "/v1alpha1")
-			g.Expect(apierrors.IsNotFound(err)).To(gmg.BeTrue(), "v1alpha1 should not be available anymore")
-		}).Should(gmg.Succeed())
-
-		// Although v1alpha1 is not available anymore, the cache is not invalidated yet so it should return a mapping.
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
-
-		// We request Limo, which is not in the mapper because it doesn't exist.
-		// This will trigger a reload of the lazy mapper cache.
-		// Reloading the cache will read v2 again and since it's not available anymore, it should invalidate the cache.
-		// 	#1: GET https://host/apis/inventory.example.com/v1alpha1
-		// 	#2: GET https://host/apis/inventory.example.com/v1
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: "Limo"})
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
-		crt.Reset()
-
-		// Now we request v1alpha1 again and it should return an error since the cache was invalidated.
-		// 	#1: GET https://host/apis/inventory.example.com/v1alpha1
-		_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind}, "v1alpha1")
-		g.Expect(err).To(beNoMatchError())
-		g.Expect(crt.GetRequestCount()).To(gmg.Equal(1))
-
-		// Verify that when requesting the mapping without a version, it doesn't error
-		// and it returns v1.
-		mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: kind})
-		g.Expect(err).NotTo(gmg.HaveOccurred())
-		g.Expect(mapping.Resource.Version).To(gmg.Equal("v1"))
-	})
+	}
 }
 
 // createNewCRD creates a new CRD with the given group, kind, and plural and returns it.

--- a/pkg/client/apiutil/restmapper_wb_test.go
+++ b/pkg/client/apiutil/restmapper_wb_test.go
@@ -21,6 +21,8 @@ import (
 
 	gmg "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/restmapper"
 )
@@ -190,7 +192,7 @@ func TestLazyRestMapper_fetchGroupVersionResourcesLocked_CacheInvalidation(t *te
 			g := gmg.NewWithT(t)
 			m := &mapper{
 				mapper:      restmapper.NewDiscoveryRESTMapper([]*restmapper.APIGroupResources{}),
-				client:      fake.NewSimpleClientset().Discovery(),
+				client:      &fakeAggregatedDiscoveryClient{DiscoveryInterface: fake.NewSimpleClientset().Discovery()},
 				apiGroups:   tt.cachedAPIGroups,
 				knownGroups: tt.cachedKnownGroups,
 			}
@@ -200,4 +202,13 @@ func TestLazyRestMapper_fetchGroupVersionResourcesLocked_CacheInvalidation(t *te
 			g.Expect(m.knownGroups).To(gmg.BeComparableTo(tt.expectedKnownGroups))
 		})
 	}
+}
+
+type fakeAggregatedDiscoveryClient struct {
+	discovery.DiscoveryInterface
+}
+
+func (f *fakeAggregatedDiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
+	groupList, err := f.DiscoveryInterface.ServerGroups()
+	return groupList, nil, nil, err
 }


### PR DESCRIPTION
This change makes the `RESTMapper` use [AggredatedDiscovery][0] if available. `AggregatedDiscovery` is beta and thus enabled by default since Kube 1.27.

What this means in particular is that during startup, we will always do a request to `/api` and `/apis`. If `AggregatedDiscovery` is enabled, that is all we have to do. If not, we have to do a third request.

The behavior for reloading remains the same: Do one request unless the request didn't include a version. In that case we have to find the group. If the group is unknown, we will keep on doing a request to `/api` and one to `/apis` to find it. If it is found we are again done in the `AggregatedDiscovery` case and have to do a third request otherwise.

All in all this means that with `AggregatedDiscovery` enabled, the only case where this is worse is if the client interacts with only one `GroupVersion`, as we end up doing one additional api request. If it is disabled, we effectively waste two api requests.

[0]: https://github.com/kubernetes/enhancements/issues/3352

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/2897

Note: Disable whitespace when reviewing, that significantly reduces the size of the diff.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
