### PR TITLE
🌱 Remove gosec linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,6 @@ linters:
     - gofmt
     - goimports
     - goprintffuncname
-    - gosec
     - gosimple
     - govet
     - importas

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -585,7 +585,7 @@ func newGVKFixupWatcher(gvk schema.GroupVersionKind, watcher watch.Interface) wa
 // hammer the apiserver with list requests simultaneously.
 func calculateResyncPeriod(resync time.Duration) time.Duration {
 	// the factor will fall into [0.9, 1.1)
-	factor := rand.Float64()/5.0 + 0.9 //nolint:gosec
+	factor := rand.Float64()/5.0 + 0.9
 	return time.Duration(float64(resync.Nanoseconds()) * factor)
 }
 

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -191,7 +191,7 @@ func setConfigs(tc testCase, dir string) {
 
 func createFiles(files map[string]string, dir string) error {
 	for path, data := range files {
-		if err := os.WriteFile(filepath.Join(dir, path), []byte(data), 0644); err != nil { //nolint:gosec
+		if err := os.WriteFile(filepath.Join(dir, path), []byte(data), 0644); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/controllerutil/controllerutil_test.go
+++ b/pkg/controller/controllerutil/controllerutil_test.go
@@ -457,7 +457,7 @@ var _ = Describe("Controllerutil", func() {
 		BeforeEach(func() {
 			deploy = &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("deploy-%d", rand.Int31()), //nolint:gosec
+					Name:      fmt.Sprintf("deploy-%d", rand.Int31()),
 					Namespace: "default",
 				},
 			}
@@ -606,7 +606,7 @@ var _ = Describe("Controllerutil", func() {
 		BeforeEach(func() {
 			deploy = &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("deploy-%d", rand.Int31()), //nolint:gosec
+					Name:      fmt.Sprintf("deploy-%d", rand.Int31()),
 					Namespace: "default",
 				},
 			}

--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -356,7 +356,7 @@ var _ = Describe("Controllerworkqueue", func() {
 
 		for range 20 {
 			for i := range 1000 {
-				rn := rand.N(100) //nolint:gosec // We don't need cryptographically secure entropy here
+				rn := rand.N(100)
 				if rn < 10 {
 					q.AddWithOpts(AddOpts{After: time.Duration(rn) * time.Millisecond}, fmt.Sprintf("foo%d", i))
 				} else {

--- a/pkg/envtest/webhook.go
+++ b/pkg/envtest/webhook.go
@@ -294,10 +294,10 @@ func (o *WebhookInstallOptions) setupCA() error {
 		return fmt.Errorf("unable to marshal webhook serving certs: %w", err)
 	}
 
-	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.crt"), certData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.crt"), certData, 0640); err != nil {
 		return fmt.Errorf("unable to write webhook serving cert to disk: %w", err)
 	}
-	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.key"), keyData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(localServingCertsDir, "tls.key"), keyData, 0640); err != nil {
 		return fmt.Errorf("unable to write webhook serving key to disk: %w", err)
 	}
 

--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -384,10 +384,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil {
 		return err
 	}
 
@@ -404,10 +404,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0640); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0640) //nolint:gosec
+	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0640)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up

--- a/pkg/internal/testing/controlplane/auth.go
+++ b/pkg/internal/testing/controlplane/auth.go
@@ -128,7 +128,7 @@ func (c *CertAuthn) Start() error {
 		return fmt.Errorf("start called before configure")
 	}
 	caCrt := c.ca.CA.CertBytes()
-	if err := os.WriteFile(c.caCrtPath(), caCrt, 0640); err != nil { //nolint:gosec
+	if err := os.WriteFile(c.caCrtPath(), caCrt, 0640); err != nil {
 		return fmt.Errorf("unable to save the client certificate CA to %s: %w", c.caCrtPath(), err)
 	}
 

--- a/pkg/internal/testing/process/process.go
+++ b/pkg/internal/testing/process/process.go
@@ -215,7 +215,7 @@ func pollURLUntilOK(url url.URL, interval time.Duration, ready chan bool, stopCh
 				// there's probably certs *somewhere*,
 				// but it's fine to just skip validating
 				// them for health checks during testing
-				InsecureSkipVerify: true, //nolint:gosec
+				InsecureSkipVerify: true,
 			},
 		},
 	}

--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -85,7 +85,7 @@ func (ev *levelFlag) Set(flagValue string) error {
 		}
 		if logLevel > 0 {
 			intLevel := -1 * logLevel
-			ev.setFunc(zap.NewAtomicLevelAt(zapcore.Level(int8(intLevel)))) //nolint:gosec // We are not worried about integer overflows (G115) here.
+			ev.setFunc(zap.NewAtomicLevelAt(zapcore.Level(int8(intLevel))))
 		} else {
 			return fmt.Errorf("invalid log level \"%s\"", flagValue)
 		}

--- a/pkg/manager/internal/integration/manager_test.go
+++ b/pkg/manager/internal/integration/manager_test.go
@@ -261,7 +261,7 @@ func createConversionWebhook(mgr manager.Manager) *ConversionWebhook {
 	// This is a hack but it's better than using a hard-coded port.
 	v := reflect.ValueOf(mgr).Elem()
 	field := v.FieldByName("healthProbeListener")
-	healthProbeListener := *(*net.Listener)(unsafe.Pointer(field.UnsafeAddr())) //nolint:gosec
+	healthProbeListener := *(*net.Listener)(unsafe.Pointer(field.UnsafeAddr()))
 	readinessEndpoint := fmt.Sprint("http://", healthProbeListener.Addr().String(), "/readyz")
 
 	return &ConversionWebhook{

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -572,7 +572,7 @@ var _ = Describe("manger.Manager", func() {
 		})
 
 		It("should return an error if the metrics bind address is already in use", func() {
-			ln, err := net.Listen("tcp", ":0") //nolint:gosec
+			ln, err := net.Listen("tcp", ":0")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			var srv metricsserver.Server
@@ -597,7 +597,7 @@ var _ = Describe("manger.Manager", func() {
 		})
 
 		It("should return an error if the metrics bind address is already in use and secure serving enabled", func() {
-			ln, err := net.Listen("tcp", ":0") //nolint:gosec
+			ln, err := net.Listen("tcp", ":0")
 			Expect(err).ShouldNot(HaveOccurred())
 
 			var srv metricsserver.Server

--- a/pkg/metrics/filters/filters_test.go
+++ b/pkg/metrics/filters/filters_test.go
@@ -72,7 +72,7 @@ var _ = Describe("manger.Manager", func() {
 					Elem().
 					Set(reflect.ValueOf(newMetricsServer))
 				httpClient = &http.Client{Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 				}}
 			})
 

--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -275,7 +275,7 @@ func (s *defaultServer) createListener(ctx context.Context, log logr.Logger) (ne
 		return s.options.ListenConfig.Listen(ctx, "tcp", s.options.BindAddress)
 	}
 
-	cfg := &tls.Config{ //nolint:gosec
+	cfg := &tls.Config{
 		NextProtos: []string{"h2"},
 	}
 	// fallback TLS config ready, will now mutate if passer wants full control over it

--- a/pkg/webhook/admission/response.go
+++ b/pkg/webhook/admission/response.go
@@ -71,7 +71,7 @@ func ValidationResponse(allowed bool, message string) Response {
 		AdmissionResponse: admissionv1.AdmissionResponse{
 			Allowed: allowed,
 			Result: &metav1.Status{
-				Code:   int32(code), //nolint:gosec // Integer overflows (G115) cannot occur here.
+				Code:   int32(code),
 				Reason: reason,
 			},
 		},

--- a/pkg/webhook/example_test.go
+++ b/pkg/webhook/example_test.go
@@ -145,7 +145,7 @@ func ExampleStandaloneWebhook() {
 	mux.Handle("/validating", validatingHookHandler)
 
 	// Run your handler
-	if err := http.ListenAndServe(port, mux); err != nil { //nolint:gosec // it's fine to not set timeouts here
+	if err := http.ListenAndServe(port, mux); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -190,7 +190,7 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 	log.Info("Starting webhook server")
 
-	cfg := &tls.Config{ //nolint:gosec
+	cfg := &tls.Config{
 		NextProtos: []string{"h2"},
 	}
 	// fallback TLS config ready, will now mutate if passer wants full control over it
@@ -272,7 +272,7 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 // server has been started.
 func (s *DefaultServer) StartedChecker() healthz.Checker {
 	config := &tls.Config{
-		InsecureSkipVerify: true, //nolint:gosec // config is used to connect to our own webhook port.
+		InsecureSkipVerify: true,
 	}
 	return func(req *http.Request) error {
 		s.mu.Lock()

--- a/tools/setup-envtest/remote/read_body.go
+++ b/tools/setup-envtest/remote/read_body.go
@@ -4,7 +4,6 @@
 package remote
 
 import (
-	//nolint:gosec // We're aware that md5 is a weak cryptographic primitive, but we don't have a choice here.
 	"crypto/md5"
 	"crypto/sha512"
 	"encoding/base64"
@@ -28,7 +27,7 @@ func readBody(resp *http.Response, out io.Writer, archiveName string, platform v
 		case versions.SHA512HashType:
 			hasher = sha512.New()
 		case versions.MD5HashType:
-			hasher = md5.New() //nolint:gosec // We're aware that md5 is a weak cryptographic primitive, but we don't have a choice here.
+			hasher = md5.New()
 		default:
 			return fmt.Errorf("hash type %s not implemented", platform.Hash.Type)
 		}

--- a/tools/setup-envtest/store/store.go
+++ b/tools/setup-envtest/store/store.go
@@ -167,14 +167,14 @@ func (s *Store) Add(ctx context.Context, item Item, contents io.Reader) (resErr 
 		// preferfing our own scheme.
 		targetPath := filepath.Base(header.Name)
 		log.V(1).Info("writing archive file to disk", "archive file", header.Name, "on-disk file", targetPath)
-		perms := 0555 & header.Mode                                                                        // make sure we're at most r+x
-		binOut, err := itemPath.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(perms)) //nolint:gosec // Integer overflows (G115) seem unlikely here.
+		perms := 0555 & header.Mode // make sure we're at most r+x
+		binOut, err := itemPath.OpenFile(targetPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(perms))
 		if err != nil {
 			return fmt.Errorf("unable to create file %s from archive to disk for version-platform pair %s", targetPath, itemName)
 		}
 		if err := func() error { // IIFE to get the defer properly in a loop
 			defer binOut.Close()
-			if _, err := io.Copy(binOut, tarReader); err != nil { //nolint:gosec
+			if _, err := io.Copy(binOut, tarReader); err != nil {
 				return fmt.Errorf("unable to write file %s from archive to disk for version-platform pair %s", targetPath, itemName)
 			}
 			return nil


### PR DESCRIPTION
It yields a lot of false positives as seen by the number of nolint directives this change removes.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
