### PR TITLE
📖Golang 1.24+ in setup-envtest/README.md

### DIFF
--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -11,7 +11,7 @@ module):
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 ```
 
-If you are using Golang 1.23, use the `release-0.19` branch instead:
+If you are using Golang 1.23, use the `release-0.20` branch instead:
 
 ```shell
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19

--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -4,17 +4,17 @@ This is a small tool that manages binaries for envtest. It can be used to
 download new binaries, list currently installed and available ones, and
 clean up versions.
 
-To use it, just go-install it with Golang 1.23+ (it's a separate, self-contained
+To use it, just go-install it with Golang 1.24+ (it's a separate, self-contained
 module):
 
 ```shell
 go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 ```
 
-If you are using Golang 1.22, use the `release-0.18` branch instead:
+If you are using Golang 1.23, use the `release-0.19` branch instead:
 
 ```shell
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.18
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
 ```
 
 For full documentation, run it with the `--help` flag, but here are some

--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -14,7 +14,7 @@ go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 If you are using Golang 1.23, use the `release-0.20` branch instead:
 
 ```shell
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.19
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.20
 ```
 
 For full documentation, run it with the `--help` flag, but here are some


### PR DESCRIPTION
It seems that with https://github.com/kubernetes-sigs/controller-runtime/commit/9d65299bd59d88a93735a99f04cd70e9fae3de20 Go 1.24+ is required for latest envtest.

This PR would help to quickly fix pipeline errors like: https://github.com/SAP/cf-service-operator/actions/runs/14042277233/job/39315277162

```
test -s /workspace/bin/setup-envtest || GOBIN=/workspace/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
go: downloading sigs.k8s.io/controller-runtime v0.20.4
go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20250324134234-561fa39c550f
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest: sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20250324134234-561fa39c550f requires go >= 1.24.0 (running go 1.23.0; GOTOOLCHAIN=local)
```

@sbueringer jfyi