### PR TITLE
⚠ fix: Stop accumulating lists in multi-namespace cache implementation

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1035,13 +1035,15 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							Version: "v1",
 							Kind:    "PodList",
 						})
-						Expect(namespacedCache.List(context.Background(), out)).To(Succeed())
+						for range 2 {
+							Expect(namespacedCache.List(context.Background(), out)).To(Succeed())
 
-						By("verifying the returned pod is from the watched namespace")
-						Expect(out.Items).NotTo(BeEmpty())
-						Expect(out.Items).Should(HaveLen(2))
-						for _, item := range out.Items {
-							Expect(item.GetNamespace()).To(Equal(testNamespaceOne))
+							By("verifying the returned pod is from the watched namespace")
+							Expect(out.Items).NotTo(BeEmpty())
+							Expect(out.Items).Should(HaveLen(2))
+							for _, item := range out.Items {
+								Expect(item.GetNamespace()).To(Equal(testNamespaceOne))
+							}
 						}
 						By("listing all nodes - should still be able to list a cluster-scoped resource")
 						nodeList := &unstructured.UnstructuredList{}

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -279,10 +279,7 @@ func (c *multiNamespaceCache) List(ctx context.Context, list client.ObjectList, 
 		return err
 	}
 
-	allItems, err := apimeta.ExtractList(list)
-	if err != nil {
-		return err
-	}
+	allItems := []runtime.Object{}
 
 	limitSet := listOpts.Limit > 0
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR fixes an issue in the multi-namespace cache implementation where repeated calls to the `List()` method on the same list object would accumulate results instead of resetting the list each time. This happens because the current implementation extracts existing items from the provided list object, then appends new items to it, causing the list to grow with each call.

The fix initializes a fresh empty slice for collected items instead of extracting from the existing list object.


fix #3194 