### PR TITLE
🐛 Fix custom defaulter: avoid deleting unknown fields (zero change patch)

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -40,15 +40,18 @@ type defaulterOptions struct {
 	removeUnknownFields bool
 }
 
-type defaulterOption func(*defaulterOptions)
+// DefaulterOption defines the type of a CustomDefaulter's option
+type DefaulterOption func(*defaulterOptions)
 
-// DefaulterRemoveUnknownFields makes the defaulter prune the fields that are not recognized in the local scheme.
+// DefaulterRemoveUnknownFields makes the defaulter prune fields that are in the json object retrieved by the
+// webhook but not in the local go type. This happens for example when the CRD in the apiserver has fields that
+// our go type doesn't know about, because it's outdated.
 func DefaulterRemoveUnknownFields(o *defaulterOptions) {
 	o.removeUnknownFields = true
 }
 
 // WithCustomDefaulter creates a new Webhook for a CustomDefaulter interface.
-func WithCustomDefaulter(scheme *runtime.Scheme, obj runtime.Object, defaulter CustomDefaulter, opts ...defaulterOption) *Webhook {
+func WithCustomDefaulter(scheme *runtime.Scheme, obj runtime.Object, defaulter CustomDefaulter, opts ...DefaulterOption) *Webhook {
 	options := &defaulterOptions{}
 	for _, o := range opts {
 		o(options)

--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -140,7 +140,10 @@ func (h *defaulterForType) dropSchemeRemovals(r Response, original runtime.Objec
 		return Errored(http.StatusInternalServerError, err)
 	}
 
-	patchOriginal := PatchResponseFromRaw(raw, marshalledOriginal).Patches
+	patchOriginal, err := jsonpatch.CreatePatch(raw, marshalledOriginal)
+	if err != nil {
+		return Errored(http.StatusInternalServerError, err)
+	}
 	removedByScheme := sets.New(slices.DeleteFunc(patchOriginal, func(p jsonpatch.JsonPatchOperation) bool { return p.Operation != opRemove })...)
 
 	r.Patches = slices.DeleteFunc(r.Patches, func(p jsonpatch.JsonPatchOperation) bool {

--- a/pkg/webhook/admission/defaulter_custom_test.go
+++ b/pkg/webhook/admission/defaulter_custom_test.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Defaulter Handler", func() {
 
-	It("should not preserve unknown fields by default", func() {
+	It("should remove unknown fields when DefaulterRemoveUnknownFields is passed", func() {
 		obj := &TestDefaulter{}
 		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterRemoveUnknownFields)
 
@@ -61,7 +61,7 @@ var _ = Describe("Defaulter Handler", func() {
 		Expect(resp.Result.Code).Should(Equal(int32(http.StatusOK)))
 	})
 
-	It("should preserve unknown fields when DefaulterPreserveUnknownFields is passed", func() {
+	It("should preserve unknown fields by default", func() {
 		obj := &TestDefaulter{}
 		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{})
 

--- a/pkg/webhook/admission/defaulter_custom_test.go
+++ b/pkg/webhook/admission/defaulter_custom_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Defaulter Handler", func() {
 
 	It("should remove unknown fields when DefaulterRemoveUnknownFields is passed", func() {
 		obj := &TestDefaulter{}
-		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterRemoveUnknownFields)
+		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterRemoveUnknownOrOmitableFields)
 
 		resp := handler.Handle(context.TODO(), Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{

--- a/pkg/webhook/admission/defaulter_custom_test.go
+++ b/pkg/webhook/admission/defaulter_custom_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Defaulter Handler", func() {
 
 	It("should not preserve unknown fields by default", func() {
 		obj := &TestDefaulter{}
-		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{})
+		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterRemoveUnknownFields)
 
 		resp := handler.Handle(context.TODO(), Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
@@ -63,7 +63,7 @@ var _ = Describe("Defaulter Handler", func() {
 
 	It("should preserve unknown fields when DefaulterPreserveUnknownFields is passed", func() {
 		obj := &TestDefaulter{}
-		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterPreserveUnknownFields)
+		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{})
 
 		resp := handler.Handle(context.TODO(), Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{


### PR DESCRIPTION
When creating a patch for the custom defaulter, don't return the removals generated by object decoding with the local scheme.

Otherwise, the patch will include a remove instruction for fields that the go type doesn't contain.

This could happen when building a webhook for a resource that belongs to another project (including k8s types).

This PR stops the defaulter from pruning the fields that are not recognized in the local scheme.
When doing this we are creating two patches one before and one after the custom defaulter call and only send back the remove operations that are not present in both patches.

The user can opt-out from this new behavior by specifying the  `DefaulterRemoveUnknownFields`  option when calling ` WithCustomDefaulter`. 

(This is a rework of #2931)