### PR TITLE
:seedling: Fixups to error when source.Start never returns

### DIFF
--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -201,7 +201,7 @@ var _ = Describe("controller", func() {
 		})
 
 		It("should error when Start() is blocking forever", func() {
-			ctrl.CacheSyncTimeout = 0
+			ctrl.CacheSyncTimeout = time.Second
 
 			controllerDone := make(chan struct{})
 			ctrl.startWatches = []source.TypedSource[reconcile.Request]{
@@ -304,7 +304,7 @@ var _ = Describe("controller", func() {
 				Expect(q).To(Equal(ctrl.Queue))
 
 				started = true
-				cancel()
+				cancel() // Cancel the context so ctrl.Start() doesn't block forever
 				return nil
 			})
 			Expect(ctrl.Watch(src)).NotTo(HaveOccurred())


### PR DESCRIPTION
Addresses the comments on https://github.com/kubernetes-sigs/controller-runtime/pull/2997

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @sbueringer 
/hold
