### PR TITLE
:bug: Fakeclient: Fix dataraces when writing to the scheme

### DIFF
--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -2516,6 +2516,93 @@ var _ = Describe("Fake client", func() {
 		Expect(cl.SubResource(subResourceScale).Update(context.Background(), obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
 	})
 
+	It("is threadsafe", func() {
+		cl := NewClientBuilder().Build()
+
+		u := func() *unstructured.Unstructured {
+			u := &unstructured.Unstructured{}
+			u.SetAPIVersion("custom/v1")
+			u.SetKind("Version")
+			u.SetName("foo")
+			return u
+		}
+
+		uList := func() *unstructured.UnstructuredList {
+			u := &unstructured.UnstructuredList{}
+			u.SetAPIVersion("custom/v1")
+			u.SetKind("Version")
+
+			return u
+		}
+
+		meta := func() *metav1.PartialObjectMetadata {
+			return &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "default",
+				},
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "custom/v1",
+					Kind:       "Version",
+				},
+			}
+		}
+		metaList := func() *metav1.PartialObjectMetadataList {
+			return &metav1.PartialObjectMetadataList{
+				TypeMeta: metav1.TypeMeta{
+
+					APIVersion: "custom/v1",
+					Kind:       "Version",
+				},
+			}
+		}
+
+		pod := func() *corev1.Pod {
+			return &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: "default",
+			}}
+		}
+
+		ctx := context.Background()
+		ops := []func(){
+			func() { _ = cl.Create(ctx, u()) },
+			func() { _ = cl.Get(ctx, client.ObjectKeyFromObject(u()), u()) },
+			func() { _ = cl.Update(ctx, u()) },
+			func() { _ = cl.Patch(ctx, u(), client.RawPatch(types.StrategicMergePatchType, []byte("foo"))) },
+			func() { _ = cl.Delete(ctx, u()) },
+			func() { _ = cl.DeleteAllOf(ctx, u(), client.HasLabels{"foo"}) },
+			func() { _ = cl.List(ctx, uList()) },
+
+			func() { _ = cl.Create(ctx, meta()) },
+			func() { _ = cl.Get(ctx, client.ObjectKeyFromObject(meta()), meta()) },
+			func() { _ = cl.Update(ctx, meta()) },
+			func() { _ = cl.Patch(ctx, meta(), client.RawPatch(types.StrategicMergePatchType, []byte("foo"))) },
+			func() { _ = cl.Delete(ctx, meta()) },
+			func() { _ = cl.DeleteAllOf(ctx, meta(), client.HasLabels{"foo"}) },
+			func() { _ = cl.List(ctx, metaList()) },
+
+			func() { _ = cl.Create(ctx, pod()) },
+			func() { _ = cl.Get(ctx, client.ObjectKeyFromObject(pod()), pod()) },
+			func() { _ = cl.Update(ctx, pod()) },
+			func() { _ = cl.Patch(ctx, pod(), client.RawPatch(types.StrategicMergePatchType, []byte("foo"))) },
+			func() { _ = cl.Delete(ctx, pod()) },
+			func() { _ = cl.DeleteAllOf(ctx, pod(), client.HasLabels{"foo"}) },
+			func() { _ = cl.List(ctx, &corev1.PodList{}) },
+		}
+
+		wg := sync.WaitGroup{}
+		wg.Add(len(ops))
+		for _, op := range ops {
+			go func() {
+				defer wg.Done()
+				op()
+			}()
+		}
+
+		wg.Wait()
+	})
+
 	scalableObjs := []client.Object{
 		&appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2604,6 +2691,7 @@ var _ = Describe("Fake client", func() {
 			scaleExpected.ResourceVersion = scaleActual.ResourceVersion
 			Expect(cmp.Diff(scaleExpected, scaleActual)).To(BeEmpty())
 		})
+
 	}
 })
 


### PR DESCRIPTION
We have a scheme write lock but plenty of other codeptaths that read from the scheme and that don't do looking, resulting in dataraces if the two happen in parallel.

This change introduces a simple RW lock and makes the fakeclient acquire read locking for all its operations except when needing the write lock. This isn't particularly smart, but given that we only have one codepath that writes to the scheme, it seems good enough.

Fixes #3139 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/cherrypick release-0.20
/cherrypick release-0.19
