### PR TITLE
✨ Leverage isInInitialList of ResourceEventHandler.OnAdd, Add IsInInitialList to TypedCreateEvent

### DIFF
--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -337,18 +337,11 @@ type handlerRegistration struct {
 	handles map[string]toolscache.ResourceEventHandlerRegistration
 }
 
-type syncer interface {
-	HasSynced() bool
-}
-
 // HasSynced asserts that the handler has been called for the full initial state of the informer.
-// This uses syncer to be compatible between client-go 1.27+ and older versions when the interface changed.
 func (h handlerRegistration) HasSynced() bool {
-	for _, reg := range h.handles {
-		if s, ok := reg.(syncer); ok {
-			if !s.HasSynced() {
-				return false
-			}
+	for _, h := range h.handles {
+		if !h.HasSynced() {
+			return false
 		}
 	}
 	return true

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -40,6 +40,9 @@ type GenericEvent = TypedGenericEvent[client.Object]
 type TypedCreateEvent[object any] struct {
 	// Object is the object from the event
 	Object object
+
+	// IsInInitialList is true if the Create event was triggered by the initial list.
+	IsInInitialList bool
 }
 
 // TypedUpdateEvent is an event where a Kubernetes object was updated. TypedUpdateEvent should be generated

--- a/pkg/handler/enqueue_mapped.go
+++ b/pkg/handler/enqueue_mapped.go
@@ -86,9 +86,8 @@ func (e *enqueueRequestsFromMapFunc[object, request]) Create(
 	reqs := map[request]empty{}
 
 	var lowPriority bool
-	if e.objectImplementsClientObject && isPriorityQueue(q) && !isNil(evt.Object) {
-		clientObjectEvent := event.CreateEvent{Object: any(evt.Object).(client.Object)}
-		if isObjectUnchanged(clientObjectEvent) {
+	if isPriorityQueue(q) && !isNil(evt.Object) {
+		if evt.IsInInitialList {
 			lowPriority = true
 		}
 	}

--- a/pkg/internal/source/internal_test.go
+++ b/pkg/internal/source/internal_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Internal", func() {
 				defer GinkgoRecover()
 				Expect(evt.Object).To(Equal(pod))
 			}
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 		})
 
 		It("should used Predicates to filter CreateEvents", func() {
@@ -105,14 +105,14 @@ var _ = Describe("Internal", func() {
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
 			})
 			set = false
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 			Expect(set).To(BeFalse())
 
 			set = false
 			instance = internal.NewEventHandler(ctx, &controllertest.Queue{}, setfuncs, []predicate.Predicate{
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
 			})
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 			Expect(set).To(BeTrue())
 
 			set = false
@@ -120,7 +120,7 @@ var _ = Describe("Internal", func() {
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
 			})
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 			Expect(set).To(BeFalse())
 
 			set = false
@@ -128,7 +128,7 @@ var _ = Describe("Internal", func() {
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
 			})
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 			Expect(set).To(BeFalse())
 
 			set = false
@@ -136,16 +136,16 @@ var _ = Describe("Internal", func() {
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return true }},
 			})
-			instance.OnAdd(pod)
+			instance.OnAdd(pod, false)
 			Expect(set).To(BeTrue())
 		})
 
 		It("should not call Create EventHandler if the object is not a runtime.Object", func() {
-			instance.OnAdd(&metav1.ObjectMeta{})
+			instance.OnAdd(&metav1.ObjectMeta{}, false)
 		})
 
 		It("should not call Create EventHandler if the object does not have metadata", func() {
-			instance.OnAdd(FooRuntimeObject{})
+			instance.OnAdd(FooRuntimeObject{}, false)
 		})
 
 		It("should create an UpdateEvent", func() {
@@ -281,7 +281,7 @@ var _ = Describe("Internal", func() {
 			instance.OnDelete(tombstone)
 		})
 		It("should ignore objects without meta", func() {
-			instance.OnAdd(Foo{})
+			instance.OnAdd(Foo{}, false)
 			instance.OnUpdate(Foo{}, Foo{})
 			instance.OnDelete(Foo{})
 		})

--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -91,7 +91,7 @@ func (ks *Kind[object, request]) Start(ctx context.Context, queue workqueue.Type
 			return
 		}
 
-		_, err := i.AddEventHandlerWithOptions(NewEventHandler(ctx, queue, ks.Handler, ks.Predicates).HandlerFuncs(), toolscache.HandlerOptions{
+		_, err := i.AddEventHandlerWithOptions(NewEventHandler(ctx, queue, ks.Handler, ks.Predicates), toolscache.HandlerOptions{
 			Logger: &logKind,
 		})
 		if err != nil {

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -286,7 +286,7 @@ func (is *Informer) Start(ctx context.Context, queue workqueue.TypedRateLimiting
 		return errors.New("must specify Informer.Handler")
 	}
 
-	_, err := is.Informer.AddEventHandlerWithOptions(internal.NewEventHandler(ctx, queue, is.Handler, is.Predicates).HandlerFuncs(), toolscache.HandlerOptions{
+	_, err := is.Informer.AddEventHandlerWithOptions(internal.NewEventHandler(ctx, queue, is.Handler, is.Predicates), toolscache.HandlerOptions{
 		Logger: &logInformer,
 	})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Let's start using IsInitialList that is provided in the OnAdd func of ResourceEventHandlers.

This can be leveraged to determine in a clean way if an add/create event came from an initial list.

https://kubernetes.slack.com/archives/C02MRBMN00Z/p1742119089612549?thread_ts=1741482643.357719&cid=C02MRBMN00Z

Reverts the parts of https://github.com/kubernetes-sigs/controller-runtime/pull/2223 that we don't need anymore.
