### PR TITLE
🌱  Source.Start(): Use errgroup without context

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -173,7 +173,7 @@ func (c *Controller[request]) Start(ctx context.Context) error {
 		// NB(directxman12): launch the sources *before* trying to wait for the
 		// caches to sync so that they have a chance to register their intendeded
 		// caches.
-		errGroup, _ := errgroup.WithContext(ctx)
+		errGroup := &errgroup.Group{}
 		for _, watch := range c.startWatches {
 			log := c.LogConstructor(nil).WithValues("source", fmt.Sprintf("%s", watch))
 			didStartSyncingSource := &atomic.Bool{}


### PR DESCRIPTION
Addresses
https://github.com/kubernetes-sigs/controller-runtime/pull/2997#discussion_r1834925687, followup to https://github.com/kubernetes-sigs/controller-runtime/pull/2997

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
