### PR TITLE
🐛  Fakeclient: preserve TypeMeta for PartialObjectMeta resources

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -508,7 +508,10 @@ func (c *fakeClient) Get(ctx context.Context, key client.ObjectKey, obj client.O
 		return err
 	}
 
-	if _, isUnstructured := obj.(runtime.Unstructured); isUnstructured {
+	_, isUnstructured := obj.(runtime.Unstructured)
+	_, isPartialObject := obj.(*metav1.PartialObjectMetadata)
+
+	if isUnstructured || isPartialObject {
 		gvk, err := apiutil.GVKForObject(obj, c.scheme)
 		if err != nil {
 			return err

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -339,6 +339,33 @@ var _ = Describe("Fake client", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
+		It("should be able to retrieve objects by PartialObjectMetadata", func() {
+			By("Creating a Resource")
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			}
+			err := cl.Create(context.Background(), secret)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Fetching the resource using a PartialObjectMeta")
+			partialObjMeta := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			}
+			partialObjMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
+
+			err = cl.Get(context.Background(), client.ObjectKeyFromObject(partialObjMeta), partialObjMeta)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(partialObjMeta.Kind).To(Equal("Secret"))
+			Expect(partialObjMeta.APIVersion).To(Equal("v1"))
+		})
+
 		It("should support filtering by labels and their values", func() {
 			By("Listing deployments with a particular label and value")
 			list := &appsv1.DeploymentList{}


### PR DESCRIPTION
<!-- What does this do, and why do we need it? -->
This updates the fake client to retain the PartialObjectMeta TypeMeta when getting resources.

Fixes: #2923