### PR TITLE
🐛 Fix race in logger test

### DIFF
--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -1092,9 +1092,14 @@ var _ = Describe("manger.Manager", func() {
 				msg := "controller log message"
 				m.GetControllerOptions().Logger.Info(msg)
 
-				Expect(messages).To(ContainElement(
-					ContainSubstring(msg),
-				))
+				Eventually(func(g Gomega) {
+					lock.Lock()
+					defer lock.Unlock()
+
+					g.Expect(messages).To(ContainElement(
+						ContainSubstring(msg),
+					))
+				}).Should(Succeed())
 			})
 
 			It("should return both runnables and stop errors when both error", func() {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Saw tests failing a few times with race condition: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/kubernetes-sigs_controller-runtime/3138/pull-controller-runtime-test/1898308642759774208
