### PR TITLE
:bug: Fix custom path for webhooks conflict

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -37,17 +37,19 @@ import (
 
 // WebhookBuilder builds a Webhook.
 type WebhookBuilder struct {
-	apiType             runtime.Object
-	customDefaulter     admission.CustomDefaulter
-	customDefaulterOpts []admission.DefaulterOption
-	customValidator     admission.CustomValidator
-	customPath          string
-	gvk                 schema.GroupVersionKind
-	mgr                 manager.Manager
-	config              *rest.Config
-	recoverPanic        *bool
-	logConstructor      func(base logr.Logger, req *admission.Request) logr.Logger
-	err                 error
+	apiType                   runtime.Object
+	customDefaulter           admission.CustomDefaulter
+	customDefaulterOpts       []admission.DefaulterOption
+	customValidator           admission.CustomValidator
+	customPath                string
+	customValidatorCustomPath string
+	customDefaulterCustomPath string
+	gvk                       schema.GroupVersionKind
+	mgr                       manager.Manager
+	config                    *rest.Config
+	recoverPanic              *bool
+	logConstructor            func(base logr.Logger, req *admission.Request) logr.Logger
+	err                       error
 }
 
 // WebhookManagedBy returns a new webhook builder.
@@ -96,8 +98,22 @@ func (blder *WebhookBuilder) RecoverPanic(recoverPanic bool) *WebhookBuilder {
 }
 
 // WithCustomPath overrides the webhook's default path by the customPath
+// Deprecated: WithCustomPath should not be used anymore.
+// Please use WithValidatorCustomPath or WithDefaulterCustomPath instead.
 func (blder *WebhookBuilder) WithCustomPath(customPath string) *WebhookBuilder {
 	blder.customPath = customPath
+	return blder
+}
+
+// WithValidatorCustomPath overrides the path of the Validator.
+func (blder *WebhookBuilder) WithValidatorCustomPath(customPath string) *WebhookBuilder {
+	blder.customValidatorCustomPath = customPath
+	return blder
+}
+
+// WithDefaulterCustomPath overrides the path of the Defaulter.
+func (blder *WebhookBuilder) WithDefaulterCustomPath(customPath string) *WebhookBuilder {
+	blder.customDefaulterCustomPath = customPath
 	return blder
 }
 
@@ -139,6 +155,10 @@ func (blder *WebhookBuilder) setLogConstructor() {
 	}
 }
 
+func (blder *WebhookBuilder) isThereCustomPathConflict() bool {
+	return (blder.customPath != "" && blder.customDefaulter != nil && blder.customValidator != nil) || (blder.customPath != "" && blder.customDefaulterCustomPath != "") || (blder.customPath != "" && blder.customValidatorCustomPath != "")
+}
+
 func (blder *WebhookBuilder) registerWebhooks() error {
 	typ, err := blder.getType()
 	if err != nil {
@@ -148,6 +168,17 @@ func (blder *WebhookBuilder) registerWebhooks() error {
 	blder.gvk, err = apiutil.GVKForObject(typ, blder.mgr.GetScheme())
 	if err != nil {
 		return err
+	}
+
+	if blder.isThereCustomPathConflict() {
+		return errors.New("only one of CustomDefaulter or CustomValidator should be set when using WithCustomPath. Otherwise, WithDefaulterCustomPath() and WithValidatorCustomPath() should be used")
+	}
+	if blder.customPath != "" {
+		// isThereCustomPathConflict() already checks for potential conflicts.
+		// Since we are sure that only one of customDefaulter or customValidator will be used,
+		// we can set both customDefaulterCustomPath and validatingCustomPath.
+		blder.customDefaulterCustomPath = blder.customPath
+		blder.customValidatorCustomPath = blder.customPath
 	}
 
 	// Register webhook(s) for type
@@ -174,8 +205,8 @@ func (blder *WebhookBuilder) registerDefaultingWebhook() error {
 	if mwh != nil {
 		mwh.LogConstructor = blder.logConstructor
 		path := generateMutatePath(blder.gvk)
-		if blder.customPath != "" {
-			generatedCustomPath, err := generateCustomPath(blder.customPath)
+		if blder.customDefaulterCustomPath != "" {
+			generatedCustomPath, err := generateCustomPath(blder.customDefaulterCustomPath)
 			if err != nil {
 				return err
 			}
@@ -212,8 +243,8 @@ func (blder *WebhookBuilder) registerValidatingWebhook() error {
 	if vwh != nil {
 		vwh.LogConstructor = blder.logConstructor
 		path := generateValidatePath(blder.gvk)
-		if blder.customPath != "" {
-			generatedCustomPath, err := generateCustomPath(blder.customPath)
+		if blder.customValidatorCustomPath != "" {
+			generatedCustomPath, err := generateCustomPath(blder.customValidatorCustomPath)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Following this PR #2998. I implemented the custom path for webhooks considering that it will be used by either only the `validating` or the `defaulting`. However, the user can actually use the both of them on the same webhook manager.

Until now, when the user was using `.WithDefaulter(&TestCustomDefaulter{})`, `.WithValidator(&TestCustomValidator{})` and `.WithCustomPath(customPath)` at the same time, an endless loop was launched by constantly calling the other webhook. This bug is caused because they are both register at the same path.

This is the reason why I made this PR. I split the `.WithCustomPath()` function into two functions `.WithDefaultingCustomPath()` and `.WithValidatingCustomPath()` in order to be used in this way:

```go
WebhookManagedBy(mgr).
	For(&TestDefaulter{}).
	WithDefaulter(&TestCustomDefaulter{}).
	WithValidator(&TestCustomValidator{}).
	WithDefaultingCustomPath(defaultingCustomPath).
	WithValidatingCustomPath(validatingCustomPath).
	Complete()
```

Also, I added two tests:
1. One that tests the example above.
2. And I take advantage of making this PR to add a second one that tests the usage of `WithDefaulter()` and `WithValidator()` at the same time (without the custom path implementation) because there were no test about this specific configuration before.