### PR TITLE
:warning: Use leader elector with client timeout

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -389,6 +389,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 			LeaderElectionResourceLock: options.LeaderElectionResourceLock,
 			LeaderElectionID:           options.LeaderElectionID,
 			LeaderElectionNamespace:    options.LeaderElectionNamespace,
+			RewnewDeadline:             *options.RenewDeadline,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -317,6 +317,28 @@ var _ = Describe("manger.Manager", func() {
 				<-m2done
 			})
 
+			It("should default RenewDeadline for leader election config", func() {
+				var rl resourcelock.Interface
+				m1, err := New(cfg, Options{
+					LeaderElection:          true,
+					LeaderElectionNamespace: "default",
+					LeaderElectionID:        "test-leader-election-id",
+					newResourceLock: func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error) {
+						if options.RewnewDeadline != 10*time.Second {
+							return nil, fmt.Errorf("expected RenewDeadline to be 10s, got %v", options.RewnewDeadline)
+						}
+						var err error
+						rl, err = leaderelection.NewResourceLock(config, recorderProvider, options)
+						return rl, err
+					},
+					HealthProbeBindAddress: "0",
+					Metrics:                metricsserver.Options{BindAddress: "0"},
+					PprofBindAddress:       "0",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(m1).ToNot(BeNil())
+			})
+
 			It("should default ID to controller-runtime if ID is not set", func() {
 				var rl resourcelock.Interface
 				m1, err := New(cfg, Options{


### PR DESCRIPTION
This change makes the leader elector use a client that internally has a smaller timeout than the renew deadline, which avoids a situation where a single request timing out makes us lose the leader lease.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3027
