### PR TITLE
🐛fix(controller): support WaitForSync in custom TypedSyncingSource

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -200,7 +200,7 @@ func (c *Controller[request]) Start(ctx context.Context) error {
 						sourceStartErrChan <- err
 						return
 					}
-					syncingSource, ok := watch.(source.SyncingSource)
+					syncingSource, ok := watch.(source.TypedSyncingSource[request])
 					if !ok {
 						return
 					}


### PR DESCRIPTION
The code that calls `WaitForSync(ctx)` checks for the original `SyncingSource`. This does not work for custom typed controllers where `TypedSyncingSource` is passed with a type parameter other than `reconcile.Request` .

this fix should be backported to v0.20 and v0.19
