### PR TITLE
✨ Publish setup-envtest binaries on releases

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -23,12 +23,14 @@ jobs:
           - ""
           - tools/setup-envtest
     steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+      - name: Calculate go version
+        id: vars
+        run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v5.0.2
         with:
-          go-version: "1.22"
-          cache: false
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+          go-version: ${{ steps.vars.outputs.go_version }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # tag=v6.1.0
         with:

--- a/.github/workflows/pr-dependabot.yaml
+++ b/.github/workflows/pr-dependabot.yaml
@@ -20,10 +20,13 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
     - name: Set up Go
       uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v5.0.2
       with:
-        go-version: '1.22'
+        go-version: ${{ steps.vars.outputs.go_version }}
     - name: Update all modules
       run: make modules
     - uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # tag=v9.1.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Upload binaries to release
+
+on:
+  push:
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Upload binaries to release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # tag=v4.1.7
+    - name: Calculate go version
+      id: vars
+      run: echo "go_version=$(make go-version)" >> $GITHUB_OUTPUT
+    - name: Set up Go
+      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # tag=v5.0.2
+      with:
+        go-version: ${{ steps.vars.outputs.go_version }}
+    - name: Generate release binaries
+      run: |
+        make release
+    - name: Release
+      uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # tag=v2.0.8
+      with:
+        draft: false
+        files: tools/setup-envtest/out/*

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,8 @@
 # Tools binaries.
 hack/tools/bin
 
+# Release artifacts
+tools/setup-envtest/out
+
 junit-report.xml
 /artifacts

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,11 @@
 SHELL:=/usr/bin/env bash
 .DEFAULT_GOAL:=help
 
+#
+# Go.
+#
+GO_VERSION ?= 1.22.5
+
 # Use GOPROXY environment variable if set
 GOPROXY := $(shell go env GOPROXY)
 ifeq ($(GOPROXY),)
@@ -33,6 +38,13 @@ export GOPROXY
 
 # Active module mode, as we use go modules to manage dependencies
 export GO111MODULE=on
+
+# Hosts running SELinux need :z added to volume mounts
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
+
+ifeq ($(SELINUX_ENABLED),1)
+  DOCKER_VOL_OPTS?=:z
+endif
 
 # Tools.
 TOOLS_DIR := hack/tools
@@ -124,6 +136,48 @@ modules: ## Runs go mod to ensure modules are up to date.
 	cd $(SCRATCH_ENV_DIR); go mod tidy
 
 ## --------------------------------------
+## Release
+## --------------------------------------
+
+RELEASE_DIR := tools/setup-envtest/out
+
+.PHONY: $(RELEASE_DIR)
+$(RELEASE_DIR):
+	mkdir -p $(RELEASE_DIR)/
+
+.PHONY: release
+release: clean-release $(RELEASE_DIR) ## Build release.
+	@if ! [ -z "$$(git status --porcelain)" ]; then echo "Your local git repository contains uncommitted changes, use git clean before proceeding."; exit 1; fi
+
+	# Build binaries first.
+	$(MAKE) release-binaries
+
+.PHONY: release-binaries
+release-binaries: ## Build release binaries.
+	RELEASE_BINARY=setup-envtest-linux-amd64       GOOS=linux   GOARCH=amd64   $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-linux-arm64       GOOS=linux   GOARCH=arm64   $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-linux-ppc64le     GOOS=linux   GOARCH=ppc64le $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-linux-s390x       GOOS=linux   GOARCH=s390x   $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-darwin-amd64      GOOS=darwin  GOARCH=amd64   $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-darwin-arm64      GOOS=darwin  GOARCH=arm64   $(MAKE) release-binary
+	RELEASE_BINARY=setup-envtest-windows-amd64.exe GOOS=windows GOARCH=amd64   $(MAKE) release-binary
+
+.PHONY: release-binary
+release-binary: $(RELEASE_DIR)
+	docker run \
+		--rm \
+		-e CGO_ENABLED=0 \
+		-e GOOS=$(GOOS) \
+		-e GOARCH=$(GOARCH) \
+		-e GOCACHE=/tmp/ \
+		--user $$(id -u):$$(id -g) \
+		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
+		-w /workspace/tools/setup-envtest \
+		golang:$(GO_VERSION) \
+		go build -a -trimpath -ldflags "-extldflags '-static'" \
+		-o ./out/$(RELEASE_BINARY) ./
+
+## --------------------------------------
 ## Cleanup / Verification
 ## --------------------------------------
 
@@ -135,6 +189,10 @@ clean: ## Cleanup.
 .PHONY: clean-bin
 clean-bin: ## Remove all generated binaries.
 	rm -rf hack/tools/bin
+
+.PHONY: clean-release
+clean-release: ## Remove the release folder
+	rm -rf $(RELEASE_DIR)
 
 .PHONY: verify-modules
 verify-modules: modules $(GO_MOD_CHECK) ## Verify go modules are up to date
@@ -149,3 +207,12 @@ APIDIFF_OLD_COMMIT ?= $(shell git rev-parse origin/main)
 .PHONY: apidiff
 verify-apidiff: $(GO_APIDIFF) ## Check for API differences
 	$(GO_APIDIFF) $(APIDIFF_OLD_COMMIT) --print-compatible
+
+## --------------------------------------
+## Helpers
+## --------------------------------------
+
+##@ helpers:
+
+go-version: ## Print the go version we use to compile our binaries and images
+	@echo $(GO_VERSION)


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR adds a GitHub action which will build & upload binaries whenever a tag/release is created
(this requires no changes to our release workflow, simply creating a GitHub release still works)

An example can be seen here: https://github.com/sbueringer/controller-runtime/releases/tag/v0.19.0-beta.0