### PR TITLE
🐛Implement priorityqueue as default on handlers if using priorityqueue interface

### DIFF
--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -52,25 +52,32 @@ func (e *TypedEnqueueRequestForObject[T]) Create(ctx context.Context, evt event.
 		enqueueLog.Error(nil, "CreateEvent received with no metadata", "event", evt)
 		return
 	}
-	q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+
+	item := reconcile.Request{NamespacedName: types.NamespacedName{
 		Name:      evt.Object.GetName(),
 		Namespace: evt.Object.GetNamespace(),
-	}})
+	}}
+
+	addToQueueCreate(q, evt, item)
 }
 
 // Update implements EventHandler.
 func (e *TypedEnqueueRequestForObject[T]) Update(ctx context.Context, evt event.TypedUpdateEvent[T], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 	switch {
 	case !isNil(evt.ObjectNew):
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+		item := reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      evt.ObjectNew.GetName(),
 			Namespace: evt.ObjectNew.GetNamespace(),
-		}})
+		}}
+
+		addToQueueUpdate(q, evt, item)
 	case !isNil(evt.ObjectOld):
-		q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+		item := reconcile.Request{NamespacedName: types.NamespacedName{
 			Name:      evt.ObjectOld.GetName(),
 			Namespace: evt.ObjectOld.GetNamespace(),
-		}})
+		}}
+
+		addToQueueUpdate(q, evt, item)
 	default:
 		enqueueLog.Error(nil, "UpdateEvent received with no metadata", "event", evt)
 	}

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -46,7 +46,7 @@ type TypedMapFunc[object any, request comparable] func(context.Context, object) 
 // For UpdateEvents which contain both a new and old object, the transformation function is run on both
 // objects and both sets of Requests are enqueue.
 func EnqueueRequestsFromMapFunc(fn MapFunc) EventHandler {
-	return TypedEnqueueRequestsFromMapFunc(fn)
+	return WithLowPriorityWhenUnchanged(TypedEnqueueRequestsFromMapFunc(fn))
 }
 
 // TypedEnqueueRequestsFromMapFunc enqueues Requests by running a transformation function that outputs a collection

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -46,7 +46,7 @@ type TypedMapFunc[object any, request comparable] func(context.Context, object) 
 // For UpdateEvents which contain both a new and old object, the transformation function is run on both
 // objects and both sets of Requests are enqueue.
 func EnqueueRequestsFromMapFunc(fn MapFunc) EventHandler {
-	return WithLowPriorityWhenUnchanged(TypedEnqueueRequestsFromMapFunc(fn))
+	return TypedEnqueueRequestsFromMapFunc(fn)
 }
 
 // TypedEnqueueRequestsFromMapFunc enqueues Requests by running a transformation function that outputs a collection

--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -48,7 +48,7 @@ type OwnerOption func(e enqueueRequestForOwnerInterface)
 //
 // - a handler.enqueueRequestForOwner EventHandler with an OwnerType of ReplicaSet and OnlyControllerOwner set to true.
 func EnqueueRequestForOwner(scheme *runtime.Scheme, mapper meta.RESTMapper, ownerType client.Object, opts ...OwnerOption) EventHandler {
-	return TypedEnqueueRequestForOwner[client.Object](scheme, mapper, ownerType, opts...)
+	return WithLowPriorityWhenUnchanged(TypedEnqueueRequestForOwner[client.Object](scheme, mapper, ownerType, opts...))
 }
 
 // TypedEnqueueRequestForOwner enqueues Requests for the Owners of an object.  E.g. the object that created


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3105

Handlers: 
- [x] `TypedEnqueueRequestForObject`
- [x] `EnqueueRequestForOwner`
- [ ] `EnqueueRequestFromMapFunc`


This brings the handler `TypedEnqueueRequestForObject` , `enqueueRequestForOwner` and `enqueuRequestFromMapFunc` handlers to use priority queue if the `workqueue.TypedRateLimitingInterface[reconcile.Request]` is of type  `priorityqueue.PriorityQueue[reconcile.Request]` without having to use the wrapper `WithLowPriorityWhenUnchanged`.

**NOTE: Added tests implement the same logic to show that this maps to the functionality of the wrapped handler in the tests**
<!-- What does this do, and why do we need it? -->

/assign @alvaroaleman @sbueringer 
