### PR TITLE
🐛 Check to see if custom source implements fmt.Stringer when logging

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -175,7 +175,16 @@ func (c *Controller[request]) Start(ctx context.Context) error {
 		// caches.
 		errGroup := &errgroup.Group{}
 		for _, watch := range c.startWatches {
-			log := c.LogConstructor(nil).WithValues("source", watch.String())
+			log := c.LogConstructor(nil)
+			_, ok := watch.(interface {
+				String() string
+			})
+
+			if !ok {
+				log = log.WithValues("source", fmt.Sprintf("%T", watch))
+			} else {
+				log = log.WithValues("source", fmt.Sprintf("%s", watch))
+			}
 			didStartSyncingSource := &atomic.Bool{}
 			errGroup.Go(func() error {
 				// Use a timeout for starting and syncing the source to avoid silently

--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -175,7 +175,7 @@ func (c *Controller[request]) Start(ctx context.Context) error {
 		// caches.
 		errGroup := &errgroup.Group{}
 		for _, watch := range c.startWatches {
-			log := c.LogConstructor(nil).WithValues("source", fmt.Sprintf("%s", watch))
+			log := c.LogConstructor(nil).WithValues("source", watch.String())
 			didStartSyncingSource := &atomic.Bool{}
 			errGroup.Go(func() error {
 				// Use a timeout for starting and syncing the source to avoid silently

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -56,10 +56,6 @@ type TypedSource[request comparable] interface {
 	// Start is internal and should be called only by the Controller to start the source.
 	// Start must be non-blocking.
 	Start(context.Context, workqueue.TypedRateLimitingInterface[request]) error
-
-	// String enforces the custom source to adhere to the fmt.Stringer interface
-	// to print when being logged.
-	String() string
 }
 
 // SyncingSource is a source that needs syncing prior to being usable. The controller

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -56,6 +56,10 @@ type TypedSource[request comparable] interface {
 	// Start is internal and should be called only by the Controller to start the source.
 	// Start must be non-blocking.
 	Start(context.Context, workqueue.TypedRateLimitingInterface[request]) error
+
+	// String enforces the custom source to adhere to the fmt.Stringer interface
+	// to print when being logged.
+	String() string
 }
 
 // SyncingSource is a source that needs syncing prior to being usable. The controller


### PR DESCRIPTION
When using a custom source, the error when starting will fail because the `fmt.Stringer` interface is not implemented by the source.  The builtin sources have already implanted this interface allow the below line to not fail:

```go
log := c.LogConstructor(nil).WithValues("source", watch.String())
```
```
fatal error: concurrent map iteration and map write
```
<!-- What does this do, and why do we need it? -->
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3057
