### PR TITLE
📖  Update incorrect method name on doc.go

### DIFF
--- a/pkg/client/fake/doc.go
+++ b/pkg/client/fake/doc.go
@@ -20,7 +20,7 @@ Package fake provides a fake client for testing.
 A fake client is backed by its simple object store indexed by GroupVersionResource.
 You can create a fake client with optional objects.
 
-	client := NewClientBuilder().WithScheme(scheme).WithObj(initObjs...).Build()
+	client := NewClientBuilder().WithScheme(scheme).WithObjects(initObjs...).Build()
 
 You can invoke the methods defined in the Client interface.
 


### PR DESCRIPTION
This PR addresses a discrepancy in method naming when constructing a fake client.

The documentation at https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/client/fake#pkg-overview currently references a `WithObj` method. However, it appears this may be a typo, and the correct method name should be `WithObjects` since there is no WithObj method

This PR fixes this.