### PR TITLE
:seedling: Enable using errors.Is with ErrResourceDiscoveryFailed error

### DIFF
--- a/pkg/client/apiutil/errors.go
+++ b/pkg/client/apiutil/errors.go
@@ -52,3 +52,9 @@ func (e *ErrResourceDiscoveryFailed) Unwrap() []error {
 	}
 	return subErrors
 }
+
+// Is makes it possible for the callers to use `errors.Is(` helper on errors wrapped with ErrResourceDiscoveryFailed error.
+func (e *ErrResourceDiscoveryFailed) Is(target error) bool {
+	_, ok := target.(*ErrResourceDiscoveryFailed)
+	return ok
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
