### PR TITLE
🐛Fix certwatcher test to be backwards compatible

### DIFF
--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certwatcher_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -114,7 +115,7 @@ var _ = Describe("CertWatcher", func() {
 			Eventually(func() bool {
 				secondcert, _ := watcher.GetCertificate(nil)
 				first := firstcert.PrivateKey.(*rsa.PrivateKey)
-				return first.Equal(secondcert.PrivateKey) || firstcert.Leaf.SerialNumber == secondcert.Leaf.SerialNumber
+				return first.Equal(secondcert.PrivateKey) || bytes.Equal(firstcert.Certificate[0], secondcert.Certificate[0])
 			}).ShouldNot(BeTrue())
 
 			ctxCancel()
@@ -144,7 +145,7 @@ var _ = Describe("CertWatcher", func() {
 			Eventually(func() bool {
 				secondcert, _ := watcher.GetCertificate(nil)
 				first := firstcert.PrivateKey.(*rsa.PrivateKey)
-				return first.Equal(secondcert.PrivateKey) || firstcert.Leaf.SerialNumber == secondcert.Leaf.SerialNumber
+				return first.Equal(secondcert.PrivateKey) || bytes.Equal(firstcert.Certificate[0], secondcert.Certificate[0])
 			}).ShouldNot(BeTrue())
 
 			ctxCancel()
@@ -171,7 +172,7 @@ var _ = Describe("CertWatcher", func() {
 			Eventually(func() bool {
 				secondcert, _ := watcher.GetCertificate(nil)
 				first := firstcert.PrivateKey.(*rsa.PrivateKey)
-				return first.Equal(secondcert.PrivateKey) || firstcert.Leaf.SerialNumber == secondcert.Leaf.SerialNumber
+				return first.Equal(secondcert.PrivateKey) || bytes.Equal(firstcert.Certificate[0], secondcert.Certificate[0])
 			}, "10s", "1s").ShouldNot(BeTrue())
 
 			ctxCancel()


### PR DESCRIPTION
https://github.com/kubernetes-sigs/controller-runtime/pull/3020 improved the certwatcher test to check not only the privatekeys, but the certificate data too. 
The test was using `cert.Leaf` field that is populated [since Go 1.23 only](https://pkg.go.dev/crypto/tls#X509KeyPair) (which is used in the main branch), so fails in the release-0.19 https://github.com/kubernetes-sigs/controller-runtime/pull/3023.

The PR updates the test to use certificate comparison that should work in all previous versions of Go properly.

Note, it checks `Certificate[0]` which might be wrong in broken chains, but this is the default behavior of `tls.X509KeyPair` - it always parses the first certificate only. And also note, that there is no need in len checks as the certificate is guaranteed to be present, otherwise Parse would return error earlier.
