### PR TITLE
 📖 Make pod naming consistent in examples

### DIFF
--- a/pkg/doc.go
+++ b/pkg/doc.go
@@ -137,11 +137,11 @@ Source provides event:
 
 EventHandler enqueues Request:
 
-* &handler.EnqueueRequestForObject{} -> (reconcile.Request{types.NamespaceName{Name: "foo", Namespace: "bar"}})
+* &handler.EnqueueRequestForObject{} -> (reconcile.Request{types.NamespaceName{Namespace: "foo", Name: "bar"}})
 
 Reconciler is called with the Request:
 
-* Reconciler(reconcile.Request{types.NamespaceName{Name: "foo", Namespace: "bar"}})
+* Reconciler(reconcile.Request{types.NamespaceName{Namespace: "foo", Name: "bar"}})
 
 # Usage
 


### PR DESCRIPTION
Namespaced naming of pods is inconsistent in the documentation: lines `140` and `144` are inconsistent with line `136`.
This PR fixes the inconsistency.