### PR TITLE
✨  Fakeclient: Add apply support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	k8s.io/client-go v0.34.0-alpha.2
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
+	sigs.k8s.io/structured-merge-diff/v4 v4.7.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -97,5 +98,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.2 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.7.0 // indirect
 )

--- a/pkg/client/fake/typeconverter.go
+++ b/pkg/client/fake/typeconverter.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+type multiTypeConverter struct {
+	upstream []managedfields.TypeConverter
+}
+
+func (m multiTypeConverter) ObjectToTyped(r runtime.Object, o ...typed.ValidationOptions) (*typed.TypedValue, error) {
+	var errs []error
+	for _, u := range m.upstream {
+		res, err := u.ObjectToTyped(r, o...)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("failed to convert Object to TypedValue: %w", kerrors.NewAggregate(errs))
+}
+
+func (m multiTypeConverter) TypedToObject(v *typed.TypedValue) (runtime.Object, error) {
+	var errs []error
+	for _, u := range m.upstream {
+		res, err := u.TypedToObject(v)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		return res, nil
+	}
+
+	return nil, fmt.Errorf("failed to convert TypedValue to Object: %w", kerrors.NewAggregate(errs))
+}

--- a/pkg/client/fake/typeconverter_test.go
+++ b/pkg/client/fake/typeconverter_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/managedfields"
+	"sigs.k8s.io/structured-merge-diff/v4/typed"
+)
+
+var _ = Describe("multiTypeConverter", func() {
+	Describe("ObjectToTyped", func() {
+		It("should use first converter when it succeeds", func() {
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+			testTyped := &typed.TypedValue{}
+
+			firstConverter := &mockTypeConverter{
+				objectToTypedResult: testTyped,
+			}
+			secondConverter := &mockTypeConverter{
+				objectToTypedError: errors.New("second converter should not be called"),
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.ObjectToTyped(testObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(testTyped))
+		})
+
+		It("should use second converter when first fails", func() {
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+			testTyped := &typed.TypedValue{}
+
+			firstConverter := &mockTypeConverter{
+				objectToTypedError: errors.New("first converter error"),
+			}
+			secondConverter := &mockTypeConverter{
+				objectToTypedResult: testTyped,
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.ObjectToTyped(testObj)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(testTyped))
+		})
+
+		It("should return aggregate error when all converters fail", func() {
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+
+			firstConverter := &mockTypeConverter{
+				objectToTypedError: errors.New("first converter error"),
+			}
+			secondConverter := &mockTypeConverter{
+				objectToTypedError: errors.New("second converter error"),
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.ObjectToTyped(testObj)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to convert Object to Typed"))
+			Expect(err.Error()).To(ContainSubstring("first converter error"))
+			Expect(err.Error()).To(ContainSubstring("second converter error"))
+		})
+
+		It("should return error when no converters provided", func() {
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{},
+			}
+
+			result, err := converter.ObjectToTyped(testObj)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to convert Object to Typed"))
+		})
+	})
+
+	Describe("TypedToObject", func() {
+		It("should use first converter when it succeeds", func() {
+			testTyped := &typed.TypedValue{}
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+
+			firstConverter := &mockTypeConverter{
+				typedToObjectResult: testObj,
+			}
+			secondConverter := &mockTypeConverter{
+				typedToObjectError: errors.New("second converter should not be called"),
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.TypedToObject(testTyped)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(testObj))
+		})
+
+		It("should use second converter when first fails", func() {
+			testTyped := &typed.TypedValue{}
+			testObj := &corev1.ConfigMap{Data: map[string]string{"key": "value"}}
+
+			firstConverter := &mockTypeConverter{
+				typedToObjectError: errors.New("first converter error"),
+			}
+			secondConverter := &mockTypeConverter{
+				typedToObjectResult: testObj,
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.TypedToObject(testTyped)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(testObj))
+		})
+
+		It("should return aggregate error when all converters fail", func() {
+			testTyped := &typed.TypedValue{}
+
+			firstConverter := &mockTypeConverter{
+				typedToObjectError: errors.New("first converter error"),
+			}
+			secondConverter := &mockTypeConverter{
+				typedToObjectError: errors.New("second converter error"),
+			}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{firstConverter, secondConverter},
+			}
+
+			result, err := converter.TypedToObject(testTyped)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to convert TypedValue to Object"))
+			Expect(err.Error()).To(ContainSubstring("first converter error"))
+			Expect(err.Error()).To(ContainSubstring("second converter error"))
+		})
+
+		It("should return error when no converters provided", func() {
+			testTyped := &typed.TypedValue{}
+
+			converter := multiTypeConverter{
+				upstream: []managedfields.TypeConverter{},
+			}
+
+			result, err := converter.TypedToObject(testTyped)
+			Expect(err).To(HaveOccurred())
+			Expect(result).To(BeNil())
+			Expect(err.Error()).To(ContainSubstring("failed to convert TypedValue to Object"))
+		})
+	})
+})
+
+type mockTypeConverter struct {
+	objectToTypedResult *typed.TypedValue
+	objectToTypedError  error
+
+	typedToObjectResult runtime.Object
+	typedToObjectError  error
+}
+
+func (m *mockTypeConverter) ObjectToTyped(r runtime.Object, o ...typed.ValidationOptions) (*typed.TypedValue, error) {
+	return m.objectToTypedResult, m.objectToTypedError
+}
+
+func (m *mockTypeConverter) TypedToObject(v *typed.TypedValue) (runtime.Object, error) {
+	return m.typedToObjectResult, m.typedToObjectError
+}


### PR DESCRIPTION
This change adds apply support into the fake client.

This relies on the upstream support for this which is implemented in a new [FieldManagedObjectTracker][0]. In order to support many types, a custom `multiTypeConverter` is added.


The `FieldManagedObjectTracker` results in `ManagedFields` being set after any operations. As that would be a very breaking change, the fake client will by default unset them and allows to optionally leave them.

Based on all existing tests still passing, I believe this change is fully backwards-compatible (But depends on breaking changes such as a very new client-go and apimachinery and https://github.com/kubernetes-sigs/controller-runtime/pull/3228).

Fixes #2341 

[0]: https://github.com/kubernetes/kubernetes/blob/4dc7a48ac6fb631a84e1974772bf7b8fd0bb9c59/staging/src/k8s.io/client-go/testing/fixture.go#L643