### PR TITLE
:seedling: Clarify that controller-runtime is not a kubebuilder subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,6 @@ See [FAQ.md](FAQ.md)
 
 Learn how to engage with the Kubernetes community on the [community page](http://kubernetes.io/community/).
 
-controller-runtime is a subproject of the [kubebuilder](https://github.com/kubernetes-sigs/kubebuilder) project
-in sig apimachinery.
-
 You can reach the maintainers of this project at:
 
 - Slack channel: [#controller-runtime](https://kubernetes.slack.com/archives/C02MRBMN00Z)


### PR DESCRIPTION
This used to be true in the very beginning of the projects but isn't anymore today, there are different people working on these projects.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
