### PR TITLE
🐛 fix: cache should list out of global cache when present and necessary

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -130,16 +130,16 @@ var _ = Describe("Informer Cache with ReaderFailOnMissingInformer", func() {
 var _ = Describe("Multi-Namespace Informer Cache", func() {
 	CacheTest(cache.New, cache.Options{
 		DefaultNamespaces: map[string]cache.Config{
-			testNamespaceOne: {},
-			testNamespaceTwo: {},
-			"default":        {},
+			cache.AllNamespaces: {FieldSelector: fields.OneTermEqualSelector("metadata.namespace", testNamespaceOne)},
+			testNamespaceTwo:    {},
+			"default":           {},
 		},
 	})
 	NonBlockingGetTest(cache.New, cache.Options{
 		DefaultNamespaces: map[string]cache.Config{
-			testNamespaceOne: {},
-			testNamespaceTwo: {},
-			"default":        {},
+			cache.AllNamespaces: {FieldSelector: fields.OneTermEqualSelector("metadata.namespace", testNamespaceOne)},
+			testNamespaceTwo:    {},
+			"default":           {},
 		},
 	})
 })

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -262,6 +262,9 @@ func (c *multiNamespaceCache) List(ctx context.Context, list client.ObjectList, 
 	if listOpts.Namespace != corev1.NamespaceAll {
 		cache, ok := c.namespaceToCache[listOpts.Namespace]
 		if !ok {
+			if global, hasGlobal := c.namespaceToCache[AllNamespaces]; hasGlobal {
+				return global.List(ctx, list, opts...)
+			}
 			return fmt.Errorf("unable to list: %v because of unknown namespace for the cache", listOpts.Namespace)
 		}
 		return cache.List(ctx, list, opts...)


### PR DESCRIPTION
When the cache options are configured with DefaultNamespaces which include an entry with `cache.AllNamespaces`, listing from the cache should fallback to the global cache if there are no namespace-specific caches that match the namespace from the list options.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
