### PR TITLE
🐛 Refactor certificate watcher to use polling, instead of fsnotify

### DIFF
--- a/examples/scratch-env/go.mod
+++ b/examples/scratch-env/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.9.0 // indirect
-	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect

--- a/examples/scratch-env/go.sum
+++ b/examples/scratch-env/go.sum
@@ -13,8 +13,6 @@ github.com/evanphx/json-patch v0.5.2 h1:xVCHIVMUu1wtM/VkR9jVZ45N3FhZfYMMYGorLCR8
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch/v5 v5.9.0 h1:kcBlZQbplgElYIlo/n1hJbls2z/1awpXxpRi0/FOJfg=
 github.com/evanphx/json-patch/v5 v5.9.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq14uClGH4abBuQ=
-github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
-github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/fxamacker/cbor/v2 v2.7.0 h1:iM5WgngdRBanHcxugY4JySA0nk1wZorNOpTgCMedv5E=
 github.com/fxamacker/cbor/v2 v2.7.0/go.mod h1:pxXPTn3joSm21Gbwsv0w9OSA2y1HFR9qXEeXQVeNoDQ=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.23.0
 
 require (
 	github.com/evanphx/json-patch/v5 v5.9.0
-	github.com/fsnotify/fsnotify v1.7.0
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
 	github.com/google/go-cmp v0.6.0
@@ -41,6 +40,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/fsnotify/fsnotify v1.7.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.7.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect

--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -59,12 +59,7 @@ func New(certPath, keyPath string) (*CertWatcher, error) {
 		interval: defaultWatchInterval,
 	}
 
-	// Initial read of certificate and key.
-	if err := cw.ReadCertificate(); err != nil {
-		return nil, err
-	}
-
-	return cw, nil
+	return cw, cw.ReadCertificate()
 }
 
 // WithWatchInterval sets the watch interval and returns the CertWatcher pointer

--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -17,16 +17,12 @@ limitations under the License.
 package certwatcher
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
-	"fmt"
+	"os"
 	"sync"
 	"time"
-
-	"github.com/fsnotify/fsnotify"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics"
 	logf "sigs.k8s.io/controller-runtime/pkg/internal/log"
@@ -34,17 +30,22 @@ import (
 
 var log = logf.RuntimeLog.WithName("certwatcher")
 
-// CertWatcher watches certificate and key files for changes.  When either file
-// changes, it reads and parses both and calls an optional callback with the new
-// certificate.
+const defaultWatchInterval = 10 * time.Second
+
+// CertWatcher watches certificate and key files for changes.
+// It always returns the cached version,
+// but periodically reads and parses certificate and key for changes
+// and calls an optional callback with the new certificate.
 type CertWatcher struct {
 	sync.RWMutex
 
 	currentCert *tls.Certificate
-	watcher     *fsnotify.Watcher
+	interval    time.Duration
 
 	certPath string
 	keyPath  string
+
+	cachedKeyPEMBlock []byte
 
 	// callback is a function to be invoked when the certificate changes.
 	callback func(tls.Certificate)
@@ -52,11 +53,10 @@ type CertWatcher struct {
 
 // New returns a new CertWatcher watching the given certificate and key.
 func New(certPath, keyPath string) (*CertWatcher, error) {
-	var err error
-
 	cw := &CertWatcher{
 		certPath: certPath,
 		keyPath:  keyPath,
+		interval: defaultWatchInterval,
 	}
 
 	// Initial read of certificate and key.
@@ -64,12 +64,13 @@ func New(certPath, keyPath string) (*CertWatcher, error) {
 		return nil, err
 	}
 
-	cw.watcher, err = fsnotify.NewWatcher()
-	if err != nil {
-		return nil, err
-	}
-
 	return cw, nil
+}
+
+// WithWatchInterval sets the watch interval and returns the CertWatcher pointer
+func (cw *CertWatcher) WithWatchInterval(interval time.Duration) *CertWatcher {
+	cw.interval = interval
+	return cw
 }
 
 // RegisterCallback registers a callback to be invoked when the certificate changes.
@@ -92,97 +93,64 @@ func (cw *CertWatcher) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate,
 
 // Start starts the watch on the certificate and key files.
 func (cw *CertWatcher) Start(ctx context.Context) error {
-	files := sets.New(cw.certPath, cw.keyPath)
-
-	{
-		var watchErr error
-		if err := wait.PollUntilContextTimeout(ctx, 1*time.Second, 10*time.Second, true, func(ctx context.Context) (done bool, err error) {
-			for _, f := range files.UnsortedList() {
-				if err := cw.watcher.Add(f); err != nil {
-					watchErr = err
-					return false, nil //nolint:nilerr // We want to keep trying.
-				}
-				// We've added the watch, remove it from the set.
-				files.Delete(f)
-			}
-			return true, nil
-		}); err != nil {
-			return fmt.Errorf("failed to add watches: %w", kerrors.NewAggregate([]error{err, watchErr}))
-		}
-	}
-
-	go cw.Watch()
+	ticker := time.NewTicker(cw.interval)
+	defer ticker.Stop()
 
 	log.Info("Starting certificate watcher")
-
-	// Block until the context is done.
-	<-ctx.Done()
-
-	return cw.watcher.Close()
-}
-
-func (cw *CertWatcher) ensureAllFilesAreWatched() {
-	watchList := sets.New(cw.watcher.WatchList()...)
-	difference := sets.New(cw.certPath, cw.keyPath).Difference(watchList)
-	if difference.Len() == 0 {
-		return
-	}
-
-	for _, missingWatchPath := range difference.UnsortedList() {
-		log.V(1).Info("re-adding missing watch", "path", missingWatchPath)
-		if err := cw.watcher.Add(missingWatchPath); err != nil {
-			log.Error(err, "failed to add watch", "path", missingWatchPath)
-			return
-		}
-	}
-
-	log.V(1).Info("all files are watched again", "list", cw.watcher.WatchList())
-
-	if err := cw.ReadCertificate(); err != nil {
-		log.Error(err, "error re-reading certificate")
-	}
-}
-
-// Watch reads events from the watcher's channel and reacts to changes.
-func (cw *CertWatcher) Watch() {
-	watcherHealthTimer := time.NewTicker(time.Second)
 	for {
 		select {
-		case event, ok := <-cw.watcher.Events:
-			// Channel is closed.
-			if !ok {
-				return
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := cw.ReadCertificate(); err != nil {
+				log.Error(err, "failed read certificate")
 			}
-
-			cw.handleEvent(event)
-
-		case err, ok := <-cw.watcher.Errors:
-			// Channel is closed.
-			if !ok {
-				return
-			}
-
-			log.Error(err, "certificate watch error")
-		case <-watcherHealthTimer.C:
-			cw.ensureAllFilesAreWatched()
 		}
 	}
+}
+
+// updateCachedCertificate checks if the new certificate differs from the cache,
+// updates it and returns the result if it was updated or not
+func (cw *CertWatcher) updateCachedCertificate(cert *tls.Certificate, keyPEMBlock []byte) bool {
+	cw.Lock()
+	defer cw.Unlock()
+
+	if cw.currentCert != nil &&
+		bytes.Equal(cw.currentCert.Certificate[0], cert.Certificate[0]) &&
+		bytes.Equal(cw.cachedKeyPEMBlock, keyPEMBlock) {
+		log.V(7).Info("certificate already cached")
+		return false
+	}
+	cw.currentCert = cert
+	cw.cachedKeyPEMBlock = keyPEMBlock
+	return true
 }
 
 // ReadCertificate reads the certificate and key files from disk, parses them,
-// and updates the current certificate on the watcher.  If a callback is set, it
+// and updates the current certificate on the watcher if updated. If a callback is set, it
 // is invoked with the new certificate.
 func (cw *CertWatcher) ReadCertificate() error {
 	metrics.ReadCertificateTotal.Inc()
-	cert, err := tls.LoadX509KeyPair(cw.certPath, cw.keyPath)
+	certPEMBlock, err := os.ReadFile(cw.certPath)
+	if err != nil {
+		metrics.ReadCertificateErrors.Inc()
+		return err
+	}
+	keyPEMBlock, err := os.ReadFile(cw.keyPath)
 	if err != nil {
 		metrics.ReadCertificateErrors.Inc()
 		return err
 	}
 
-	cw.Lock()
-	cw.currentCert = &cert
-	cw.Unlock()
+	cert, err := tls.X509KeyPair(certPEMBlock, keyPEMBlock)
+	if err != nil {
+		metrics.ReadCertificateErrors.Inc()
+		return err
+	}
+
+	if !cw.updateCachedCertificate(&cert, keyPEMBlock) {
+		return nil
+	}
 
 	log.Info("Updated current TLS certificate")
 
@@ -195,40 +163,4 @@ func (cw *CertWatcher) ReadCertificate() error {
 		}()
 	}
 	return nil
-}
-
-func (cw *CertWatcher) handleEvent(event fsnotify.Event) {
-	// Only care about events which may modify the contents of the file.
-	if !(isWrite(event) || isRemove(event) || isCreate(event) || isChmod(event)) {
-		return
-	}
-
-	log.V(1).Info("certificate event", "event", event)
-
-	// If the file was removed or renamed, re-add the watch to the previous name
-	if isRemove(event) || isChmod(event) {
-		if err := cw.watcher.Add(event.Name); err != nil {
-			log.Error(err, "error re-watching file")
-		}
-	}
-
-	if err := cw.ReadCertificate(); err != nil {
-		log.Error(err, "error re-reading certificate")
-	}
-}
-
-func isWrite(event fsnotify.Event) bool {
-	return event.Op.Has(fsnotify.Write)
-}
-
-func isCreate(event fsnotify.Event) bool {
-	return event.Op.Has(fsnotify.Create)
-}
-
-func isRemove(event fsnotify.Event) bool {
-	return event.Op.Has(fsnotify.Remove)
-}
-
-func isChmod(event fsnotify.Event) bool {
-	return event.Op.Has(fsnotify.Chmod)
 }

--- a/pkg/certwatcher/certwatcher_suite_test.go
+++ b/pkg/certwatcher/certwatcher_suite_test.go
@@ -22,6 +22,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )

--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -81,7 +81,7 @@ var _ = Describe("CertWatcher", func() {
 			go func() {
 				defer GinkgoRecover()
 				defer close(doneCh)
-				Expect(watcher.Start(ctx)).To(Succeed())
+				Expect(watcher.WithWatchInterval(time.Second).Start(ctx)).To(Succeed())
 			}()
 			// wait till we read first cert
 			Eventually(func() error {
@@ -193,8 +193,8 @@ var _ = Describe("CertWatcher", func() {
 
 				Eventually(func() error {
 					readCertificateTotalAfter := testutil.ToFloat64(metrics.ReadCertificateTotal)
-					if readCertificateTotalAfter != readCertificateTotalBefore+1.0 {
-						return fmt.Errorf("metric read certificate total expected: %v and got: %v", readCertificateTotalBefore+1.0, readCertificateTotalAfter)
+					if readCertificateTotalAfter < readCertificateTotalBefore+1.0 {
+						return fmt.Errorf("metric read certificate total expected at least: %v and got: %v", readCertificateTotalBefore+1.0, readCertificateTotalAfter)
 					}
 					return nil
 				}, "4s").Should(Succeed())
@@ -208,8 +208,8 @@ var _ = Describe("CertWatcher", func() {
 
 				Eventually(func() error {
 					readCertificateTotalAfter := testutil.ToFloat64(metrics.ReadCertificateTotal)
-					if readCertificateTotalAfter != readCertificateTotalBefore+1.0 {
-						return fmt.Errorf("metric read certificate total expected: %v and got: %v", readCertificateTotalBefore+1.0, readCertificateTotalAfter)
+					if readCertificateTotalAfter < readCertificateTotalBefore+1.0 {
+						return fmt.Errorf("metric read certificate total expected at least: %v and got: %v", readCertificateTotalBefore+1.0, readCertificateTotalAfter)
 					}
 					readCertificateTotalBefore = readCertificateTotalAfter
 					return nil
@@ -220,15 +220,15 @@ var _ = Describe("CertWatcher", func() {
 				// Note, we are checking two errors here, because os.Remove generates two fsnotify events: Chmod + Remove
 				Eventually(func() error {
 					readCertificateTotalAfter := testutil.ToFloat64(metrics.ReadCertificateTotal)
-					if readCertificateTotalAfter != readCertificateTotalBefore+2.0 {
-						return fmt.Errorf("metric read certificate total expected: %v and got: %v", readCertificateTotalBefore+2.0, readCertificateTotalAfter)
+					if readCertificateTotalAfter < readCertificateTotalBefore+2.0 {
+						return fmt.Errorf("metric read certificate total expected at least: %v and got: %v", readCertificateTotalBefore+2.0, readCertificateTotalAfter)
 					}
 					return nil
 				}, "4s").Should(Succeed())
 				Eventually(func() error {
 					readCertificateErrorsAfter := testutil.ToFloat64(metrics.ReadCertificateErrors)
-					if readCertificateErrorsAfter != readCertificateErrorsBefore+2.0 {
-						return fmt.Errorf("metric read certificate errors expected: %v and got: %v", readCertificateErrorsBefore+2.0, readCertificateErrorsAfter)
+					if readCertificateErrorsAfter < readCertificateErrorsBefore+2.0 {
+						return fmt.Errorf("metric read certificate errors expected at least: %v and got: %v", readCertificateErrorsBefore+2.0, readCertificateErrorsAfter)
 					}
 					return nil
 				}, "4s").Should(Succeed())

--- a/pkg/certwatcher/example_test.go
+++ b/pkg/certwatcher/example_test.go
@@ -39,7 +39,7 @@ func Example() {
 		panic(err)
 	}
 
-	// Start goroutine with certwatcher running fsnotify against supplied certdir
+	// Start goroutine with certwatcher running against supplied cert
 	go func() {
 		if err := watcher.Start(ctx); err != nil {
 			panic(err)

--- a/pkg/certwatcher/metrics/metrics.go
+++ b/pkg/certwatcher/metrics/metrics.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 


### PR DESCRIPTION
### Summary

In the current controller-runtime/certwatcher behaviour if any of the files (cert or key) are deleted before the replacement, the code removes the watcher. It gets stuck with watching nothing, so when the replacement arrives - no goroutine will receive that event and all the future certificate updates (including this) are missed until the code is restarted.

### Details

The added test in the PR shows the example scenario of updating the certificate in two steps:
1. `rm /certs/mtls.pem /certs/mtls.key`
2. `tar xvf -C /certs new_mtls.tar.gz` (or similar).

**Expected behaviour:**
Return the previous certificate until the new files appear, reestablish the watch and reread the certs when ready.

**Current behaviour:**
The watch is removed and new files do not trigger anything.

### Possible options to consider

1. The `ensureAllFilesAreWatched` could be called in `select/default` branch, but it increases the load drastically. 1 second seems reasonable enough.
2. The ticker could be increased to 10 seconds to reduce load (or be customizable), but don't see a big issue here as it checks the filesystem and its internal locks only.
3. Instead of reestablishing watches we could stop the watcher and trigger controller code to be reinitialised from the beginning - it is a nice behaviour we use for Kube caches and watchers, but does not seem good for certificates to reinitialise the whole context after such small change.