### PR TITLE
🌱 Add action to approve actions if ok-to-test is set

### DIFF
--- a/.github/workflows/pr-gh-workflow-approve.yaml
+++ b/.github/workflows/pr-gh-workflow-approve.yaml
@@ -1,0 +1,42 @@
+name: PR approve GH Workflows
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - labeled
+      - reopened
+      - synchronize
+
+permissions: {}
+
+jobs:
+  approve:
+    name: Approve ok-to-test
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Update PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        continue-on-error: true
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const result = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+              per_page: 100
+            });
+
+            for (var run of result.data.workflow_runs) {
+              await github.rest.actions.approveWorkflowRun({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id
+              });
+            }


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This automatically approves GitHub actions once ok-to-test is set. This avoids that maintainers have to click the approve button for GitHub actions on PRs of new contributors
