### PR TITLE
🌱 Do not deduplicate warnings by default

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -113,11 +113,11 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 	}
 
 	if config.WarningHandler == nil {
-		// By default, we de-duplicate and surface warnings.
+		// By default, we surface warnings.
 		config.WarningHandler = log.NewKubeAPIWarningLogger(
 			log.Log.WithName("KubeAPIWarningLogger"),
 			log.KubeAPIWarningLoggerOptions{
-				Deduplicate: true,
+				Deduplicate: false,
 			},
 		)
 	}


### PR DESCRIPTION
Controllers are long-running processes, and deduplication, as implemented, increases memory use.

With this change, duplicate warnings will appear in the log by default. However, this is safe, because Kubernetes rotates container logs by default.

If a specific controller sees many duplicate warnings, it can configure the handler to deduplicate them.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
