### PR TITLE
🐛 Add DeletionTimeStamp when deleting objects with clients 

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -763,6 +763,8 @@ func (c *fakeClient) Delete(ctx context.Context, obj client.Object, opts ...clie
 	}
 	delOptions := client.DeleteOptions{}
 	delOptions.ApplyOptions(opts)
+	now := metav1.Now()
+	obj.SetDeletionTimestamp(&now)
 
 	for _, dryRunOpt := range delOptions.DryRun {
 		if dryRunOpt == metav1.DryRunAll {

--- a/pkg/client/metadata_client.go
+++ b/pkg/client/metadata_client.go
@@ -63,6 +63,8 @@ func (mc *metadataClient) Delete(ctx context.Context, obj Object, opts ...Delete
 
 	deleteOpts := DeleteOptions{}
 	deleteOpts.ApplyOptions(opts)
+	now := metav1.Now()
+	metadata.SetDeletionTimestamp(&now)
 
 	return resInt.Delete(ctx, metadata.Name, *deleteOpts.AsDeleteOptions())
 }

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -19,6 +19,7 @@ package client
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -78,6 +79,8 @@ func (c *typedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOpti
 
 	deleteOpts := DeleteOptions{}
 	deleteOpts.ApplyOptions(opts)
+	now := metav1.Now()
+	o.SetDeletionTimestamp(&now)
 
 	return o.Delete().
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -104,6 +105,8 @@ func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...De
 
 	deleteOpts := DeleteOptions{}
 	deleteOpts.ApplyOptions(opts)
+	now := metav1.Now()
+	o.SetDeletionTimestamp(&now)
 
 	return o.Delete().
 		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

When deleting the object with the fake client and type client, the DeletionTimeStamp is not updated on the object.

Resolves #3059 

/assign @sbueringer 
/assign @alvaroaleman 