### PR TITLE
[release-0.20] :bug: Revert "✨ Expose all Go runtime metrics"

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -88,7 +88,7 @@ func init() {
 		ActiveWorkers,
 		// expose process metrics like CPU, Memory, file descriptor usage etc.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		// expose all Go runtime metrics like GC stats, memory stats etc.
-		collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)),
+		// expose Go runtime metrics like GC stats, memory stats etc.
+		collectors.NewGoCollector(),
 	)
 }


### PR DESCRIPTION
This reverts commit fc485839d5c10112642325e7e6df25084553c0e4.

This change breaks some users.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3144

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
