### PR TITLE
🐛 Fix(manager): Prevent goroutine leak on shutdown timeout

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -417,7 +417,7 @@ func New(config *rest.Config, options Options) (Manager, error) {
 	}
 
 	errChan := make(chan error, 1)
-	runnables := newRunnables(options.BaseContext, errChan)
+	runnables := newRunnables(options.BaseContext, errChan).withLogger(options.Logger)
 	return &controllerManager{
 		stopProcedureEngaged:          ptr.To(int64(0)),
 		cluster:                       cluster,


### PR DESCRIPTION
Fixes #3218

A race condition during manager shutdown can cause a goroutine leak if the graceful shutdown period is exceeded.

When the `gracefulShutdownTimeout` is reached, the manager stops waiting for runnables and terminates the goroutine responsible for draining errors from runnables. If a slow runnable subsequently fails, its attempt to send an error on the shared channel (errChan) will block its goroutine forever, causing a leak.

This change prevents the leak by replacing the blocking error send in the runnableGroup with a non-blocking select statement. If the context is canceled, indicating a shutdown is in progress, the error is logged and dropped. This allows the runnable's goroutine to terminate cleanly instead of blocking forever.

Example test failure without this fix:
```
$ go test ./pkg/manager -v -ginkgo.focus="should not leak goroutines when a runnable returns error slowly after being
 signaled to stop"
=== RUN   TestSource
Running Suite: Manager Suite - /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager
==============================================================================================================================
Random Seed: 1750977926

Will run 1 of 98 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
• [FAILED] [1.712 seconds]
manger.Manager [It] should not leak goroutines when a runnable returns error slowly after being signaled to stop
/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/manager_test.go:1889

  Timeline >>
  2025-06-26T22:45:31Z  INFO    Stopping and waiting for non leader election runnables
  2025-06-26T22:45:31Z  INFO    Stopping and waiting for leader election runnables
  2025-06-26T22:45:31Z  INFO    Stopping and waiting for caches
  2025-06-26T22:45:31Z  INFO    Stopping and waiting for webhooks
  2025-06-26T22:45:31Z  INFO    Stopping and waiting for HTTP servers
  2025-06-26T22:45:31Z  INFO    Wait completed, proceeding to shutdown the manager
  [FAILED] in [It] - /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/manager_test.go:1934 @ 06/26/25 22:45:32.755
  << Timeline

  [FAILED] Timed out after 1.360s.
  Expected success, but got an error:
      <*errors.errorString | 0xc000194450>: 
      found unexpected goroutines:
      [Goroutine 65 in state chan send, with sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1 on top of the stack:
      sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002f4840)
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:227 +0xe5
      created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 262
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:210 +0x191
       Goroutine 274 in state chan send, with sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1 on top of the stack:
      sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002f4860)
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:227 +0xe5
      created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 262
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:210 +0x191
       Goroutine 269 in state sync.WaitGroup.Wait, with sync.runtime_SemacquireWaitGroup on top of the stack:
      sync.runtime_SemacquireWaitGroup(0xc0002e9f98?)
        /usr/local/google/home/jingyih/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/sema.go:110 +0x25
      sync.(*WaitGroup).Wait(0xc0002e9fd0?)
        /usr/local/google/home/jingyih/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/sync/waitgroup.go:118 +0x48
      sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).StopAndWait.func1.2()
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:307 +0x4e
      created by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).StopAndWait.func1 in goroutine 267
        /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:304 +0x118
      ]
      {
          s: "found unexpected goroutines:\n[Goroutine 65 in state chan send, with sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1 on top of the stack:\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002f4840)\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:227 +0xe5\ncreated by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 262\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:210 +0x191\n Goroutine 274 in state chan send, with sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1 on top of the stack:\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile.func1(0xc0002f4860)\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:227 +0xe5\ncreated by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).reconcile in goroutine 262\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:210 +0x191\n Goroutine 269 in state sync.WaitGroup.Wait, with sync.runtime_SemacquireWaitGroup on top of the stack:\nsync.runtime_SemacquireWaitGroup(0xc0002e9f98?)\n\t/usr/local/google/home/jingyih/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/runtime/sema.go:110 +0x25\nsync.(*WaitGroup).Wait(0xc0002e9fd0?)\n\t/usr/local/google/home/jingyih/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.0.linux-amd64/src/sync/waitgroup.go:118 +0x48\nsigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).StopAndWait.func1.2()\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:307 +0x4e\ncreated by sigs.k8s.io/controller-runtime/pkg/manager.(*runnableGroup).StopAndWait.func1 in goroutine 267\n\t/usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/runnable_group.go:304 +0x118\n]",
      }
  In [It] at: /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/manager_test.go:1934 @ 06/26/25 22:45:32.755
------------------------------
SSSSSSSSSSSSS

Summarizing 1 Failure:
  [FAIL] manger.Manager [It] should not leak goroutines when a runnable returns error slowly after being signaled to stop
  /usr/local/google/home/jingyih/go/src/github.com/kubernetes-sigs/controller-runtime/pkg/manager/manager_test.go:1934

Ran 1 of 98 Specs in 7.215 seconds
FAIL! -- 0 Passed | 1 Failed | 0 Pending | 97 Skipped
--- FAIL: TestSource (7.22s)
FAIL
FAIL    sigs.k8s.io/controller-runtime/pkg/manager      7.279s
FAIL
```

