### PR TITLE
📖Update docs for setupenvtest 

### DIFF
--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -4,17 +4,17 @@ This is a small tool that manages binaries for envtest. It can be used to
 download new binaries, list currently installed and available ones, and
 clean up versions.
 
-To use it, just go-install it with Golang 1.22+ (it's a separate, self-contained
+To use it, just go-install it with Golang 1.23+ (it's a separate, self-contained
 module):
 
 ```shell
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 ```
 
-If you are using Golang 1.20 or 1.21, use the `release-0.17` branch instead:
+If you are using Golang 1.22, use the `release-0.18` branch instead:
 
 ```shell
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.17
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
 ```
 
 For full documentation, run it with the `--help` flag, but here are some
@@ -47,7 +47,7 @@ setup-envtest use -i --use-env
 # sideload a pre-downloaded tarball as Kubernetes 1.16.2 into our store
 setup-envtest sideload 1.16.2 < downloaded-envtest.tar.gz
 
-# Per default envtest binaries are downloaded from: 
+# Per default envtest binaries are downloaded from:
 # https://raw.githubusercontent.com/kubernetes-sigs/controller-tools/master/envtest-releases.yaml
 # To download from a custom index use the following:
 setup-envtest use --index https://custom.com/envtest-releases.yaml


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This [PR](https://github.com/kubernetes-sigs/controller-runtime/pull/2971) introduced an issue where setupenvtest is now pointing at a go.mod for setupenvtest@latest to require go1.23.  This PR updates the docs to reflect that. 
