### PR TITLE
:bug: Fix a bug in the priorityqueue metrics

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue.go
+++ b/pkg/controller/priorityqueue/priorityqueue.go
@@ -163,6 +163,9 @@ func (w *priorityqueue[T]) AddWithOpts(o AddOpts, items ...T) {
 		}
 
 		if item.readyAt != nil && (readyAt == nil || readyAt.Before(*item.readyAt)) {
+			if readyAt == nil {
+				w.metrics.add(key)
+			}
 			item.readyAt = readyAt
 		}
 


### PR DESCRIPTION
The priorityqueue needs to call `metrics.add` but only once an item was ready. When an item was initially added with `After`, so not ready, then without which makes it ready, we didn't do that, resulting in potentially negative values for the queue depth metric.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
