### PR TITLE
:book: clarify comments of GenerationChangedPredicate

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -173,7 +173,8 @@ func (TypedResourceVersionChangedPredicate[T]) Update(e event.TypedUpdateEvent[T
 // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
 // This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
 //
-// For CustomResource objects the Generation is only incremented when the status subresource is not enabled.
+// For CustomResource objects the Generation is incremented when spec is changed, or status changed and status not modeled as subresource.
+// subresource status update will not increase Generation.
 //
 // Caveats:
 //
@@ -191,7 +192,8 @@ type GenerationChangedPredicate = TypedGenerationChangedPredicate[client.Object]
 // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
 // This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
 //
-// For CustomResource objects the Generation is only incremented when the status subresource is not enabled.
+// For CustomResource objects the Generation is incremented when spec is changed, or status changed and status not modeled as subresource.
+// subresource status update will not increase Generation.
 //
 // Caveats:
 //

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -173,7 +173,7 @@ func (TypedResourceVersionChangedPredicate[T]) Update(e event.TypedUpdateEvent[T
 // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
 // This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
 //
-// For CustomResource objects the Generation is only incremented when the status subresource is enabled.
+// For CustomResource objects the Generation is only incremented when the status subresource is not enabled.
 //
 // Caveats:
 //
@@ -191,7 +191,7 @@ type GenerationChangedPredicate = TypedGenerationChangedPredicate[client.Object]
 // The metadata.generation field of an object is incremented by the API server when writes are made to the spec field of an object.
 // This allows a controller to ignore update events where the spec is unchanged, and only the metadata and/or status fields are changed.
 //
-// For CustomResource objects the Generation is only incremented when the status subresource is enabled.
+// For CustomResource objects the Generation is only incremented when the status subresource is not enabled.
 //
 // Caveats:
 //


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

comments of GenerationChangedPredicate is confusing, we know that `generation` is not updated if its status is defined as subresource.