### PR TITLE
:warning: Config: Disable client-side ratelimiter by default

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -77,12 +77,18 @@ var (
 	// If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 	// in cluster and use the cluster provided kubeconfig.
 	//
+	// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+	// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
+	//
 	// Will log an error and exit if there is an error creating the rest.Config.
 	GetConfigOrDie = config.GetConfigOrDie
 
 	// GetConfig creates a *rest.Config for talking to a Kubernetes apiserver.
 	// If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 	// in cluster and use the cluster provided kubeconfig.
+	//
+	// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+	// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 	//
 	// Config precedence
 	//

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -61,6 +61,9 @@ func RegisterFlags(fs *flag.FlagSet) {
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
 //
+// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
+//
 // It also applies saner defaults for QPS and burst based on the Kubernetes
 // controller manager defaults (20 QPS, 30 burst)
 //
@@ -81,6 +84,9 @@ func GetConfig() (*rest.Config, error) {
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
 //
+// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
+//
 // It also applies saner defaults for QPS and burst based on the Kubernetes
 // controller manager defaults (20 QPS, 30 burst)
 //
@@ -99,10 +105,9 @@ func GetConfigWithContext(context string) (*rest.Config, error) {
 		return nil, err
 	}
 	if cfg.QPS == 0.0 {
-		cfg.QPS = 20.0
-	}
-	if cfg.Burst == 0 {
-		cfg.Burst = 30
+		// Disable client-side ratelimer by default, we can rely on
+		// API priority and fairness
+		cfg.QPS = -1
 	}
 	return cfg, nil
 }
@@ -169,6 +174,9 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 // GetConfigOrDie creates a *rest.Config for talking to a Kubernetes apiserver.
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
+//
+// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 //
 // Will log an error and exit if there is an error creating the rest.Config.
 func GetConfigOrDie() *rest.Config {

--- a/pkg/client/config/config_test.go
+++ b/pkg/client/config/config_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Config", func() {
 					cfg, err := GetConfigWithContext(tc.context)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(cfg.Host).To(Equal(tc.wantHost))
+					Expect(cfg.QPS).To(Equal(float32(-1)))
 				})
 			}
 		}
@@ -82,8 +83,8 @@ var _ = Describe("Config", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				cfg, err := GetConfigWithContext("")
-				Expect(cfg).To(BeNil())
 				Expect(err).To(HaveOccurred())
+				Expect(cfg).To(BeNil())
 			})
 		})
 


### PR DESCRIPTION
Sig-Apimachinery recommends [disabling the client-side ratelimiter][0] and rely on API priority and fairness instead for any [Kubernetes version >= 1.22][1]. Update our config getters to do that.

[0]: https://kubernetes.slack.com/archives/C0EG7JC6T/p1680889646346859?thread_ts=1680791299.631439&cid=C0EG7JC6T
[1]: https://kubernetes.slack.com/archives/C0EG7JC6T/p1680892224956789?thread_ts=1680791299.631439&cid=C0EG7JC6T

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
