### PR TITLE
⚠ Recover panics per default

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -42,7 +42,7 @@ type WebhookBuilder struct {
 	gvk             schema.GroupVersionKind
 	mgr             manager.Manager
 	config          *rest.Config
-	recoverPanic    bool
+	recoverPanic    *bool
 	logConstructor  func(base logr.Logger, req *admission.Request) logr.Logger
 	err             error
 }
@@ -84,8 +84,9 @@ func (blder *WebhookBuilder) WithLogConstructor(logConstructor func(base logr.Lo
 }
 
 // RecoverPanic indicates whether panics caused by the webhook should be recovered.
-func (blder *WebhookBuilder) RecoverPanic() *WebhookBuilder {
-	blder.recoverPanic = true
+// Defaults to true.
+func (blder *WebhookBuilder) RecoverPanic(recoverPanic *bool) *WebhookBuilder {
+	blder.recoverPanic = recoverPanic
 	return blder
 }
 

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -160,7 +161,7 @@ func runTests(admissionReviewVersion string) {
 
 		err = WebhookManagedBy(m).
 			For(&TestDefaulter{Panic: true}).
-			RecoverPanic().
+			RecoverPanic(nil). // Defaults to true.
 			Complete()
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		svr := m.GetWebhookServer()
@@ -369,7 +370,7 @@ func runTests(admissionReviewVersion string) {
 
 		err = WebhookManagedBy(m).
 			For(&TestValidator{Panic: true}).
-			RecoverPanic().
+			RecoverPanic(ptr.To[bool](true)).
 			Complete()
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		svr := m.GetWebhookServer()

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/ptr"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -161,7 +160,7 @@ func runTests(admissionReviewVersion string) {
 
 		err = WebhookManagedBy(m).
 			For(&TestDefaulter{Panic: true}).
-			RecoverPanic(nil). // Defaults to true.
+			// RecoverPanic defaults to true.
 			Complete()
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		svr := m.GetWebhookServer()
@@ -370,7 +369,7 @@ func runTests(admissionReviewVersion string) {
 
 		err = WebhookManagedBy(m).
 			For(&TestValidator{Panic: true}).
-			RecoverPanic(ptr.To[bool](true)).
+			RecoverPanic(true).
 			Complete()
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 		svr := m.GetWebhookServer()

--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -41,6 +41,7 @@ type Controller struct {
 
 	// RecoverPanic indicates whether the panic caused by reconcile should be recovered.
 	// Defaults to the Controller.RecoverPanic setting from the Manager if unset.
+	// Defaults to true if Controller.RecoverPanic setting from the Manager is also unset.
 	RecoverPanic *bool
 
 	// NeedLeaderElection indicates whether the controller needs to use leader election.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -45,6 +45,7 @@ type TypedOptions[request comparable] struct {
 
 	// RecoverPanic indicates whether the panic caused by reconcile should be recovered.
 	// Defaults to the Controller.RecoverPanic setting from the Manager if unset.
+	// Defaults to true if Controller.RecoverPanic setting from the Manager is also unset.
 	RecoverPanic *bool
 
 	// NeedLeaderElection indicates whether the controller needs to use leader election.

--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -46,6 +46,13 @@ var (
 		Help: "Total number of terminal reconciliation errors per controller",
 	}, []string{"controller"})
 
+	// ReconcilePanics is a prometheus counter metrics which holds the total
+	// number of panics from the Reconciler.
+	ReconcilePanics = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_reconcile_panics_total",
+		Help: "Total number of reconciliation panics per controller",
+	}, []string{"controller"})
+
 	// ReconcileTime is a prometheus metric which keeps track of the duration
 	// of reconciliations.
 	ReconcileTime = prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -75,6 +82,7 @@ func init() {
 		ReconcileTotal,
 		ReconcileErrors,
 		TerminalReconcileErrors,
+		ReconcilePanics,
 		ReconcileTime,
 		WorkerCount,
 		ActiveWorkers,

--- a/pkg/webhook/admission/metrics/metrics.go
+++ b/pkg/webhook/admission/metrics/metrics.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	// WebhookPanics is a prometheus counter metrics which holds the total
+	// number of panics from webhooks.
+	WebhookPanics = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_webhook_panics_total",
+		Help: "Total number of webhook panics",
+	}, []string{})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		WebhookPanics,
+	)
+	// Init metric.
+	WebhookPanics.WithLabelValues().Add(0)
+}

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
+	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics"
@@ -123,7 +124,8 @@ type Webhook struct {
 	Handler Handler
 
 	// RecoverPanic indicates whether the panic caused by webhook should be recovered.
-	RecoverPanic bool
+	// Defaults to true.
+	RecoverPanic *bool
 
 	// WithContextFunc will allow you to take the http.Request.Context() and
 	// add any additional information such as passing the request path or
@@ -141,7 +143,8 @@ type Webhook struct {
 }
 
 // WithRecoverPanic takes a bool flag which indicates whether the panic caused by webhook should be recovered.
-func (wh *Webhook) WithRecoverPanic(recoverPanic bool) *Webhook {
+// Defaults to true.
+func (wh *Webhook) WithRecoverPanic(recoverPanic *bool) *Webhook {
 	wh.RecoverPanic = recoverPanic
 	return wh
 }
@@ -151,17 +154,26 @@ func (wh *Webhook) WithRecoverPanic(recoverPanic bool) *Webhook {
 // If the webhook is validating type, it delegates the AdmissionRequest to each handler and
 // deny the request if anyone denies.
 func (wh *Webhook) Handle(ctx context.Context, req Request) (response Response) {
-	if wh.RecoverPanic {
-		defer func() {
-			if r := recover(); r != nil {
+	defer func() {
+		if r := recover(); r != nil {
+			admissionmetrics.WebhookPanics.WithLabelValues().Inc()
+
+			if wh.RecoverPanic == nil || *wh.RecoverPanic {
 				for _, fn := range utilruntime.PanicHandlers {
 					fn(ctx, r)
 				}
 				response = Errored(http.StatusInternalServerError, fmt.Errorf("panic: %v [recovered]", r))
+				// Note: We explicitly have to set the response UID. Usually that is done via resp.Complete below,
+				// but if we encounter a panic in wh.Handler.Handle we are never going to reach resp.Complete.
+				response.UID = req.UID
 				return
 			}
-		}()
-	}
+
+			log := logf.FromContext(ctx)
+			log.Info(fmt.Sprintf("Observed a panic in webhook: %v", r))
+			panic(r)
+		}
+	}()
 
 	reqLog := wh.getLogger(&req)
 	ctx = logf.IntoContext(ctx, reqLog)
@@ -169,7 +181,10 @@ func (wh *Webhook) Handle(ctx context.Context, req Request) (response Response) 
 	resp := wh.Handler.Handle(ctx, req)
 	if err := resp.Complete(req); err != nil {
 		reqLog.Error(err, "unable to encode response")
-		return Errored(http.StatusInternalServerError, errUnableToEncodeResponse)
+		resp := Errored(http.StatusInternalServerError, errUnableToEncodeResponse)
+		// Note: We explicitly have to set the response UID. Usually that is done via resp.Complete.
+		resp.UID = req.UID
+		return resp
 	}
 
 	return resp

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -144,8 +144,8 @@ type Webhook struct {
 
 // WithRecoverPanic takes a bool flag which indicates whether the panic caused by webhook should be recovered.
 // Defaults to true.
-func (wh *Webhook) WithRecoverPanic(recoverPanic *bool) *Webhook {
-	wh.RecoverPanic = recoverPanic
+func (wh *Webhook) WithRecoverPanic(recoverPanic bool) *Webhook {
+	wh.RecoverPanic = &recoverPanic
 	return wh
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

Recover panics in reconcilers & webhooks per default. Also adds corresponding metrics.

<!-- What does this do, and why do we need it? -->

Fixes #2167