### PR TITLE
:seedling: envtest: fix nil pointer exception in Stop().

### DIFF
--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -384,10 +384,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0640); err != nil {
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.crt"), certData, 0o640); err != nil {
 		return err
 	}
-	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0640); err != nil {
+	if err := os.WriteFile(filepath.Join(s.CertDir, "apiserver.key"), keyData, 0o640); err != nil {
 		return err
 	}
 
@@ -404,10 +404,10 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0640); err != nil {
+	if err := os.WriteFile(filepath.Join(s.CertDir, saCertFile), saCert, 0o640); err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0640)
+	return os.WriteFile(filepath.Join(s.CertDir, saKeyFile), saKey, 0o640)
 }
 
 // Stop stops this process gracefully, waits for its termination, and cleans up
@@ -420,6 +420,9 @@ func (s *APIServer) Stop() error {
 		if err := s.processState.Stop(); err != nil {
 			return err
 		}
+	}
+	if s.Authn == nil {
+		return nil
 	}
 	return s.Authn.Stop()
 }


### PR DESCRIPTION
old code:

```go
func (s *APIServer) Stop() error {
	if s.processState != nil {
		if s.processState.DirNeedsCleaning {
			s.CertDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
		}
		if err := s.processState.Stop(); err != nil {
			return err
		}
	}
	return s.Authn.Stop()
}
```

If setup failed, and then Stop() gets called, `s.Authn` could be nil.

This PR checks if s.Auth is nil.