### PR TITLE
🐛Return warnings on webhook response

### DIFF
--- a/pkg/webhook/admission/multi_test.go
+++ b/pkg/webhook/admission/multi_test.go
@@ -46,6 +46,17 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 		},
 	}
 
+	withWarnings := &fakeHandler{
+		fn: func(ctx context.Context, req Request) Response {
+			return Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:  true,
+					Warnings: []string{"handler-warning"},
+				},
+			}
+		},
+	}
+
 	Context("with validating handlers", func() {
 		It("should deny the request if any handler denies the request", func() {
 			By("setting up a handler with accept and deny")
@@ -54,6 +65,7 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 			By("checking that the handler denies the request")
 			resp := handler.Handle(context.Background(), Request{})
 			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Warnings).To(BeEmpty())
 		})
 
 		It("should allow the request if all handlers allow the request", func() {
@@ -63,6 +75,17 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 			By("checking that the handler allows the request")
 			resp := handler.Handle(context.Background(), Request{})
 			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Warnings).To(BeEmpty())
+		})
+
+		It("should show the warnings if all handlers allow the request", func() {
+			By("setting up a handler with only accept")
+			handler := MultiValidatingHandler(alwaysAllow, withWarnings)
+
+			By("checking that the handler allows the request")
+			resp := handler.Handle(context.Background(), Request{})
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Warnings).To(HaveLen(1))
 		})
 	})
 
@@ -107,6 +130,25 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 			},
 		}
 
+		patcher3 := &fakeHandler{
+			fn: func(ctx context.Context, req Request) Response {
+				return Response{
+					Patches: []jsonpatch.JsonPatchOperation{
+						{
+							Operation: "add",
+							Path:      "/metadata/annotation/newest-key",
+							Value:     "value",
+						},
+					},
+					AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed:   true,
+						Warnings:  []string{"annotation-warning"},
+						PatchType: func() *admissionv1.PatchType { pt := admissionv1.PatchTypeJSONPatch; return &pt }(),
+					},
+				}
+			},
+		}
+
 		It("should not return any patches if the request is denied", func() {
 			By("setting up a webhook with some patches and a deny")
 			handler := MultiMutatingHandler(patcher1, patcher2, alwaysDeny)
@@ -128,5 +170,20 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 				`[{"op":"add","path":"/metadata/annotation/new-key","value":"new-value"},` +
 					`{"op":"replace","path":"/spec/replicas","value":"2"},{"op":"add","path":"/metadata/annotation/hello","value":"world"}]`)))
 		})
+
+		It("should produce all patches if the requests are all allowed and show warnings", func() {
+			By("setting up a webhook with some patches")
+			handler := MultiMutatingHandler(patcher1, patcher2, alwaysAllow, patcher3)
+
+			By("checking that the handler accepts the request and returns all patches")
+			resp := handler.Handle(context.Background(), Request{})
+			Expect(resp.Allowed).To(BeTrue())
+			Expect(resp.Patch).To(Equal([]byte(
+				`[{"op":"add","path":"/metadata/annotation/new-key","value":"new-value"},` +
+					`{"op":"replace","path":"/spec/replicas","value":"2"},{"op":"add","path":"/metadata/annotation/hello","value":"world"},` +
+					`{"op":"add","path":"/metadata/annotation/newest-key","value":"value"}]`)))
+			Expect(resp.Warnings).To(HaveLen(1))
+		})
+
 	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
When creating an allowed response, we do not return the warnings.  This PR will allow the warnings to be returned for validating and mutating webhooks. 

<!-- What does this do, and why do we need it? -->
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3219

/assign @sbueringer 
/assign @alvaroaleman 

cc: @dlipovetsky 