### PR TITLE
🌱 add deprecated Watch() to certwatcher

### DIFF
--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -104,6 +104,13 @@ func (cw *CertWatcher) Start(ctx context.Context) error {
 	}
 }
 
+// Watch used to read events from the watcher's channel and reacts to changes,
+// it has currently no function and it's left here for backward compatibility until a future release.
+//
+// Deprecated: fsnotify has been removed and Start() is now polling instead.
+func (cw *CertWatcher) Watch() {
+}
+
 // updateCachedCertificate checks if the new certificate differs from the cache,
 // updates it and returns the result if it was updated or not
 func (cw *CertWatcher) updateCachedCertificate(cert *tls.Certificate, keyPEMBlock []byte) bool {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
