### PR TITLE
:sparkles: Allow panic as log level

### DIFF
--- a/pkg/log/zap/flags.go
+++ b/pkg/log/zap/flags.go
@@ -32,6 +32,7 @@ var levelStrings = map[string]zapcore.Level{
 	"debug": zap.DebugLevel,
 	"info":  zap.InfoLevel,
 	"error": zap.ErrorLevel,
+	"panic": zap.PanicLevel,
 }
 
 var stackLevelStrings = map[string]zapcore.Level{

--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -247,7 +247,7 @@ func NewRaw(opts ...Opts) *zap.Logger {
 //     Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn)
 //     Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error)
 //   - zap-encoder: Zap log encoding (one of 'json' or 'console')
-//   - zap-log-level: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error',
+//   - zap-log-level: Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'
 //     or any integer value > 0 which corresponds to custom debug levels of increasing verbosity").
 //   - zap-stacktrace-level: Zap Level at and above which stacktraces are captured (one of 'info', 'error' or 'panic')
 //   - zap-time-encoding: Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'),
@@ -271,7 +271,7 @@ func (o *Options) BindFlags(fs *flag.FlagSet) {
 		o.Level = fromFlag
 	}
 	fs.Var(&levelVal, "zap-log-level",
-		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', "+
+		"Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', 'panic'"+
 			"or any integer value > 0 which corresponds to custom debug levels of increasing verbosity")
 
 	// Set the StrackTrace Level

--- a/pkg/log/zap/zap_test.go
+++ b/pkg/log/zap/zap_test.go
@@ -327,6 +327,24 @@ var _ = Describe("Zap log level flag options setup", func() {
 
 			Expect(outRaw).To(BeEmpty())
 		})
+
+		It("Should output only panic logs, otherwise empty logs", func() {
+			args := []string{"--zap-log-level=panic"}
+			fromFlags.BindFlags(&fs)
+			err := fs.Parse(args)
+			Expect(err).ToNot(HaveOccurred())
+
+			logOut := new(bytes.Buffer)
+
+			logger := New(UseFlagOptions(&fromFlags), WriteTo(logOut))
+			logger.V(0).Info(logInfoLevel0)
+			logger.V(1).Info(logDebugLevel1)
+			logger.V(2).Info(logDebugLevel2)
+
+			outRaw := logOut.Bytes()
+
+			Expect(outRaw).To(BeEmpty())
+		})
 	})
 
 	Context("with  zap-log-level  with increased verbosity.", func() {


### PR DESCRIPTION
This allows logging to be disabled for all but panic log entries.

The Zap Level config parameter (https://github.com/uber-go/zap/blob/6d482535bdd97f4d97b2f9573ac308f1cf9b574e/config.go#L62) isn't available via the Option interface, so it's not possible to disable it completely via a user-added flag.
