### PR TITLE
🐛 Fix custom defaulter: compare only remove patches

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -155,7 +155,7 @@ func (h *defaulterForType) dropSchemeRemovals(r Response, original runtime.Objec
 	removedByScheme := sets.New(slices.DeleteFunc(patchOriginal, func(p jsonpatch.JsonPatchOperation) bool { return p.Operation != opRemove })...)
 
 	r.Patches = slices.DeleteFunc(r.Patches, func(p jsonpatch.JsonPatchOperation) bool {
-		return removedByScheme.Has(p)
+		return p.Operation == opRemove && removedByScheme.Has(p)
 	})
 
 	if len(r.Patches) == 0 {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR fixes an issue that occurs when comparing non-hashable values.

For more details, see https://github.com/kubernetes-sigs/controller-runtime/pull/2982#issuecomment-2568136431.