### PR TITLE
🌱 Export envtest.ReadCRDFiles

### DIFF
--- a/pkg/envtest/crd.go
+++ b/pkg/envtest/crd.go
@@ -94,7 +94,7 @@ func InstallCRDs(config *rest.Config, options CRDInstallOptions) ([]*apiextensio
 	defaultCRDOptions(&options)
 
 	// Read the CRD yamls into options.CRDs
-	if err := readCRDFiles(&options); err != nil {
+	if err := ReadCRDFiles(&options); err != nil {
 		return nil, fmt.Errorf("unable to read CRD files: %w", err)
 	}
 
@@ -115,8 +115,8 @@ func InstallCRDs(config *rest.Config, options CRDInstallOptions) ([]*apiextensio
 	return options.CRDs, nil
 }
 
-// readCRDFiles reads the directories of CRDs in options.Paths and adds the CRD structs to options.CRDs.
-func readCRDFiles(options *CRDInstallOptions) error {
+// ReadCRDFiles reads the directories of CRDs in options.Paths and adds the CRD structs to options.CRDs.
+func ReadCRDFiles(options *CRDInstallOptions) error {
 	if len(options.Paths) > 0 {
 		crdList, err := renderCRDs(options)
 		if err != nil {
@@ -217,7 +217,7 @@ func (p *poller) poll(ctx context.Context) (done bool, err error) {
 // UninstallCRDs uninstalls a collection of CRDs by reading the crd yaml files from a directory.
 func UninstallCRDs(config *rest.Config, options CRDInstallOptions) error {
 	// Read the CRD yamls into options.CRDs
-	if err := readCRDFiles(&options); err != nil {
+	if err := ReadCRDFiles(&options); err != nil {
 		return err
 	}
 

--- a/pkg/envtest/crd_test.go
+++ b/pkg/envtest/crd_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Test", func() {
 					"testdata/crdv1_original",
 				},
 			}
-			err := readCRDFiles(&opt)
+			err := ReadCRDFiles(&opt)
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedCRDs := sets.NewString(


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

I would like to export ReadCRDFiles so I can use the functionality without being forced to use the entire InstallCRDs func.

CreateCRDs and WaitForCRDs are already exported