### PR TITLE
🌱 Fix godoc of TypedEventHandler

### DIFF
--- a/pkg/handler/eventhandler.go
+++ b/pkg/handler/eventhandler.go
@@ -65,7 +65,7 @@ type EventHandler = TypedEventHandler[client.Object, reconcile.Request]
 //
 // Unless you are implementing your own TypedEventHandler, you can ignore the functions on the TypedEventHandler interface.
 // Most users shouldn't need to implement their own TypedEventHandler.
-
+//
 // TypedEventHandler is experimental and subject to future change.
 type TypedEventHandler[object any, request comparable] interface {
 	// Create is called in response to a create event - e.g. Pod Creation.


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

This PR fixes the godoc of TypedEventHandler, before only l.69 showed up

Follow-up to https://github.com/kubernetes-sigs/controller-runtime/pull/3111#discussion_r1992735055


<!-- What does this do, and why do we need it? -->
