### PR TITLE
:warning: Add native SSA support

### DIFF
--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -518,7 +518,7 @@ func (ip *Informers) makeListWatcher(gvk schema.GroupVersionKind, obj runtime.Ob
 	// Structured.
 	//
 	default:
-		client, err := apiutil.RESTClientForGVK(gvk, false, ip.config, ip.codecs, ip.httpClient)
+		client, err := apiutil.RESTClientForGVK(gvk, false, false, ip.config, ip.codecs, ip.httpClient)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/client/apiutil/apimachinery.go
+++ b/pkg/client/apiutil/apimachinery.go
@@ -161,15 +161,27 @@ func GVKForObject(obj runtime.Object, scheme *runtime.Scheme) (schema.GroupVersi
 // RESTClientForGVK constructs a new rest.Interface capable of accessing the resource associated
 // with the given GroupVersionKind. The REST client will be configured to use the negotiated serializer from
 // baseConfig, if set, otherwise a default serializer will be set.
-func RESTClientForGVK(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config, codecs serializer.CodecFactory, httpClient *http.Client) (rest.Interface, error) {
+func RESTClientForGVK(
+	gvk schema.GroupVersionKind,
+	forceDisableProtoBuf bool,
+	isUnstructured bool,
+	baseConfig *rest.Config,
+	codecs serializer.CodecFactory,
+	httpClient *http.Client,
+) (rest.Interface, error) {
 	if httpClient == nil {
 		return nil, fmt.Errorf("httpClient must not be nil, consider using rest.HTTPClientFor(c) to create a client")
 	}
-	return rest.RESTClientForConfigAndClient(createRestConfig(gvk, isUnstructured, baseConfig, codecs), httpClient)
+	return rest.RESTClientForConfigAndClient(createRestConfig(gvk, forceDisableProtoBuf, isUnstructured, baseConfig, codecs), httpClient)
 }
 
 // createRestConfig copies the base config and updates needed fields for a new rest config.
-func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConfig *rest.Config, codecs serializer.CodecFactory) *rest.Config {
+func createRestConfig(gvk schema.GroupVersionKind,
+	forceDisableProtoBuf bool,
+	isUnstructured bool,
+	baseConfig *rest.Config,
+	codecs serializer.CodecFactory,
+) *rest.Config {
 	gv := gvk.GroupVersion()
 
 	cfg := rest.CopyConfig(baseConfig)
@@ -183,7 +195,7 @@ func createRestConfig(gvk schema.GroupVersionKind, isUnstructured bool, baseConf
 		cfg.UserAgent = rest.DefaultKubernetesUserAgent()
 	}
 	// TODO(FillZpp): In the long run, we want to check discovery or something to make sure that this is actually true.
-	if cfg.ContentType == "" && !isUnstructured {
+	if cfg.ContentType == "" && !forceDisableProtoBuf {
 		protobufSchemeLock.RLock()
 		if protobufScheme.Recognizes(gvk) {
 			cfg.ContentType = runtime.ContentTypeProtobuf

--- a/pkg/client/applyconfigurations.go
+++ b/pkg/client/applyconfigurations.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type unstructuredApplyConfiguration struct {
+	*unstructured.Unstructured
+}
+
+func (u *unstructuredApplyConfiguration) IsApplyConfiguration() {}
+
+// ApplyConfigurationFromUnstructured creates a runtime.ApplyConfiguration from an *unstructured.Unstructured object.
+func ApplyConfigurationFromUnstructured(u *unstructured.Unstructured) runtime.ApplyConfiguration {
+	return &unstructuredApplyConfiguration{Unstructured: u}
+}
+
+type applyconfigurationRuntimeObject struct {
+	runtime.ApplyConfiguration
+}
+
+func (a *applyconfigurationRuntimeObject) GetObjectKind() schema.ObjectKind {
+	return a
+}
+
+func (a *applyconfigurationRuntimeObject) GroupVersionKind() schema.GroupVersionKind {
+	return schema.GroupVersionKind{}
+}
+
+func (a *applyconfigurationRuntimeObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {}
+
+func (a *applyconfigurationRuntimeObject) DeepCopyObject() runtime.Object {
+	panic("applyconfigurationRuntimeObject does not support DeepCopyObject")
+}
+
+func runtimeObjectFromApplyConfiguration(ac runtime.ApplyConfiguration) runtime.Object {
+	return &applyconfigurationRuntimeObject{ApplyConfiguration: ac}
+}

--- a/pkg/client/applyconfigurations.go
+++ b/pkg/client/applyconfigurations.go
@@ -30,8 +30,8 @@ func (u *unstructuredApplyConfiguration) IsApplyConfiguration() {}
 
 // ApplyConfigurationFromUnstructured creates a runtime.ApplyConfiguration from an *unstructured.Unstructured object.
 //
-// Do not use Unstructured objects here that were generated from API objects, as those
-// contain zero values.
+// Do not use Unstructured objects here that were generated from API objects, as its impossible to tell
+// if a zero value was explicitly set.
 func ApplyConfigurationFromUnstructured(u *unstructured.Unstructured) runtime.ApplyConfiguration {
 	return &unstructuredApplyConfiguration{Unstructured: u}
 }

--- a/pkg/client/applyconfigurations.go
+++ b/pkg/client/applyconfigurations.go
@@ -17,9 +17,12 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 )
 
 type unstructuredApplyConfiguration struct {
@@ -56,4 +59,17 @@ func (a *applyconfigurationRuntimeObject) DeepCopyObject() runtime.Object {
 
 func runtimeObjectFromApplyConfiguration(ac runtime.ApplyConfiguration) runtime.Object {
 	return &applyconfigurationRuntimeObject{ApplyConfiguration: ac}
+}
+
+func gvkFromApplyConfiguration(ac applyConfiguration) (schema.GroupVersionKind, error) {
+	var gvk schema.GroupVersionKind
+	gv, err := schema.ParseGroupVersion(ptr.Deref(ac.GetAPIVersion(), ""))
+	if err != nil {
+		return gvk, fmt.Errorf("failed to parse %q as GroupVersion: %w", ptr.Deref(ac.GetAPIVersion(), ""), err)
+	}
+	gvk.Group = gv.Group
+	gvk.Version = gv.Version
+	gvk.Kind = ptr.Deref(ac.GetKind(), "")
+
+	return gvk, nil
 }

--- a/pkg/client/applyconfigurations.go
+++ b/pkg/client/applyconfigurations.go
@@ -29,6 +29,9 @@ type unstructuredApplyConfiguration struct {
 func (u *unstructuredApplyConfiguration) IsApplyConfiguration() {}
 
 // ApplyConfigurationFromUnstructured creates a runtime.ApplyConfiguration from an *unstructured.Unstructured object.
+//
+// Do not use Unstructured objects here that were generated from API objects, as those
+// contain zero values.
 func ApplyConfigurationFromUnstructured(u *unstructured.Unstructured) runtime.ApplyConfiguration {
 	return &unstructuredApplyConfiguration{Unstructured: u}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -329,6 +329,16 @@ func (c *client) Patch(ctx context.Context, obj Object, patch Patch, opts ...Pat
 	}
 }
 
+func (c *client) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	switch obj := obj.(type) {
+	case *unstructuredApplyConfiguration:
+		defer c.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+		return c.unstructuredClient.Apply(ctx, obj, opts...)
+	default:
+		return c.typedClient.Apply(ctx, obj, opts...)
+	}
+}
+
 // Get implements client.Client.
 func (c *client) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
 	if isUncached, err := c.shouldBypassCache(obj); err != nil {

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -115,7 +115,7 @@ func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
 	}
 
 	_, isUnstructured := obj.(runtime.Unstructured)
-	disableProtoBuf := isUnstructured || isApplyConfiguration
+	forceDisableProtoBuf := isUnstructured || isApplyConfiguration
 
 	// It's better to do creation work twice than to not let multiple
 	// people make requests at once
@@ -139,7 +139,7 @@ func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
 	// Initialize a new Client
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	r, err = c.newResource(gvk, isList, disableProtoBuf, isUnstructured)
+	r, err = c.newResource(gvk, isList, forceDisableProtoBuf, isUnstructured)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -17,16 +17,17 @@ limitations under the License.
 package client
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
@@ -56,13 +57,17 @@ type clientRestResources struct {
 
 // newResource maps obj to a Kubernetes Resource and constructs a client for that Resource.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientRestResources) newResource(gvk schema.GroupVersionKind, isList, isUnstructured bool) (*resourceMeta, error) {
+func (c *clientRestResources) newResource(gvk schema.GroupVersionKind,
+	isList bool,
+	forceDisableProtoBuf bool,
+	isUnstructured bool,
+) (*resourceMeta, error) {
 	if strings.HasSuffix(gvk.Kind, "List") && isList {
 		// if this was a list, treat it as a request for the item's resource
 		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
 	}
 
-	client, err := apiutil.RESTClientForGVK(gvk, isUnstructured, c.config, c.codecs, c.httpClient)
+	client, err := apiutil.RESTClientForGVK(gvk, forceDisableProtoBuf, isUnstructured, c.config, c.codecs, c.httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -73,15 +78,44 @@ func (c *clientRestResources) newResource(gvk schema.GroupVersionKind, isList, i
 	return &resourceMeta{Interface: client, mapping: mapping, gvk: gvk}, nil
 }
 
+type applyConfiguration interface {
+	GetName() *string
+	GetNamespace() *string
+	GetKind() *string
+	GetAPIVersion() *string
+}
+
 // getResource returns the resource meta information for the given type of object.
 // If the object is a list, the resource represents the item's type instead.
-func (c *clientRestResources) getResource(obj runtime.Object) (*resourceMeta, error) {
-	gvk, err := apiutil.GVKForObject(obj, c.scheme)
-	if err != nil {
-		return nil, err
+func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
+	var gvk schema.GroupVersionKind
+	var err error
+	var isApplyConfiguration bool
+	switch o := obj.(type) {
+	case runtime.Object:
+		gvk, err = apiutil.GVKForObject(o, c.scheme)
+		if err != nil {
+			return nil, err
+		}
+	case runtime.ApplyConfiguration:
+		ac, ok := o.(applyConfiguration)
+		if !ok {
+			return nil, fmt.Errorf("%T is a runtime.ApplyConfiguration but not an applyConfiguration", o)
+		}
+		gv, err := schema.ParseGroupVersion(ptr.Deref(ac.GetAPIVersion(), ""))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse %q as GroupVersion: %w", ptr.Deref(ac.GetAPIVersion(), ""), err)
+		}
+		gvk.Group = gv.Group
+		gvk.Version = gv.Version
+		gvk.Kind = ptr.Deref(ac.GetKind(), "")
+		isApplyConfiguration = true
+	default:
+		return nil, fmt.Errorf("bug: %T is neither a runtime.Object nor a runtime.ApplyConfiguration", o)
 	}
 
 	_, isUnstructured := obj.(runtime.Unstructured)
+	disableProtoBuf := isUnstructured || isApplyConfiguration
 
 	// It's better to do creation work twice than to not let multiple
 	// people make requests at once
@@ -97,10 +131,15 @@ func (c *clientRestResources) getResource(obj runtime.Object) (*resourceMeta, er
 		return r, nil
 	}
 
+	var isList bool
+	if runtimeObject, ok := obj.(runtime.Object); ok && meta.IsListType(runtimeObject) {
+		isList = true
+	}
+
 	// Initialize a new Client
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	r, err = c.newResource(gvk, meta.IsListType(obj), isUnstructured)
+	r, err = c.newResource(gvk, isList, disableProtoBuf, isUnstructured)
 	if err != nil {
 		return nil, err
 	}
@@ -109,16 +148,29 @@ func (c *clientRestResources) getResource(obj runtime.Object) (*resourceMeta, er
 }
 
 // getObjMeta returns objMeta containing both type and object metadata and state.
-func (c *clientRestResources) getObjMeta(obj runtime.Object) (*objMeta, error) {
+func (c *clientRestResources) getObjMeta(obj any) (*objMeta, error) {
 	r, err := c.getResource(obj)
 	if err != nil {
 		return nil, err
 	}
-	m, err := meta.Accessor(obj)
-	if err != nil {
-		return nil, err
+	objMeta := &objMeta{resourceMeta: r}
+
+	switch o := obj.(type) {
+	case runtime.Object:
+		m, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		objMeta.namespace = m.GetNamespace()
+		objMeta.name = m.GetName()
+	case applyConfiguration:
+		objMeta.namespace = ptr.Deref(o.GetNamespace(), "")
+		objMeta.name = ptr.Deref(o.GetName(), "")
+	default:
+		return nil, fmt.Errorf("object %T is neither a runtime.Object nor a runtime.ApplyConfiguration", obj)
 	}
-	return &objMeta{resourceMeta: r, Object: m}, err
+
+	return objMeta, nil
 }
 
 // resourceMeta stores state for a Kubernetes type.
@@ -146,6 +198,6 @@ type objMeta struct {
 	// resourceMeta contains type information for the object
 	*resourceMeta
 
-	// Object contains meta data for the object instance
-	metav1.Object
+	namespace string
+	name      string
 }

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -102,13 +102,10 @@ func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
 		if !ok {
 			return nil, fmt.Errorf("%T is a runtime.ApplyConfiguration but not an applyConfiguration", o)
 		}
-		gv, err := schema.ParseGroupVersion(ptr.Deref(ac.GetAPIVersion(), ""))
+		gvk, err = gvkFromApplyConfiguration(ac)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse %q as GroupVersion: %w", ptr.Deref(ac.GetAPIVersion(), ""), err)
+			return nil, err
 		}
-		gvk.Group = gv.Group
-		gvk.Version = gv.Version
-		gvk.Kind = ptr.Deref(ac.GetKind(), "")
 		isApplyConfiguration = true
 	default:
 		return nil, fmt.Errorf("bug: %T is neither a runtime.Object nor a runtime.ApplyConfiguration", o)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -949,62 +949,6 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				Expect(cm.Data).To(BeComparableTo(obj.Data))
 			})
 		})
-
-		Context("with FieldValidation", func() {
-			It("should handle invalid fields based on FieldValidation setting", func() {
-				cl, err := client.New(cfg, client.Options{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(cl).NotTo(BeNil())
-
-				data := map[string]any{
-					"some-key": "some-value",
-				}
-				obj := &unstructured.Unstructured{Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]any{
-						"name":      "test-configmap-fieldvalidation",
-						"namespace": "default",
-					},
-					"data": data,
-					"invalidField": "invalid-value",
-				}}
-
-				// Apply with disabled field validation should succeed
-				err = cl.Apply(context.Background(), client.ApplyConfigurationFromUnstructured(obj), &client.ApplyOptions{
-					FieldManager:    "test-manager",
-					FieldValidation: metav1.FieldValidationIgnore,
-				})
-				Expect(err).NotTo(HaveOccurred())
-
-				cm, err := clientset.CoreV1().ConfigMaps(obj.GetNamespace()).Get(context.Background(), obj.GetName(), metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-
-				actualData := map[string]any{}
-				for k, v := range cm.Data {
-					actualData[k] = v
-				}
-				Expect(actualData).To(BeComparableTo(data))
-
-				// Apply with default (strict) field validation should fail
-				obj2 := &unstructured.Unstructured{Object: map[string]any{
-					"apiVersion": "v1",
-					"kind":       "ConfigMap",
-					"metadata": map[string]any{
-						"name":      "test-configmap-fieldvalidation-strict",
-						"namespace": "default",
-					},
-					"data": data,
-					"invalidField": "invalid-value",
-				}}
-
-				err = cl.Apply(context.Background(), client.ApplyConfigurationFromUnstructured(obj2), &client.ApplyOptions{
-					FieldManager: "test-manager",
-				})
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("unknown field"))
-			})
-		})
 	})
 
 	Describe("SubResourceClient", func() {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -949,6 +949,62 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				Expect(cm.Data).To(BeComparableTo(obj.Data))
 			})
 		})
+
+		Context("with FieldValidation", func() {
+			It("should handle invalid fields based on FieldValidation setting", func() {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				data := map[string]any{
+					"some-key": "some-value",
+				}
+				obj := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-configmap-fieldvalidation",
+						"namespace": "default",
+					},
+					"data": data,
+					"invalidField": "invalid-value",
+				}}
+
+				// Apply with disabled field validation should succeed
+				err = cl.Apply(context.Background(), client.ApplyConfigurationFromUnstructured(obj), &client.ApplyOptions{
+					FieldManager:    "test-manager",
+					FieldValidation: metav1.FieldValidationIgnore,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				cm, err := clientset.CoreV1().ConfigMaps(obj.GetNamespace()).Get(context.Background(), obj.GetName(), metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				actualData := map[string]any{}
+				for k, v := range cm.Data {
+					actualData[k] = v
+				}
+				Expect(actualData).To(BeComparableTo(data))
+
+				// Apply with default (strict) field validation should fail
+				obj2 := &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]any{
+						"name":      "test-configmap-fieldvalidation-strict",
+						"namespace": "default",
+					},
+					"data": data,
+					"invalidField": "invalid-value",
+				}}
+
+				err = cl.Apply(context.Background(), client.ApplyConfigurationFromUnstructured(obj2), &client.ApplyOptions{
+					FieldManager: "test-manager",
+				})
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unknown field"))
+			})
+		})
 	})
 
 	Describe("SubResourceClient", func() {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -894,7 +894,9 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				Expect(actualData).To(BeComparableTo(data))
 				Expect(actualData).To(BeComparableTo(obj.Object["data"]))
 
-				data["a-new-key"] = "a-new-value"
+				data = map[string]any{
+					"a-new-key": "a-new-value",
+				}
 				obj.Object["data"] = data
 				unstructured.RemoveNestedField(obj.Object, "metadata", "managedFields")
 
@@ -936,7 +938,9 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				Expect(cm.Data).To(BeComparableTo(data))
 				Expect(cm.Data).To(BeComparableTo(obj.Data))
 
-				data["a-new-key"] = "a-new-value"
+				data = map[string]string{
+					"a-new-key": "a-new-value",
+				}
 				obj.Data = data
 
 				err = cl.Apply(context.Background(), obj, &client.ApplyOptions{FieldManager: "test-manager"})

--- a/pkg/client/dryrun.go
+++ b/pkg/client/dryrun.go
@@ -82,6 +82,10 @@ func (c *dryRunClient) Patch(ctx context.Context, obj Object, patch Patch, opts 
 	return c.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
 }
 
+func (c *dryRunClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	return c.client.Apply(ctx, obj, append(opts, DryRunAll)...)
+}
+
 // Get implements client.Client.
 func (c *dryRunClient) Get(ctx context.Context, key ObjectKey, obj Object, opts ...GetOption) error {
 	return c.client.Get(ctx, key, obj, opts...)

--- a/pkg/client/fieldowner.go
+++ b/pkg/client/fieldowner.go
@@ -54,6 +54,10 @@ func (f *clientWithFieldManager) Patch(ctx context.Context, obj Object, patch Pa
 	return f.c.Patch(ctx, obj, patch, append([]PatchOption{FieldOwner(f.owner)}, opts...)...)
 }
 
+func (f *clientWithFieldManager) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	return f.c.Apply(ctx, obj, append([]ApplyOption{FieldOwner(f.owner)}, opts...)...)
+}
+
 func (f *clientWithFieldManager) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {
 	return f.c.Delete(ctx, obj, opts...)
 }

--- a/pkg/client/fieldvalidation.go
+++ b/pkg/client/fieldvalidation.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"context"
-	"errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +54,7 @@ func (c *clientWithFieldValidation) Patch(ctx context.Context, obj Object, patch
 }
 
 func (c *clientWithFieldValidation) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
-	return errors.New("Apply is not supported with field validation")
+	return c.client.Apply(ctx, obj, append([]ApplyOption{c.validation}, opts...)...)
 }
 
 func (c *clientWithFieldValidation) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {

--- a/pkg/client/fieldvalidation.go
+++ b/pkg/client/fieldvalidation.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,7 +55,7 @@ func (c *clientWithFieldValidation) Patch(ctx context.Context, obj Object, patch
 }
 
 func (c *clientWithFieldValidation) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
-	return c.client.Apply(ctx, obj, append([]ApplyOption{c.validation}, opts...)...)
+	return errors.New("Apply is not supported with field validation")
 }
 
 func (c *clientWithFieldValidation) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {

--- a/pkg/client/fieldvalidation.go
+++ b/pkg/client/fieldvalidation.go
@@ -18,7 +18,6 @@ package client
 
 import (
 	"context"
-	"errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -55,7 +54,7 @@ func (c *clientWithFieldValidation) Patch(ctx context.Context, obj Object, patch
 }
 
 func (c *clientWithFieldValidation) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
-	return errors.New("Apply is not supported with field validation")
+	return c.client.Apply(ctx, obj, opts...)
 }
 
 func (c *clientWithFieldValidation) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {

--- a/pkg/client/fieldvalidation.go
+++ b/pkg/client/fieldvalidation.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,6 +52,10 @@ func (c *clientWithFieldValidation) Update(ctx context.Context, obj Object, opts
 
 func (c *clientWithFieldValidation) Patch(ctx context.Context, obj Object, patch Patch, opts ...PatchOption) error {
 	return c.client.Patch(ctx, obj, patch, append([]PatchOption{c.validation}, opts...)...)
+}
+
+func (c *clientWithFieldValidation) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	return errors.New("Apply is not supported with field validation")
 }
 
 func (c *clientWithFieldValidation) Delete(ctx context.Context, obj Object, opts ...DeleteOption) error {

--- a/pkg/client/fieldvalidation_test.go
+++ b/pkg/client/fieldvalidation_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -106,7 +105,6 @@ func TestWithStrictFieldValidation(t *testing.T) {
 	_ = wrappedClient.Create(ctx, dummyObj)
 	_ = wrappedClient.Update(ctx, dummyObj)
 	_ = wrappedClient.Patch(ctx, dummyObj, nil)
-	_ = wrappedClient.Apply(ctx, nil)
 	_ = wrappedClient.Status().Create(ctx, dummyObj, dummyObj)
 	_ = wrappedClient.Status().Update(ctx, dummyObj)
 	_ = wrappedClient.Status().Patch(ctx, dummyObj, nil)
@@ -114,7 +112,7 @@ func TestWithStrictFieldValidation(t *testing.T) {
 	_ = wrappedClient.SubResource("some-subresource").Update(ctx, dummyObj)
 	_ = wrappedClient.SubResource("some-subresource").Patch(ctx, dummyObj, nil)
 
-	if expectedCalls := 10; calls != expectedCalls {
+	if expectedCalls := 9; calls != expectedCalls {
 		t.Fatalf("wrong number of calls to assertions: expected=%d; got=%d", expectedCalls, calls)
 	}
 }
@@ -131,7 +129,6 @@ func TestWithStrictFieldValidationOverridden(t *testing.T) {
 	_ = wrappedClient.Create(ctx, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.Update(ctx, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.Patch(ctx, dummyObj, nil, client.FieldValidation(metav1.FieldValidationWarn))
-	_ = wrappedClient.Apply(ctx, nil, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.Status().Create(ctx, dummyObj, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.Status().Update(ctx, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.Status().Patch(ctx, dummyObj, nil, client.FieldValidation(metav1.FieldValidationWarn))
@@ -139,7 +136,7 @@ func TestWithStrictFieldValidationOverridden(t *testing.T) {
 	_ = wrappedClient.SubResource("some-subresource").Update(ctx, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))
 	_ = wrappedClient.SubResource("some-subresource").Patch(ctx, dummyObj, nil, client.FieldValidation(metav1.FieldValidationWarn))
 
-	if expectedCalls := 10; calls != expectedCalls {
+	if expectedCalls := 9; calls != expectedCalls {
 		t.Fatalf("wrong number of calls to assertions: expected=%d; got=%d", expectedCalls, calls)
 	}
 }
@@ -270,27 +267,6 @@ func testFieldValidationClient(t *testing.T, expectedFieldValidation string, cal
 
 			co := &client.PatchOptions{}
 			out.ApplyToPatch(co)
-			if got := co.FieldValidation; expectedFieldValidation != got {
-				t.Fatalf("wrong field validation: expected=%q; got=%q", expectedFieldValidation, got)
-			}
-			return nil
-		},
-		Apply: func(ctx context.Context, c client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
-			callback()
-			out := &client.ApplyOptions{}
-			for _, f := range opts {
-				f.ApplyToApply(out)
-			}
-			if got := out.FieldValidation; expectedFieldValidation != got {
-				t.Fatalf("wrong field validation: expected=%q; got=%q", expectedFieldValidation, got)
-			}
-
-			if got := out.AsPatchOptions().FieldValidation; expectedFieldValidation != got {
-				t.Fatalf("wrong field validation: expected=%q; got=%q", expectedFieldValidation, got)
-			}
-
-			co := &client.ApplyOptions{}
-			out.ApplyToApply(co)
 			if got := co.FieldValidation; expectedFieldValidation != got {
 				t.Fatalf("wrong field validation: expected=%q; got=%q", expectedFieldValidation, got)
 			}

--- a/pkg/client/interceptor/intercept.go
+++ b/pkg/client/interceptor/intercept.go
@@ -19,6 +19,7 @@ type Funcs struct {
 	DeleteAllOf       func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error
 	Update            func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error
 	Patch             func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error
+	Apply             func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error
 	Watch             func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error)
 	SubResource       func(client client.WithWatch, subResource string) client.SubResourceClient
 	SubResourceGet    func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error
@@ -90,6 +91,14 @@ func (c interceptor) Patch(ctx context.Context, obj client.Object, patch client.
 		return c.funcs.Patch(ctx, c.client, obj, patch, opts...)
 	}
 	return c.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (c interceptor) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	if c.funcs.Apply != nil {
+		return c.funcs.Apply(ctx, c.client, obj, opts...)
+	}
+
+	return c.client.Apply(ctx, obj, opts...)
 }
 
 func (c interceptor) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {

--- a/pkg/client/interceptor/intercept_test.go
+++ b/pkg/client/interceptor/intercept_test.go
@@ -360,6 +360,10 @@ func (d dummyClient) Patch(ctx context.Context, obj client.Object, patch client.
 	return nil
 }
 
+func (d dummyClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	return nil
+}
+
 func (d dummyClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	return nil
 }

--- a/pkg/client/interceptor/intercept_test.go
+++ b/pkg/client/interceptor/intercept_test.go
@@ -63,6 +63,29 @@ var _ = Describe("NewClient", func() {
 		_ = client2.List(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
+	It("should call the provided Apply function", func() {
+		var called bool
+		client := NewClient(wrappedClient, Funcs{
+			Apply: func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				called = true
+				return nil
+			},
+		})
+		_ = client.Apply(ctx, nil)
+		Expect(called).To(BeTrue())
+	})
+	It("should call the underlying client if the provided Apply function is nil", func() {
+		var called bool
+		client1 := NewClient(wrappedClient, Funcs{
+			Apply: func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+				called = true
+				return nil
+			},
+		})
+		client2 := NewClient(client1, Funcs{})
+		_ = client2.Apply(ctx, nil)
+		Expect(called).To(BeTrue())
+	})
 	It("should call the provided Create function", func() {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -61,6 +61,9 @@ type Reader interface {
 
 // Writer knows how to create, delete, and update Kubernetes objects.
 type Writer interface {
+	// Apply applies the given apply configuration to the Kubernetes cluster.
+	Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error
+
 	// Create saves the object obj in the Kubernetes cluster. obj must be a
 	// struct pointer so that obj can be updated with the content returned by the Server.
 	Create(ctx context.Context, obj Object, opts ...CreateOption) error
@@ -78,9 +81,6 @@ type Writer interface {
 
 	// DeleteAllOf deletes all objects of the given type matching the given options.
 	DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error
-
-	// Apply applies the given apply configuration to the Kubernetes cluster.
-	Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error
 }
 
 // StatusClient knows how to create a client which can update status subresource

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -78,6 +78,9 @@ type Writer interface {
 
 	// DeleteAllOf deletes all objects of the given type matching the given options.
 	DeleteAllOf(ctx context.Context, obj Object, opts ...DeleteAllOfOption) error
+
+	// Apply applies the given apply configuration to the Kubernetes cluster.
+	Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error
 }
 
 // StatusClient knows how to create a client which can update status subresource

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -149,6 +149,10 @@ func (n *namespacedClient) Patch(ctx context.Context, obj Object, patch Patch, o
 }
 
 func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	// It is non-trivial to make this work as the current check if an object is namespaces takes a runtime.Object,
+	// we would need to update that to be able to deal with a runtime.ApplyConfiguration. Additionally, ACs
+	// do allow setting the namespace through a `WithNamespace(string) T` method, but we would have to use reflect
+	// due to the `T` return.
 	return errors.New("Apply is not supported on namespaced client")
 }
 

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -18,12 +18,14 @@ package client
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // NewNamespacedClient wraps an existing client enforcing the namespace value.
@@ -149,11 +151,49 @@ func (n *namespacedClient) Patch(ctx context.Context, obj Object, patch Patch, o
 }
 
 func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
-	// It is non-trivial to make this work as the current check if an object is namespaces takes a runtime.Object,
-	// we would need to update that to be able to deal with a runtime.ApplyConfiguration. Additionally, ACs
-	// do allow setting the namespace through a `WithNamespace(string) T` method, but we would have to use reflect
-	// due to the `T` return.
-	return errors.New("Apply is not supported on namespaced client")
+	var gvk schema.GroupVersionKind
+	switch o := obj.(type) {
+	case applyConfiguration:
+		var err error
+		gvk, err = gvkFromApplyConfiguration(o)
+		if err != nil {
+			return err
+		}
+	case *unstructuredApplyConfiguration:
+		gvk = o.GroupVersionKind()
+	default:
+		return fmt.Errorf("object %T is not a valid apply configuration", obj)
+	}
+	isNamespaceScoped, err := apiutil.IsGVKNamespaced(gvk, n.RESTMapper())
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+	if isNamespaceScoped {
+		switch o := obj.(type) {
+		case applyConfiguration:
+			if o.GetNamespace() != nil && *o.GetNamespace() != "" && *o.GetNamespace() != n.namespace {
+				return fmt.Errorf("namespace %s provided for the object %s does not match the namespace %s on the client",
+					*o.GetNamespace(), ptr.Deref(o.GetName(), ""), n.namespace)
+			}
+			v := reflect.ValueOf(o)
+			withNamespace := v.MethodByName("WithNamespace")
+			if !withNamespace.IsValid() {
+				return fmt.Errorf("ApplyConfiguration %T does not have a WithNamespace method", o)
+			}
+			if tp := withNamespace.Type(); tp.NumIn() != 1 || tp.In(0).Kind() != reflect.String {
+				return fmt.Errorf("WithNamespace method of ApplyConfiguration %T must take a single string argument", o)
+			}
+			withNamespace.Call([]reflect.Value{reflect.ValueOf(n.namespace)})
+		case *unstructuredApplyConfiguration:
+			if o.GetNamespace() != "" && o.GetNamespace() != n.namespace {
+				return fmt.Errorf("namespace %s provided for the object %s does not match the namespace %s on the client",
+					o.GetNamespace(), o.GetName(), n.namespace)
+			}
+			o.SetNamespace(n.namespace)
+		}
+	}
+
+	return n.client.Apply(ctx, obj, opts...)
 }
 
 // Get implements client.Client.

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -18,6 +18,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -145,6 +146,10 @@ func (n *namespacedClient) Patch(ctx context.Context, obj Object, patch Patch, o
 		obj.SetNamespace(n.namespace)
 	}
 	return n.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	return errors.New("Apply is not supported on namespaced client")
 }
 
 // Get implements client.Client.

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -62,6 +62,12 @@ type PatchOption interface {
 	ApplyToPatch(*PatchOptions)
 }
 
+// ApplyOption is some configuration that modifies options for a apply request.
+type ApplyOption interface {
+	// A ApplyToApply applies this configuration to the given apply options.
+	ApplyToApply(*ApplyOptions)
+}
+
 // DeleteAllOfOption is some configuration that modifies options for a delete request.
 type DeleteAllOfOption interface {
 	// ApplyToDeleteAllOf applies this configuration to the given deletecollection options.
@@ -116,6 +122,10 @@ func (dryRunAll) ApplyToPatch(opts *PatchOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
 
+func (drun dryRunAll) ApplyToApply(opts *ApplyOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
 // ApplyToPatch applies this configuration to the given delete options.
 func (dryRunAll) ApplyToDelete(opts *DeleteOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
@@ -152,6 +162,11 @@ func (f FieldOwner) ApplyToCreate(opts *CreateOptions) {
 
 // ApplyToUpdate applies this configuration to the given update options.
 func (f FieldOwner) ApplyToUpdate(opts *UpdateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToApply applies this configuration to the given apply options.
+func (f FieldOwner) ApplyToApply(opts *ApplyOptions) {
 	opts.FieldManager = string(f)
 }
 
@@ -872,10 +887,18 @@ func (o *PatchOptions) AsPatchOptions() *metav1.PatchOptions {
 		o.Raw = &metav1.PatchOptions{}
 	}
 
-	o.Raw.DryRun = o.DryRun
-	o.Raw.Force = o.Force
-	o.Raw.FieldManager = o.FieldManager
-	o.Raw.FieldValidation = o.FieldValidation
+	if o.DryRun != nil {
+		o.Raw.DryRun = o.DryRun
+	}
+	if o.Force != nil {
+		o.Raw.Force = o.Force
+	}
+	if o.FieldManager != "" {
+		o.Raw.FieldManager = o.FieldManager
+	}
+	if o.FieldValidation != "" {
+		o.Raw.FieldValidation = o.FieldValidation
+	}
 	return o.Raw
 }
 
@@ -948,3 +971,57 @@ func (o *DeleteAllOfOptions) ApplyToDeleteAllOf(do *DeleteAllOfOptions) {
 }
 
 // }}}
+
+// ApplyOptions are the options for an apply request.
+type ApplyOptions struct {
+	// When present, indicates that modifications should not be
+	// persisted. An invalid or unrecognized dryRun directive will
+	// result in an error response and no further processing of the
+	// request. Valid values are:
+	// - All: all dry run stages will be processed
+	// +optional
+	// +listType=atomic
+	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,1,rep,name=dryRun"`
+
+	// Force is going to "force" Apply requests. It means user will
+	// re-acquire conflicting fields owned by other people.
+	Force *bool `json:"force" protobuf:"varint,2,opt,name=force"`
+
+	// fieldManager is a name associated with the actor or entity
+	// that is making these changes. The value must be less than or
+	// 128 characters long, and only contain printable characters,
+	// as defined by https://golang.org/pkg/unicode/#IsPrint. This
+	// field is required.
+	FieldManager string `json:"fieldManager" protobuf:"bytes,3,name=fieldManager"`
+}
+
+// ApplyOptions applies the given opts onto the ApplyOptions
+func (o *ApplyOptions) ApplyOptions(opts []ApplyOption) *ApplyOptions {
+	for _, opt := range opts {
+		opt.ApplyToApply(o)
+	}
+	return o
+}
+
+// ApplyToApply applies the given opts onto the ApplyOptions
+func (o *ApplyOptions) ApplyToApply(opts *ApplyOptions) {
+	if o.DryRun != nil {
+		opts.DryRun = o.DryRun
+	}
+	if o.Force != nil {
+		opts.Force = o.Force
+	}
+
+	if o.FieldManager != "" {
+		opts.FieldManager = o.FieldManager
+	}
+}
+
+// AsPatchOptions constructs patch options from the given ApplyOptions
+func (o *ApplyOptions) AsPatchOptions() *metav1.PatchOptions {
+	return &metav1.PatchOptions{
+		DryRun:       o.DryRun,
+		Force:        o.Force,
+		FieldManager: o.FieldManager,
+	}
+}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -931,13 +931,15 @@ var ForceOwnership = forceOwnership{}
 type forceOwnership struct{}
 
 func (forceOwnership) ApplyToPatch(opts *PatchOptions) {
-	definitelyTrue := true
-	opts.Force = &definitelyTrue
+	opts.Force = ptr.To(true)
 }
 
 func (forceOwnership) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
-	definitelyTrue := true
-	opts.Force = &definitelyTrue
+	opts.Force = ptr.To(true)
+}
+
+func (forceOwnership) ApplyToApply(opts *ApplyOptions) {
+	opts.Force = ptr.To(true)
 }
 
 // }}}

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -218,11 +218,6 @@ func (f FieldValidation) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions
 	opts.FieldValidation = string(f)
 }
 
-// ApplyToApply applies this configuration to the given apply options.
-func (f FieldValidation) ApplyToApply(opts *ApplyOptions) {
-	opts.FieldValidation = string(f)
-}
-
 // }}}
 
 // {{{ Create Options
@@ -998,24 +993,6 @@ type ApplyOptions struct {
 	// as defined by https://golang.org/pkg/unicode/#IsPrint. This
 	// field is required.
 	FieldManager string `json:"fieldManager" protobuf:"bytes,3,name=fieldManager"`
-
-	// fieldValidation instructs the server on how to handle
-	// objects in the apply request containing unknown
-	// or duplicate fields. Valid values are:
-	// - Ignore: This will ignore any unknown fields that are silently
-	// dropped from the object, and will ignore all but the last duplicate
-	// field that the decoder encounters.
-	// - Warn: This will send a warning via the standard warning response
-	// header for each unknown field that is dropped from the object, and
-	// for each duplicate field that is encountered. The request will
-	// still succeed if there are no other errors, and will only persist
-	// the last of any duplicate fields.
-	// - Strict: This will fail the request with a BadRequest error if
-	// any unknown fields would be dropped from the object, or if any
-	// duplicate fields are present. The error returned from the server
-	// will contain all unknown and duplicate fields encountered.
-	// This is the default for apply requests.
-	FieldValidation string `json:"fieldValidation,omitempty" protobuf:"bytes,4,opt,name=fieldValidation"`
 }
 
 // ApplyOptions applies the given opts onto the ApplyOptions
@@ -1038,17 +1015,13 @@ func (o *ApplyOptions) ApplyToApply(opts *ApplyOptions) {
 	if o.FieldManager != "" {
 		opts.FieldManager = o.FieldManager
 	}
-	if o.FieldValidation != "" {
-		opts.FieldValidation = o.FieldValidation
-	}
 }
 
 // AsPatchOptions constructs patch options from the given ApplyOptions
 func (o *ApplyOptions) AsPatchOptions() *metav1.PatchOptions {
 	return &metav1.PatchOptions{
-		DryRun:          o.DryRun,
-		Force:           o.Force,
-		FieldManager:    o.FieldManager,
-		FieldValidation: o.FieldValidation,
+		DryRun:       o.DryRun,
+		Force:        o.Force,
+		FieldManager: o.FieldManager,
 	}
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -62,9 +62,9 @@ type PatchOption interface {
 	ApplyToPatch(*PatchOptions)
 }
 
-// ApplyOption is some configuration that modifies options for a apply request.
+// ApplyOption is some configuration that modifies options for an apply request.
 type ApplyOption interface {
-	// A ApplyToApply applies this configuration to the given apply options.
+	// ApplyToApply applies this configuration to the given apply options.
 	ApplyToApply(*ApplyOptions)
 }
 
@@ -122,11 +122,12 @@ func (dryRunAll) ApplyToPatch(opts *PatchOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
 
-func (drun dryRunAll) ApplyToApply(opts *ApplyOptions) {
+// ApplyToApply applies this configuration to the given apply options.
+func (dryRunAll) ApplyToApply(opts *ApplyOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
 
-// ApplyToPatch applies this configuration to the given delete options.
+// ApplyToDelete applies this configuration to the given delete options.
 func (dryRunAll) ApplyToDelete(opts *DeleteOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
@@ -981,20 +982,20 @@ type ApplyOptions struct {
 	// result in an error response and no further processing of the
 	// request. Valid values are:
 	// - All: all dry run stages will be processed
-	// +optional
-	// +listType=atomic
-	DryRun []string `json:"dryRun,omitempty" protobuf:"bytes,1,rep,name=dryRun"`
+	DryRun []string
 
 	// Force is going to "force" Apply requests. It means user will
 	// re-acquire conflicting fields owned by other people.
-	Force *bool `json:"force" protobuf:"varint,2,opt,name=force"`
+	Force *bool
 
 	// fieldManager is a name associated with the actor or entity
 	// that is making these changes. The value must be less than or
 	// 128 characters long, and only contain printable characters,
 	// as defined by https://golang.org/pkg/unicode/#IsPrint. This
 	// field is required.
-	FieldManager string `json:"fieldManager" protobuf:"bytes,3,name=fieldManager"`
+	//
+	// +required
+	FieldManager string
 }
 
 // ApplyOptions applies the given opts onto the ApplyOptions

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -218,6 +218,11 @@ func (f FieldValidation) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions
 	opts.FieldValidation = string(f)
 }
 
+// ApplyToApply applies this configuration to the given apply options.
+func (f FieldValidation) ApplyToApply(opts *ApplyOptions) {
+	opts.FieldValidation = string(f)
+}
+
 // }}}
 
 // {{{ Create Options
@@ -993,6 +998,24 @@ type ApplyOptions struct {
 	// as defined by https://golang.org/pkg/unicode/#IsPrint. This
 	// field is required.
 	FieldManager string `json:"fieldManager" protobuf:"bytes,3,name=fieldManager"`
+
+	// fieldValidation instructs the server on how to handle
+	// objects in the apply request containing unknown
+	// or duplicate fields. Valid values are:
+	// - Ignore: This will ignore any unknown fields that are silently
+	// dropped from the object, and will ignore all but the last duplicate
+	// field that the decoder encounters.
+	// - Warn: This will send a warning via the standard warning response
+	// header for each unknown field that is dropped from the object, and
+	// for each duplicate field that is encountered. The request will
+	// still succeed if there are no other errors, and will only persist
+	// the last of any duplicate fields.
+	// - Strict: This will fail the request with a BadRequest error if
+	// any unknown fields would be dropped from the object, or if any
+	// duplicate fields are present. The error returned from the server
+	// will contain all unknown and duplicate fields encountered.
+	// This is the default for apply requests.
+	FieldValidation string `json:"fieldValidation,omitempty" protobuf:"bytes,4,opt,name=fieldValidation"`
 }
 
 // ApplyOptions applies the given opts onto the ApplyOptions
@@ -1015,13 +1038,17 @@ func (o *ApplyOptions) ApplyToApply(opts *ApplyOptions) {
 	if o.FieldManager != "" {
 		opts.FieldManager = o.FieldManager
 	}
+	if o.FieldValidation != "" {
+		opts.FieldValidation = o.FieldValidation
+	}
 }
 
 // AsPatchOptions constructs patch options from the given ApplyOptions
 func (o *ApplyOptions) AsPatchOptions() *metav1.PatchOptions {
 	return &metav1.PatchOptions{
-		DryRun:       o.DryRun,
-		Force:        o.Force,
-		FieldManager: o.FieldManager,
+		DryRun:          o.DryRun,
+		Force:           o.Force,
+		FieldManager:    o.FieldManager,
+		FieldValidation: o.FieldValidation,
 	}
 }

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -109,6 +109,27 @@ var _ = Describe("GetOptions", func() {
 	})
 })
 
+var _ = Describe("ApplyOptions", func() {
+	It("Should set DryRun", func() {
+		o := &client.ApplyOptions{DryRun: []string{"Hello", "Theodore"}}
+		newApplyOpts := &client.ApplyOptions{}
+		o.ApplyToApply(newApplyOpts)
+		Expect(newApplyOpts).To(Equal(o))
+	})
+	It("Should set Force", func() {
+		o := &client.ApplyOptions{Force: ptr.To(true)}
+		newApplyOpts := &client.ApplyOptions{}
+		o.ApplyToApply(newApplyOpts)
+		Expect(newApplyOpts).To(Equal(o))
+	})
+	It("Should set FieldManager", func() {
+		o := &client.ApplyOptions{FieldManager: "field-manager"}
+		newApplyOpts := &client.ApplyOptions{}
+		o.ApplyToApply(newApplyOpts)
+		Expect(newApplyOpts).To(Equal(o))
+	})
+})
+
 var _ = Describe("CreateOptions", func() {
 	It("Should set DryRun", func() {
 		o := &client.CreateOptions{DryRun: []string{"Hello", "Theodore"}}
@@ -278,11 +299,68 @@ var _ = Describe("MatchingLabels", func() {
 	})
 })
 
+var _ = Describe("DryRunAll", func() {
+	It("Should apply to ApplyOptions", func() {
+		o := &client.ApplyOptions{DryRun: []string{"server"}}
+		t := client.DryRunAll
+		t.ApplyToApply(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to CreateOptions", func() {
+		o := &client.CreateOptions{DryRun: []string{"server"}}
+		t := client.DryRunAll
+		t.ApplyToCreate(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to UpdateOptions", func() {
+		o := &client.UpdateOptions{DryRun: []string{"server"}}
+		t := client.DryRunAll
+		t.ApplyToUpdate(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to PatchOptions", func() {
+		o := &client.PatchOptions{DryRun: []string{"server"}}
+		t := client.DryRunAll
+		t.ApplyToPatch(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to DeleteOptions", func() {
+		o := &client.DeleteOptions{DryRun: []string{"server"}}
+		t := client.DryRunAll
+		t.ApplyToDelete(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to SubResourcePatchOptions", func() {
+		o := &client.SubResourcePatchOptions{PatchOptions: client.PatchOptions{DryRun: []string{"server"}}}
+		t := client.DryRunAll
+		t.ApplyToSubResourcePatch(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to SubResourceCreateOptions", func() {
+		o := &client.SubResourceCreateOptions{CreateOptions: client.CreateOptions{DryRun: []string{"server"}}}
+		t := client.DryRunAll
+		t.ApplyToSubResourceCreate(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+	It("Should apply to SubResourceUpdateOptions", func() {
+		o := &client.SubResourceUpdateOptions{UpdateOptions: client.UpdateOptions{DryRun: []string{"server"}}}
+		t := client.DryRunAll
+		t.ApplyToSubResourceUpdate(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
+})
+
 var _ = Describe("FieldOwner", func() {
 	It("Should apply to PatchOptions", func() {
 		o := &client.PatchOptions{FieldManager: "bar"}
 		t := client.FieldOwner("foo")
 		t.ApplyToPatch(o)
+		Expect(o.FieldManager).To(Equal("foo"))
+	})
+	It("Should apply to ApplyOptions", func() {
+		o := &client.ApplyOptions{FieldManager: "bar"}
+		t := client.FieldOwner("foo")
+		t.ApplyToApply(o)
 		Expect(o.FieldManager).To(Equal("foo"))
 	})
 	It("Should apply to CreateOptions", func() {

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -330,6 +330,12 @@ var _ = Describe("ForceOwnership", func() {
 		t.ApplyToSubResourcePatch(o)
 		Expect(*o.Force).To(BeTrue())
 	})
+	It("Should apply to ApplyOptions", func() {
+		o := &client.ApplyOptions{}
+		t := client.ForceOwnership
+		t.ApplyToApply(o)
+		Expect(*o.Force).To(BeTrue())
+	})
 })
 
 var _ = Describe("HasLabels", func() {

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -27,6 +27,7 @@ import (
 
 var (
 	// Apply uses server-side apply to patch the given object.
+	// Deprecated: Use client.Apply instead.
 	Apply Patch = applyPatch{}
 
 	// Merge uses the raw object as a merge patch, without modifications.

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -18,8 +18,10 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/apply"
 )
 
 var _ Reader = &typedClient{}
@@ -41,7 +43,7 @@ func (c *typedClient) Create(ctx context.Context, obj Object, opts ...CreateOpti
 	createOpts.ApplyOptions(opts)
 
 	return o.Post().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Body(obj).
 		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
@@ -60,9 +62,9 @@ func (c *typedClient) Update(ctx context.Context, obj Object, opts ...UpdateOpti
 	updateOpts.ApplyOptions(opts)
 
 	return o.Put().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		Body(obj).
 		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
 		Do(ctx).
@@ -80,9 +82,9 @@ func (c *typedClient) Delete(ctx context.Context, obj Object, opts ...DeleteOpti
 	deleteOpts.ApplyOptions(opts)
 
 	return o.Delete().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		Body(deleteOpts.AsDeleteOptions()).
 		Do(ctx).
 		Error()
@@ -123,13 +125,38 @@ func (c *typedClient) Patch(ctx context.Context, obj Object, patch Patch, opts .
 	patchOpts.ApplyOptions(opts)
 
 	return o.Patch(patch.Type()).
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		VersionedParams(patchOpts.AsPatchOptions(), c.paramCodec).
 		Body(data).
 		Do(ctx).
 		Into(obj)
+}
+
+func (c *typedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	o, err := c.resources.getObjMeta(obj)
+	if err != nil {
+		return err
+	}
+	req, err := apply.NewRequest(o, obj)
+	if err != nil {
+		return fmt.Errorf("failed to create apply request: %w", err)
+	}
+	applyOpts := &ApplyOptions{}
+	applyOpts.ApplyOptions(opts)
+
+	return req.
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.name).
+		VersionedParams(applyOpts.AsPatchOptions(), c.paramCodec).
+		Do(ctx).
+		// This is hacky, it is required because `Into` takes a `runtime.Object` and
+		// that is not implemented by the ApplyConfigurations. The generated clients
+		// don't have this problem because they deserialize into the api type, not the
+		// apply configuration: https://github.com/kubernetes/kubernetes/blob/22f5e01a37c0bc6a5f494dec14dd4e3688ee1d55/staging/src/k8s.io/client-go/gentype/type.go#L296-L317
+		Into(runtimeObjectFromApplyConfiguration(obj))
 }
 
 // Get implements client.Client.
@@ -179,9 +206,9 @@ func (c *typedClient) GetSubResource(ctx context.Context, obj, subResourceObj Ob
 	getOpts.ApplyOptions(opts)
 
 	return o.Get().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		VersionedParams(getOpts.AsGetOptions(), c.paramCodec).
 		Do(ctx).
@@ -202,9 +229,9 @@ func (c *typedClient) CreateSubResource(ctx context.Context, obj Object, subReso
 	createOpts.ApplyOptions(opts)
 
 	return o.Post().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(subResourceObj).
 		VersionedParams(createOpts.AsCreateOptions(), c.paramCodec).
@@ -237,9 +264,9 @@ func (c *typedClient) UpdateSubResource(ctx context.Context, obj Object, subReso
 	}
 
 	return o.Put().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(body).
 		VersionedParams(updateOpts.AsUpdateOptions(), c.paramCodec).
@@ -268,9 +295,9 @@ func (c *typedClient) PatchSubResource(ctx context.Context, obj Object, subResou
 	}
 
 	return o.Patch(patch.Type()).
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(data).
 		VersionedParams(patchOpts.AsPatchOptions(), c.paramCodec).

--- a/pkg/client/unstructured_client.go
+++ b/pkg/client/unstructured_client.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/util/apply"
 )
 
 var _ Reader = &unstructuredClient{}
@@ -50,7 +51,7 @@ func (uc *unstructuredClient) Create(ctx context.Context, obj Object, opts ...Cr
 	createOpts.ApplyOptions(opts)
 
 	result := o.Post().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Body(obj).
 		VersionedParams(createOpts.AsCreateOptions(), uc.paramCodec).
@@ -79,9 +80,9 @@ func (uc *unstructuredClient) Update(ctx context.Context, obj Object, opts ...Up
 	updateOpts.ApplyOptions(opts)
 
 	result := o.Put().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		Body(obj).
 		VersionedParams(updateOpts.AsUpdateOptions(), uc.paramCodec).
 		Do(ctx).
@@ -106,9 +107,9 @@ func (uc *unstructuredClient) Delete(ctx context.Context, obj Object, opts ...De
 	deleteOpts.ApplyOptions(opts)
 
 	return o.Delete().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		Body(deleteOpts.AsDeleteOptions()).
 		Do(ctx).
 		Error()
@@ -157,13 +158,39 @@ func (uc *unstructuredClient) Patch(ctx context.Context, obj Object, patch Patch
 	patchOpts.ApplyOptions(opts)
 
 	return o.Patch(patch.Type()).
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		VersionedParams(patchOpts.AsPatchOptions(), uc.paramCodec).
 		Body(data).
 		Do(ctx).
 		Into(obj)
+}
+
+func (uc *unstructuredClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	unstructuredApplyConfig, ok := obj.(*unstructuredApplyConfiguration)
+	if !ok {
+		return fmt.Errorf("bug: unstructured client got an applyconfiguration that was not %T but %T", &unstructuredApplyConfiguration{}, obj)
+	}
+	o, err := uc.resources.getObjMeta(unstructuredApplyConfig.Unstructured)
+	if err != nil {
+		return err
+	}
+
+	req, err := apply.NewRequest(o, obj)
+	if err != nil {
+		return fmt.Errorf("failed to create apply request: %w", err)
+	}
+	applyOpts := &ApplyOptions{}
+	applyOpts.ApplyOptions(opts)
+
+	return req.
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
+		Resource(o.resource()).
+		Name(o.name).
+		VersionedParams(applyOpts.AsPatchOptions(), uc.paramCodec).
+		Do(ctx).
+		Into(unstructuredApplyConfig.Unstructured)
 }
 
 // Get implements client.Client.
@@ -244,9 +271,9 @@ func (uc *unstructuredClient) GetSubResource(ctx context.Context, obj, subResour
 	getOpts.ApplyOptions(opts)
 
 	return o.Get().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		VersionedParams(getOpts.AsGetOptions(), uc.paramCodec).
 		Do(ctx).
@@ -275,9 +302,9 @@ func (uc *unstructuredClient) CreateSubResource(ctx context.Context, obj, subRes
 	createOpts.ApplyOptions(opts)
 
 	return o.Post().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(subResourceObj).
 		VersionedParams(createOpts.AsCreateOptions(), uc.paramCodec).
@@ -310,9 +337,9 @@ func (uc *unstructuredClient) UpdateSubResource(ctx context.Context, obj Object,
 	}
 
 	return o.Put().
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(body).
 		VersionedParams(updateOpts.AsUpdateOptions(), uc.paramCodec).
@@ -347,9 +374,9 @@ func (uc *unstructuredClient) PatchSubResource(ctx context.Context, obj Object, 
 	}
 
 	result := o.Patch(patch.Type()).
-		NamespaceIfScoped(o.GetNamespace(), o.isNamespaced()).
+		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
-		Name(o.GetName()).
+		Name(o.name).
 		SubResource(subResource).
 		Body(data).
 		VersionedParams(patchOpts.AsPatchOptions(), uc.paramCodec).


### PR DESCRIPTION
 This change adds native server-side apply support to the client by extending it with an `Apply` method that takes a `runtime.ApplyConfiguration`.

Ref https://github.com/kubernetes-sigs/controller-runtime/issues/3183