### PR TITLE
✨Add RELEASE_TAG to tools/setup-envtest to show binary version with setup-envtest version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,8 @@ jobs:
     name: Upload binaries to release
     runs-on: ubuntu-latest
     steps:
+    - name: Set env
+      run:  echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
     - name: Check out code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # tag=v4.2.2
     - name: Calculate go version

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ release-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace/tools/setup-envtest \
 		golang:$(GO_VERSION) \
-		go build -a -trimpath -ldflags "-extldflags '-static'" \
+		go build -a -trimpath -ldflags "-X 'sigs.k8s.io/controller-runtime/tools/setup-envtest/version.version=$(RELEASE_TAG)' -extldflags '-static'" \
 		-o ./out/$(RELEASE_BINARY) ./
 
 ## --------------------------------------

--- a/tools/setup-envtest/main.go
+++ b/tools/setup-envtest/main.go
@@ -184,6 +184,9 @@ Commands:
 		reads a .tar.gz file from stdin and expand it into the store.
 		must have a concrete version and platform.
 
+	version:
+		list the installed version of setup-envtest.
+
 Versions:
 
 	Versions take the form of a small subset of semver selectors.
@@ -256,7 +259,6 @@ Environment Variables:
 		version = flag.Arg(1)
 	}
 	env := setupEnv(globalLog, version)
-
 	// perform our main set of actions
 	switch action := flag.Arg(0); action {
 	case "use":
@@ -274,6 +276,8 @@ Environment Variables:
 			Input:       os.Stdin,
 			PrintFormat: printFormat,
 		}.Do(env)
+	case "version":
+		workflows.Version{}.Do(env)
 	default:
 		flag.Usage()
 		envp.Exit(2, "unknown action %q", action)

--- a/tools/setup-envtest/version/version.go
+++ b/tools/setup-envtest/version/version.go
@@ -1,0 +1,21 @@
+package version
+
+import "runtime/debug"
+
+// Version to be set using ldflags:
+// -ldflags "-X sigs.k8s.io/controller-tools/pkg/version.version=v1.0.0"
+// falls back to module information is unse
+var version = ""
+
+// Version returns the version of the main module
+func Version() string {
+	if version != "" {
+		return version
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info == nil || info.Main.Version == "" {
+		// binary has not been built with module support or doesn't contain a version.
+		return "(unknown)"
+	}
+	return info.Main.Version
+}

--- a/tools/setup-envtest/version/version_suite_test.go
+++ b/tools/setup-envtest/version/version_suite_test.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersioning(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test Version Suite")
+}

--- a/tools/setup-envtest/version/version_test.go
+++ b/tools/setup-envtest/version/version_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+
+limitations under the License.
+*/
+
+package version
+
+import (
+	"runtime/debug"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TestVersion", func() {
+
+	info, ok := debug.ReadBuildInfo()
+	Expect(ok).To(BeTrue())
+	tests := map[string]struct {
+		version  string
+		expected string
+	}{
+		"empty returns build info": {
+			version:  "",
+			expected: info.Main.Version,
+		},
+		"set to a value returns it": {
+			version:  "1.2.3",
+			expected: "1.2.3",
+		},
+	}
+	for name, tc := range tests {
+		It("Version set to "+name, func() {
+			versionBackup := version
+			defer func() {
+				version = versionBackup
+			}()
+			version = tc.version
+			result := Version()
+			Expect(result).To(Equal(tc.expected))
+		})
+	}
+})

--- a/tools/setup-envtest/workflows/workflows.go
+++ b/tools/setup-envtest/workflows/workflows.go
@@ -5,11 +5,13 @@ package workflows
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/go-logr/logr"
 
 	envp "sigs.k8s.io/controller-runtime/tools/setup-envtest/env"
+	"sigs.k8s.io/controller-runtime/tools/setup-envtest/version"
 )
 
 // Use is a workflow that prints out information about stored
@@ -84,4 +86,13 @@ func (f Sideload) Do(env *envp.Env) {
 	env.NoDownload = true
 	env.Sideload(ctx, f.Input)
 	env.PrintInfo(f.PrintFormat)
+}
+
+// Version is the workflow that shows the current binary version
+// of setup-envtest.
+type Version struct{}
+
+// Do executes the workflow.
+func (v Version) Do(env *envp.Env) {
+	fmt.Fprintf(env.Out, "setup-envtest version: %s\n", version.Version())
 }

--- a/tools/setup-envtest/workflows/workflows_test.go
+++ b/tools/setup-envtest/workflows/workflows_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"runtime/debug"
 	"sort"
 	"strings"
 
@@ -443,4 +444,16 @@ var _ = Describe("Workflows", func() {
 			Expect(string(outContents)).To(HavePrefix(expectedPrefix), "should have the debugging prefix")
 		})
 	})
+
+	Describe("version", func() {
+		It("should print out the version if the RELEASE_TAG is empty", func() {
+			v := wf.Version{}
+			v.Do(env)
+			info, ok := debug.ReadBuildInfo()
+			Expect(ok).To(BeTrue())
+			Expect(out.String()).ToNot(BeEmpty())
+			Expect(out.String()).To(Equal(fmt.Sprintf("setup-envtest version: %s\n", info.Main.Version)))
+		})
+	})
+
 })


### PR DESCRIPTION
With the setup-envtest binary, it is difficult to determine the version of the binary that is installed.  This will allow the user to use the command `setup-envtest version` to see what version of the binary is installed.

~~**Note: This is targeting the branch when built and not a specific tag.  The setup-envtest instructions for installation shows to target the release branch for specific versions**~~

**This will target the release tag defined in the GitHub action when binaries are built.**
<!-- What does this do, and why do we need it? -->
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3158

![image](https://github.com/user-attachments/assets/7262a790-1f32-4299-99d8-07580850affc)
