### PR TITLE
🐛 Don't log name and namespace twice

### DIFF
--- a/pkg/builder/controller.go
+++ b/pkg/builder/controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -445,9 +444,6 @@ func (blder *TypedBuilder[request]) doController(r reconcile.TypedReconciler[req
 			log := log
 
 			if req, ok := any(in).(*reconcile.Request); ok && req != nil {
-				if hasGVK {
-					log = log.WithValues(gvk.Kind, klog.KRef(req.Namespace, req.Name))
-				}
 				log = log.WithValues(
 					"namespace", req.Namespace, "name", req.Name,
 				)


### PR DESCRIPTION
Currently, the logs for my controller look like this:
```
I1206 09:17:57.766036   13278 controller.go:212] "Successfully finished the reconciliation." logger="Reconcile" controller="test" controllerGroup="test.com" controllerKind="Test" Test="namespace1/resource1" namespace="namespace1" name="resource1" reconcileID="6594dad2-87a7-4525-8549-f7967f7447e5"
```

Notice that `Test="namespace1/resource1"` just repeats information that was already available in other key-value pairs (`controllerKind="Test"`, `namespace="namespace1"` and `name="resource1"`).

After this PR, the logs look like this:
```
I1206 09:17:57.766036   13278 controller.go:212] "Successfully finished the reconciliation." logger="Reconcile" controller="test" controllerGroup="test.com" controllerKind="Test" namespace="namespace1" name="resource1" reconcileID="6594dad2-87a7-4525-8549-f7967f7447e5"
```