### PR TITLE
🌱  (fix): Enable status subresource in ChaosPod example

### DIFF
--- a/examples/crd/pkg/groupversion_info.go
+++ b/examples/crd/pkg/groupversion_info.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 // +kubebuilder:object:generate=true
 // +groupName=chaosapps.metamagical.io
+// +versionName=v1
 package pkg
 
 import (

--- a/examples/crd/pkg/resource.go
+++ b/examples/crd/pkg/resource.go
@@ -35,6 +35,7 @@ type ChaosPodStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // ChaosPod is the Schema for the randomjobs API
 // +kubebuilder:printcolumn:name="next stop",type="string",JSONPath=".spec.nextStop",format="date"


### PR DESCRIPTION
## Description

This PR fixes an issue on `examples/crd` controller.
- adds marker to enable status subresource on the crd's api
- fixes scheme initialization in the manager

## Issue
At the moment, even though the reconciler works on ChaosPod instance's Status field, the status subresource is not enabled on ChaosPod. This commit adds `// +kubebuilder:subresource:status` marker to allow the generator tool to enable the status subresource on the custom resource definition.

Also, when the example manager starts, it fails due to scheme initialization as the registered types need to be added before starting the manager. Also, it misses `corev1` scheme even though the controller owns Pods.
