### PR TITLE
:seedling: Validate that unstructued objects don't require scheme registration

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1036,7 +1036,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 
 		Context("with unstructured objects", func() {
 			It("should be able to read the Scale subresource", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1061,7 +1061,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				Expect(int32(val)).To(Equal(*dep.Spec.Replicas))
 			})
 			It("should be able to create ServiceAccount tokens", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1089,7 +1089,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to create Pod evictions", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1122,7 +1122,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to create Pod bindings", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1157,7 +1157,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to approve CSRs", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1188,7 +1188,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to approve CSRs using Patch", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1220,7 +1220,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to update the scale subresource", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 
@@ -1250,7 +1250,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 			})
 
 			It("should be able to patch the scale subresource", func() {
-				cl, err := client.New(cfg, client.Options{})
+				cl, err := client.New(cfg, client.Options{Scheme: runtime.NewScheme()})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cl).NotTo(BeNil())
 


### PR DESCRIPTION
If someone is interacting with objects through unstructured, we generally do not expect that to require any sort of registration in the scheme. It look like we never had any tests for this, this change adds them.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
