### PR TITLE
🐛 cache: clone maps to prevent data race when concurrently creating caches using the same options

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -469,6 +469,8 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 		}
 	}
 
+	opts.ByObject = maps.Clone(opts.ByObject)
+	opts.DefaultNamespaces = maps.Clone(opts.DefaultNamespaces)
 	for obj, byObject := range opts.ByObject {
 		isNamespaced, err := apiutil.IsObjectNamespaced(obj, opts.Scheme, opts.Mapper)
 		if err != nil {
@@ -480,6 +482,8 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 
 		if isNamespaced && byObject.Namespaces == nil {
 			byObject.Namespaces = maps.Clone(opts.DefaultNamespaces)
+		} else {
+			byObject.Namespaces = maps.Clone(byObject.Namespaces)
 		}
 
 		// Default the namespace-level configs first, because they need to use the undefaulted type-level config
@@ -487,7 +491,6 @@ func defaultOpts(config *rest.Config, opts Options) (Options, error) {
 		for namespace, config := range byObject.Namespaces {
 			// 1. Default from the undefaulted type-level config
 			config = defaultConfig(config, byObjectToConfig(byObject))
-
 			// 2. Default from the namespace-level config. This was defaulted from the global default config earlier, but
 			//    might not have an entry for the current namespace.
 			if defaultNamespaceSettings, hasDefaultNamespace := opts.DefaultNamespaces[namespace]; hasDefaultNamespace {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR adds clones to the cache packages `defaultOpts` function.
This is necessary to prevent data races when creating caches in parallel using the same options.

Note: we found this in CAPI and workaround using: https://github.com/kubernetes-sigs/cluster-api/pull/11707

Data races before:

```
==================
WARNING: DATA RACE
Write at 0x00c00046c900 by goroutine 29:
  runtime.mapaccess2()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map.go:479 +0x28c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:523 +0x650
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous read at 0x00c00046c900 by goroutine 28:
  runtime.mapdelete()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map.go:741 +0x43c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:472 +0x144
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00046c930 by goroutine 28:
  runtime.mapdelete()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map.go:741 +0x43c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:487 +0x418
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous write at 0x00c00046c930 by goroutine 29:
  runtime.mapaccess2_faststr()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map_faststr.go:117 +0x42c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:509 +0x1270
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Write at 0x00c0004a6b90 by goroutine 29:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:523 +0x660
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous read at 0x00c0004a6b90 by goroutine 28:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:472 +0x308
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0004c4590 by goroutine 28:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:487 +0xcf0
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous write at 0x00c0004c4590 by goroutine 29:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:509 +0x1280
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c00046c960 by goroutine 28:
  runtime.mapassign_fast64ptr()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map_fast64.go:214 +0x36c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:493 +0xe68
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous write at 0x00c00046c960 by goroutine 29:
  runtime.mapaccess2_faststr()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map_faststr.go:117 +0x42c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:539 +0xa4c
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Read at 0x00c0004c4810 by goroutine 28:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:493 +0xe78
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous write at 0x00c0004c4810 by goroutine 29:
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:539 +0xa5c
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
==================
==================
WARNING: DATA RACE
Write at 0x00c00046c900 by goroutine 28:
  runtime.mapaccess2()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map.go:479 +0x28c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:523 +0x650
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Previous read at 0x00c00046c900 by goroutine 29:
  runtime.mapiterinit()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/runtime/map.go:877 +0x27c
  sigs.k8s.io/controller-runtime/pkg/cache.defaultOpts()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache.go:472 +0x2a8
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace.func1()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:35 +0xe8

Goroutine 28 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40

Goroutine 29 (running) created at:
  sigs.k8s.io/controller-runtime/pkg/cache.TestDefaultOptsRace()
      /Users/schlotterc/go/src/sigs.k8s.io/controller-runtime/pkg/cache/cache_race_test.go:33 +0x4e4
  testing.tRunner()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1690 +0x184
  testing.(*T).Run.gowrap1()
      /Users/schlotterc/.bin/go-archive/go1.23.2.darwin-arm64/src/testing/testing.go:1743 +0x40
```


Reproduction using the following command and unit test:

```sh
go test -race -count=1 -timeout 300s -run ^TestDefaultOptsRace$ sigs.k8s.io/controller-runtime/pkg/cache
```

File `pkg/cache/cache_race_test.go`:

```go
package cache

import (
	"sync"
	"testing"

	corev1 "k8s.io/api/core/v1"
	"k8s.io/apimachinery/pkg/labels"
	"k8s.io/client-go/rest"
	"sigs.k8s.io/controller-runtime/pkg/client"
)

func TestDefaultOptsRace(t *testing.T) {
	opts := Options{
		Mapper: &fakeRESTMapper{},
		ByObject: map[client.Object]ByObject{
			&corev1.Pod{}: {
				Label: labels.SelectorFromSet(map[string]string{"from": "pod"}),
				Namespaces: map[string]Config{"default": {
					LabelSelector: labels.SelectorFromSet(map[string]string{"from": "pod"}),
				}},
			},
		},
		DefaultNamespaces: map[string]Config{"default": {}},
	}

	m := sync.RWMutex{}
	wg := sync.WaitGroup{}
	// Block until we finished the setup
	m.Lock()
	for range 2 {
		wg.Add(1)
		go func() {
			m.RLock()
			defaultOpts(&rest.Config{}, opts)
			wg.Done()
		}()
	}
	m.Unlock()
	wg.Wait()
}
```


