### PR TITLE
✨ fakeclient: Add support for ServiceAccount Token subresource

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1169,7 +1169,7 @@ func (sw *fakeSubResourceClient) Create(ctx context.Context, obj client.Object, 
 		tokenRequest.Status.Token = "fake-token"
 		tokenRequest.Status.ExpirationTimestamp = metav1.Date(6041, 1, 1, 0, 0, 0, 0, time.UTC)
 
-		return nil
+		return sw.client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 	default:
 		return fmt.Errorf("fakeSubResourceWriter does not support create for %s", sw.subResource)
 	}

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -32,8 +32,8 @@ import (
 	// Using v4 to match upstream
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1982,8 +1982,6 @@ var _ = Describe("Fake client", func() {
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
-
-
 	It("should error when creating a token with the wrong subresource type", func() {
 		cl := NewClientBuilder().Build()
 		err := cl.SubResource("token").Create(context.Background(), &corev1.ServiceAccount{}, &corev1.Namespace{})

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1976,8 +1976,7 @@ var _ = Describe("Fake client", func() {
 		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		cl := NewClientBuilder().Build()
 
-		tokenRequest := &authenticationv1.TokenRequest{}
-		err := cl.SubResource("token").Create(context.Background(), sa, tokenRequest)
+		err := cl.SubResource("token").Create(context.Background(), sa, &authenticationv1.TokenRequest{})
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
@@ -1985,13 +1984,15 @@ var _ = Describe("Fake client", func() {
 	It("should error when creating a token with the wrong subresource type", func() {
 		cl := NewClientBuilder().Build()
 		err := cl.SubResource("token").Create(context.Background(), &corev1.ServiceAccount{}, &corev1.Namespace{})
+		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 	})
 
 	It("should error when creating a token with the wrong type", func() {
 		cl := NewClientBuilder().Build()
-		err := cl.SubResource("token").Create(context.Background(), &corev1.Secret{}, &corev1.Namespace{})
-		Expect(apierrors.IsBadRequest(err)).To(BeTrue())
+		err := cl.SubResource("token").Create(context.Background(), &corev1.Secret{}, &authenticationv1.TokenRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	It("should leave typemeta empty on typed get", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Adds the [TokenRequest API ](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/)