### PR TITLE
✨ Allow to wire an object mutation handler

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -67,6 +67,9 @@ func (blder *WebhookBuilder) For(apiType runtime.Object) *WebhookBuilder {
 }
 
 // WithMutationHandler takes an admission.Handler, a MutatingWebhook will be wired for it.
+// A mutation handler is a low-level plug point for advanced use cases that need control
+// to generate patches. If in doubt, prefer using WithDefaulter to register a defaulter.
+// You can only use one of WithMutationHandler or WithDefaulter.
 func (blder *WebhookBuilder) WithMutationHandler(h admission.Handler) *WebhookBuilder {
 	blder.mutationHandler = h
 	return blder

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -649,8 +649,7 @@ func (*TestDefaultValidatorList) DeepCopyObject() runtime.Object   { return nil 
 type TestCustomDefaulter struct{}
 
 func (*TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) error {
-	log := logf.FromContext(ctx)
-	log.Info("Defaulting object")
+	logf.FromContext(ctx).Info("Defaulting object")
 	req, err := admission.RequestFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("expected admission.Request in ctx: %w", err)
@@ -676,8 +675,7 @@ var _ admission.CustomDefaulter = &TestCustomDefaulter{}
 type TestMutationHandler struct{}
 
 func (*TestMutationHandler) Handle(ctx context.Context, req admission.Request) admission.Response {
-	log := logf.FromContext(ctx)
-	log.Info("Mutating object")
+	logf.FromContext(ctx).Info("Mutating object")
 	return admission.Response{
 		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed:   true,

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -27,7 +27,6 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -96,9 +95,6 @@ func (r *Response) Complete(req Request) error {
 	return nil
 }
 
-// HandlerFactory can create a Handler for the given type.
-type HandlerFactory func(obj runtime.Object, decoder Decoder) Handler
-
 // Handler can handle an AdmissionRequest.
 type Handler interface {
 	// Handle yields a response to an AdmissionRequest.
@@ -116,13 +112,6 @@ var _ Handler = HandlerFunc(nil)
 // Handle process the AdmissionRequest by invoking the underlying function.
 func (f HandlerFunc) Handle(ctx context.Context, req Request) Response {
 	return f(ctx, req)
-}
-
-// WithHandlerFactory creates a new Webhook for a handler factory.
-func WithHandlerFactory(scheme *runtime.Scheme, obj runtime.Object, factory HandlerFactory) *Webhook {
-	return &Webhook{
-		Handler: factory(obj, NewDecoder(scheme)),
-	}
 }
 
 // Webhook represents each individual webhook.

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -27,6 +27,7 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/json"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/klog/v2"
@@ -95,6 +96,9 @@ func (r *Response) Complete(req Request) error {
 	return nil
 }
 
+// HandlerFactory can create a Handler for the given type.
+type HandlerFactory func(obj runtime.Object, decoder Decoder) Handler
+
 // Handler can handle an AdmissionRequest.
 type Handler interface {
 	// Handle yields a response to an AdmissionRequest.
@@ -112,6 +116,13 @@ var _ Handler = HandlerFunc(nil)
 // Handle process the AdmissionRequest by invoking the underlying function.
 func (f HandlerFunc) Handle(ctx context.Context, req Request) Response {
 	return f(ctx, req)
+}
+
+// WithHandlerFactory creates a new Webhook for a handler factory.
+func WithHandlerFactory(scheme *runtime.Scheme, obj runtime.Object, factory HandlerFactory) *Webhook {
+	return &Webhook{
+		Handler: factory(obj, NewDecoder(scheme)),
+	}
 }
 
 // Webhook represents each individual webhook.


### PR DESCRIPTION
## Proposal

Allow wiring an `admission.Handler` to process mutations in a webhook, as part of the `builder.WebhookBuilder`.

## Motivation

Currently, mutations can be done through a `CustomDefaulter` which accepts and modifies a `runtime.Object`. The creation of patches is hidden from the developer. The jsonpatch is created from the difference of the request's raw yaml and the marshalled object modified by the `CustomDefaulter`.

This works for webhooks that are always released along with CRD changes. However, it doesn't work for webhooks written for CRDs from other projects. An example of this is Kueue, which writes webhooks for k8s Jobs, kubeflow, kuberay and others. Whenever there is a new version of the third party CRD, the hidden controller-runtime handler will produce a patch that removes all unknown fields.

A mechanism to fully override the handler allows developers to write patches that are safer against these version changes.

### Goals

- A mechanism to override jsonpatch generation for mutation webhooks.

### Non Goals

- A breaking-change in the libraries to build webhooks.
- A breaking-change in the way patches are built when using a CustomDefaulter.
- A mechanism to wire an `admission.Handler` to process validations. This could easily be added in a follow up proposal, but it doesn't seem to provide as much value as processing mutations.

## Alternatives

My first proposal was #2931, which is to round-trip the raw object to get rid of unknown fields, and generate a jsondiff from this object.
However, @sbueringer pointed out that the round-trip might also add fields that didn't exist in the raw object is the go types are missing omitempty, which might lead to patches that can't be applied to the raw object in the apiserver. So the suggestion was to give full control to developers over the handler to build patches as they see fit.