### PR TITLE
🌱  Use envtest v1.30.2

### DIFF
--- a/hack/check-everything.sh
+++ b/hack/check-everything.sh
@@ -28,7 +28,7 @@ kb_root_dir=$tmp_root/kubebuilder
 ${hack_dir}/verify.sh
 
 # Envtest.
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.28.0"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.30.2"}
 
 header_text "installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 tmp_bin=/tmp/cr-tests-bin


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Just realized we're still using 1.28 when looking into https://github.com/kubernetes-sigs/controller-runtime/pull/2901
