### PR TITLE
🐛 fix verbose info lost when clone

### DIFF
--- a/pkg/log/zap/kube_helpers.go
+++ b/pkg/log/zap/kube_helpers.go
@@ -78,6 +78,7 @@ func (w kubeObjectWrapper) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 func (k *KubeAwareEncoder) Clone() zapcore.Encoder {
 	return &KubeAwareEncoder{
 		Encoder: k.Encoder.Clone(),
+		Verbose: k.Verbose,
 	}
 }
 


### PR DESCRIPTION
The `Verbose` info will be lost when using methods like `With()`.
