### PR TITLE
✨ envtest: search the assets index for latest of a release series

### DIFF
--- a/examples/scratch-env/go.mod
+++ b/examples/scratch-env/go.mod
@@ -9,8 +9,8 @@ require (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/examples/scratch-env/go.sum
+++ b/examples/scratch-env/go.sum
@@ -1,7 +1,7 @@
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/controller-runtime
 go 1.24.0
 
 require (
-	github.com/blang/semver/v4 v4.0.0
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.2
@@ -37,6 +37,7 @@ require (
 	cel.dev/expr v0.24.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 cel.dev/expr v0.24.0 h1:56OvJKSH3hDGL0ml5uSxZmz3/3Pq4tJ+fb1unVLAFcY=
 cel.dev/expr v0.24.0/go.mod h1:hLPLo1W4QUmuYdA72RBX06QTs6MXw941piREPl3Yfiw=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
 github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/pkg/envtest/binaries_test.go
+++ b/pkg/envtest/binaries_test.go
@@ -68,12 +68,31 @@ var _ = Describe("Test download binaries", func() {
 		Expect(actualFiles).To(ConsistOf("some-file"))
 	})
 
-	It("should download v1.32.0 binaries", func(ctx SpecContext) {
+	It("should download binaries of an exact version", func(ctx SpecContext) {
 		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(ctx, downloadDirectory, "v1.31.0", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 
-		// Verify latest stable version (v1.32.0) was downloaded
+		// Verify exact version (v1.31.0) was downloaded
 		versionDownloadDirectory := path.Join(downloadDirectory, fmt.Sprintf("1.31.0-%s-%s", runtime.GOOS, runtime.GOARCH))
+		Expect(apiServerPath).To(Equal(path.Join(versionDownloadDirectory, "kube-apiserver")))
+		Expect(etcdPath).To(Equal(path.Join(versionDownloadDirectory, "etcd")))
+		Expect(kubectlPath).To(Equal(path.Join(versionDownloadDirectory, "kubectl")))
+
+		dirEntries, err := os.ReadDir(versionDownloadDirectory)
+		Expect(err).ToNot(HaveOccurred())
+		var actualFiles []string
+		for _, e := range dirEntries {
+			actualFiles = append(actualFiles, e.Name())
+		}
+		Expect(actualFiles).To(ConsistOf("some-file"))
+	})
+
+	It("should download binaries of latest stable version of a release series", func(ctx SpecContext) {
+		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(ctx, downloadDirectory, "1.31", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Verify stable version (v1.31.4) was downloaded
+		versionDownloadDirectory := path.Join(downloadDirectory, fmt.Sprintf("1.31.4-%s-%s", runtime.GOOS, runtime.GOARCH))
 		Expect(apiServerPath).To(Equal(path.Join(versionDownloadDirectory, "kube-apiserver")))
 		Expect(etcdPath).To(Equal(path.Join(versionDownloadDirectory, "etcd")))
 		Expect(kubectlPath).To(Equal(path.Join(versionDownloadDirectory, "kubectl")))
@@ -99,6 +118,15 @@ var (
 				"envtest-v1.32.0-linux-ppc64le.tar.gz": {},
 				"envtest-v1.32.0-linux-s390x.tar.gz":   {},
 				"envtest-v1.32.0-windows-amd64.tar.gz": {},
+			},
+			"v1.31.4": map[string]archive{
+				"envtest-v1.31.4-darwin-amd64.tar.gz":  {},
+				"envtest-v1.31.4-darwin-arm64.tar.gz":  {},
+				"envtest-v1.31.4-linux-amd64.tar.gz":   {},
+				"envtest-v1.31.4-linux-arm64.tar.gz":   {},
+				"envtest-v1.31.4-linux-ppc64le.tar.gz": {},
+				"envtest-v1.31.4-linux-s390x.tar.gz":   {},
+				"envtest-v1.31.4-windows-amd64.tar.gz": {},
 			},
 			"v1.31.0": map[string]archive{
 				"envtest-v1.31.0-darwin-amd64.tar.gz":  {},


### PR DESCRIPTION
This lets one configure the `DownloadBinaryAssetsVersion` field of `envtest.Environment` with only the Major.Minor portions of a Kubernetes API version. When `DownloadBinaryAssets` is set, the framework will search the asset index for the latest stable version in that release series.

This matches the behavior of `setup-envtest use {major}.{minor}` without the full complexity of version selectors. The leading `v` is now optional, too.

For example:
- `"v1.29"` resolves to [v1.29.4](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L24)
- `"1.27"` resolves to [v1.27.1](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L134)
- `"1.24"` resolves to [v1.24.2](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L222)