### PR TITLE
:seedling: TypedEnqueueRequestForOwner: Decrease priority when unchanged

### DIFF
--- a/pkg/handler/enqueue_owner.go
+++ b/pkg/handler/enqueue_owner.go
@@ -48,7 +48,7 @@ type OwnerOption func(e enqueueRequestForOwnerInterface)
 //
 // - a handler.enqueueRequestForOwner EventHandler with an OwnerType of ReplicaSet and OnlyControllerOwner set to true.
 func EnqueueRequestForOwner(scheme *runtime.Scheme, mapper meta.RESTMapper, ownerType client.Object, opts ...OwnerOption) EventHandler {
-	return WithLowPriorityWhenUnchanged(TypedEnqueueRequestForOwner[client.Object](scheme, mapper, ownerType, opts...))
+	return TypedEnqueueRequestForOwner[client.Object](scheme, mapper, ownerType, opts...)
 }
 
 // TypedEnqueueRequestForOwner enqueues Requests for the Owners of an object.  E.g. the object that created
@@ -72,7 +72,7 @@ func TypedEnqueueRequestForOwner[object client.Object](scheme *runtime.Scheme, m
 	for _, opt := range opts {
 		opt(e)
 	}
-	return e
+	return WithLowPriorityWhenUnchanged(e)
 }
 
 // OnlyControllerOwner if provided will only look at the first OwnerReference with Controller: true.

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -799,6 +799,16 @@ var _ = Describe("Eventhandler", func() {
 				},
 			},
 			{
+				name: "TypedEnqueueRequestForOwner",
+				handler: func() handler.EventHandler {
+					return handler.TypedEnqueueRequestForOwner[client.Object](
+						scheme.Scheme,
+						mapper,
+						&corev1.Pod{},
+					)
+				},
+			},
+			{
 				name: "Funcs",
 				handler: func() handler.EventHandler {
 					return handler.TypedFuncs[client.Object, reconcile.Request]{


### PR DESCRIPTION
We already did this for RequestForOwner, but not the typed variation, this change adds that.

/assign @sbueringer 
/hold

Ref https://github.com/kubernetes-sigs/controller-runtime/issues/3105

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
