### PR TITLE
🐛 Clean up and namespace verification while removing owner ref and controller ref

### DIFF
--- a/pkg/controller/controllerutil/controllerutil.go
+++ b/pkg/controller/controllerutil/controllerutil.go
@@ -82,7 +82,6 @@ func SetControllerReference(owner, controlled metav1.Object, scheme *runtime.Sch
 	}
 
 	ref := metav1.NewControllerRef(owner, gvk)
-
 	for _, opt := range opts {
 		opt(ref)
 	}
@@ -138,7 +137,6 @@ func RemoveOwnerReference(owner, object metav1.Object, scheme *runtime.Scheme) e
 	if !ok {
 		return fmt.Errorf("%T is not a runtime.Object, cannot call RemoveOwnerReference", owner)
 	}
-
 	if err := validateOwnerWithNS(owner, object); err != nil {
 		return err
 	}
@@ -189,7 +187,7 @@ func RemoveControllerReference(owner, object metav1.Object, scheme *runtime.Sche
 
 	if controller := metav1.GetControllerOfNoCopy(object); controller == nil {
 		return fmt.Errorf("%T does not have a owner reference with controller equals true", object)
-	} else if !referSameObject(*controller, *NewOwnerRef(owner, gvk)) {
+	} else if !referSameObject(*controller, *metav1.NewControllerRef(owner, gvk)) {
 		return fmt.Errorf("%T owner is not the controller reference for %T", owner, object)
 	}
 


### PR DESCRIPTION
Signed-off-by: Hiranmoy Das Chowdhury <hiranmoy.das70@gmail.com>

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
As we know for a resource there only one name can be allocated for every individual namespace. So, when we are removing ownerRef or controllerRef from an controlled object by passing the owner object, we are only checking the name+group+kind but not the namespace. To verify this I added namespace verification and also did some cleanup.
