### PR TITLE
🌱 Adopt WarningHandlerWithContext

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -74,8 +74,8 @@ type NewClientFunc func(config *rest.Config, options Options) (Client, error)
 // New returns a new Client using the provided config and Options.
 //
 // By default, the client surfaces warnings returned by the server. To
-// suppress warnings, set config.WarningHandler = rest.NoWarnings{}. To
-// define custom behavior, implement the rest.WarningHandler interface.
+// suppress warnings, set config.WarningHandlerWithContext = rest.NoWarnings{}. To
+// define custom behavior, implement the rest.WarningHandlerWithContext interface.
 // See [sigs.k8s.io/controller-runtime/pkg/log.KubeAPIWarningLogger] for
 // an example.
 //
@@ -112,10 +112,9 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		config.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 
-	if config.WarningHandler == nil {
+	if config.WarningHandler == nil && config.WarningHandlerWithContext == nil {
 		// By default, we surface warnings.
-		config.WarningHandler = log.NewKubeAPIWarningLogger(
-			log.Log.WithName("KubeAPIWarningLogger"),
+		config.WarningHandlerWithContext = log.NewKubeAPIWarningLogger(
 			log.KubeAPIWarningLoggerOptions{
 				Deduplicate: false,
 			},

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -59,8 +59,8 @@ func ExampleNew() {
 
 func ExampleNew_suppress_warnings() {
 	cfg := config.GetConfigOrDie()
-	// Use a rest.WarningHandler that discards warning messages.
-	cfg.WarningHandler = rest.NoWarnings{}
+	// Use a rest.WarningHandlerWithContext that discards warning messages.
+	cfg.WarningHandlerWithContext = rest.NoWarnings{}
 
 	cl, err := client.New(cfg, client.Options{})
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
/hold
/assign @alvaroaleman @vincepri 

<!-- What does this do, and why do we need it? -->

Tested it with Cluster API, warning logs look now like this

> {"ts":1742724964192.3147,"caller":"log/warning_handler.go:64","msg":"metadata.finalizers: \"cluster.cluster.x-k8s.io\": prefer a domain-qualified finalizer name including a path (/) to avoid accidental conflicts with other finalizer writers","controller":"cluster","controllerGroup":"cluster.x-k8s.io","controllerKind":"Cluster","Cluster":{"name":"in-memory-7608","namespace":"default"},"namespace":"default","name":"in-memory-7608","reconcileID":"198f6d32-150f-46c1-a276-75b838ce8320","v":0}


