### PR TITLE
⚠️ Migration to the new events API

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -40,7 +40,6 @@ var _ = Describe("cluster.Cluster", func() {
 			c, err := New(nil)
 			Expect(c).To(BeNil())
 			Expect(err.Error()).To(ContainSubstring("must specify Config"))
-
 		})
 
 		It("should return an error if it can't create a RestMapper", func() {
@@ -50,7 +49,6 @@ var _ = Describe("cluster.Cluster", func() {
 			})
 			Expect(c).To(BeNil())
 			Expect(err).To(Equal(expected))
-
 		})
 
 		It("should return an error it can't create a client.Client", func() {
@@ -96,7 +94,6 @@ var _ = Describe("cluster.Cluster", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("expected error"))
 		})
-
 	})
 
 	Describe("Start", func() {
@@ -160,7 +157,13 @@ var _ = Describe("cluster.Cluster", func() {
 	It("should provide a function to get the EventRecorder", func() {
 		c, err := New(cfg)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(c.GetEventRecorderFor("test")).NotTo(BeNil())
+		Expect(c.GetEventRecorder("test")).NotTo(BeNil())
+	})
+
+	It("should provide a function to get the deprecated EventRecorder", func() {
+		c, err := New(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.GetEventRecorderFor("test")).NotTo(BeNil()) //nolint:staticcheck
 	})
 	It("should provide a function to get the APIReader", func() {
 		c, err := New(cfg)

--- a/pkg/cluster/internal.go
+++ b/pkg/cluster/internal.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -85,6 +86,10 @@ func (c *cluster) GetCache() cache.Cache {
 
 func (c *cluster) GetEventRecorderFor(name string) record.EventRecorder {
 	return c.recorderProvider.GetEventRecorderFor(name)
+}
+
+func (c *cluster) GetEventRecorder(name string) events.EventRecorder {
+	return c.recorderProvider.GetEventRecorder(name)
 }
 
 func (c *cluster) GetRESTMapper() meta.RESTMapper {

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -21,7 +21,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	eventsv1 "k8s.io/api/events/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes/scheme"
 	ref "k8s.io/client-go/tools/reference"
@@ -36,20 +38,22 @@ import (
 )
 
 var _ = Describe("recorder", func() {
-	Describe("recorder", func() {
+	Describe("deprecated recorder", func() {
 		It("should publish events", func(ctx SpecContext) {
 			By("Creating the Manager")
 			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the Controller")
-			recorder := cm.GetEventRecorderFor("test-recorder")
+			deprecatedRecorder := cm.GetEventRecorderFor("test-deprecated-recorder") //nolint:staticcheck
+			recorder := cm.GetEventRecorder("test-recorder")
 			instance, err := controller.New("foo-controller", cm, controller.Options{
 				Reconciler: reconcile.Func(
 					func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 						dp, err := clientset.AppsV1().Deployments(request.Namespace).Get(ctx, request.Name, metav1.GetOptions{})
 						Expect(err).NotTo(HaveOccurred())
-						recorder.Event(dp, corev1.EventTypeNormal, "test-reason", "test-msg")
+						deprecatedRecorder.Event(dp, corev1.EventTypeNormal, "deprecated-test-reason", "deprecated-test-msg")
+						recorder.Eventf(dp, nil, corev1.EventTypeNormal, "test-reason", "test-action", "test-note")
 						return reconcile.Result{}, nil
 					}),
 			})
@@ -66,7 +70,7 @@ var _ = Describe("recorder", func() {
 			}()
 
 			deployment := &appsv1.Deployment{
-				ObjectMeta: metav1.ObjectMeta{Name: "deployment-name"},
+				ObjectMeta: metav1.ObjectMeta{Name: "deprecated-deployment-name"},
 				Spec: appsv1.DeploymentSpec{
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{"foo": "bar"},
@@ -89,23 +93,42 @@ var _ = Describe("recorder", func() {
 			deployment, err = clientset.AppsV1().Deployments("default").Create(ctx, deployment, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Validate event is published as expected")
-			evtWatcher, err := clientset.CoreV1().Events("default").Watch(ctx, metav1.ListOptions{})
+			// watch both deprecated and new events based on the reason
+			By("Validate deprecated event is published as expected")
+			deprecatedEvtWatcher, err := clientset.CoreV1().Events("default").Watch(ctx,
+				metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("reason", "deprecated-test-reason").String()})
 			Expect(err).NotTo(HaveOccurred())
 
-			resultEvent := <-evtWatcher.ResultChan()
+			resultEvent := <-deprecatedEvtWatcher.ResultChan()
 
 			Expect(resultEvent.Type).To(Equal(watch.Added))
-			evt, isEvent := resultEvent.Object.(*corev1.Event)
+			deprecatedEvt, isEvent := resultEvent.Object.(*corev1.Event)
 			Expect(isEvent).To(BeTrue())
 
 			dpRef, err := ref.GetReference(scheme.Scheme, deployment)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(evt.InvolvedObject).To(Equal(*dpRef))
+			Expect(deprecatedEvt.InvolvedObject).To(Equal(*dpRef))
+			Expect(deprecatedEvt.Type).To(Equal(corev1.EventTypeNormal))
+			Expect(deprecatedEvt.Reason).To(Equal("deprecated-test-reason"))
+			Expect(deprecatedEvt.Message).To(Equal("deprecated-test-msg"))
+
+			By("Validate event is published as expected")
+			evtWatcher, err := clientset.EventsV1().Events("default").Watch(ctx,
+				metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("reason", "test-reason").String()})
+			Expect(err).NotTo(HaveOccurred())
+
+			resultEvent = <-evtWatcher.ResultChan()
+
+			Expect(resultEvent.Type).To(Equal(watch.Added))
+			evt, isEvent := resultEvent.Object.(*eventsv1.Event)
+			Expect(isEvent).To(BeTrue())
+
+			Expect(evt.Regarding).To(Equal(*dpRef))
 			Expect(evt.Type).To(Equal(corev1.EventTypeNormal))
 			Expect(evt.Reason).To(Equal("test-reason"))
-			Expect(evt.Message).To(Equal("test-msg"))
+			Expect(evt.Action).To(Equal("test-action"))
+			Expect(evt.Note).To(Equal("test-note"))
 		})
 	})
 })

--- a/pkg/leaderelection/leader_election.go
+++ b/pkg/leaderelection/leader_election.go
@@ -127,8 +127,10 @@ func NewResourceLock(config *rest.Config, recorderProvider recorder.Provider, op
 		corev1Client,
 		coordinationClient,
 		resourcelock.ResourceLockConfig{
-			Identity:      id,
-			EventRecorder: recorderProvider.GetEventRecorderFor(id),
+			Identity: id,
+			// TODO(clebs): Replace with the new events API after leader election is updated upstream.
+			// REF: https://github.com/kubernetes/kubernetes/issues/82846
+			EventRecorder: recorderProvider.GetEventRecorderFor(id), //nolint:staticcheck
 		},
 		options.LeaderLabels,
 	)

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
@@ -256,7 +257,11 @@ func (cm *controllerManager) GetCache() cache.Cache {
 }
 
 func (cm *controllerManager) GetEventRecorderFor(name string) record.EventRecorder {
-	return cm.cluster.GetEventRecorderFor(name)
+	return cm.cluster.GetEventRecorderFor(name) //nolint:staticcheck
+}
+
+func (cm *controllerManager) GetEventRecorder(name string) events.EventRecorder {
+	return cm.cluster.GetEventRecorder(name)
 }
 
 func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -29,7 +29,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
+	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
@@ -337,7 +339,10 @@ func New(config *rest.Config, options Options) (Manager, error) {
 		return nil, errors.New("must specify Config")
 	}
 	// Set default values for options fields
-	options = setOptionsDefaults(options)
+	options, err := setOptionsDefaults(config, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed setting manager default options: %w", err)
+	}
 
 	cluster, err := cluster.New(config, func(clusterOptions *cluster.Options) {
 		clusterOptions.Scheme = options.Scheme
@@ -493,7 +498,7 @@ func defaultBaseContext() context.Context {
 }
 
 // setOptionsDefaults set default values for Options fields.
-func setOptionsDefaults(options Options) Options {
+func setOptionsDefaults(config *rest.Config, options Options) (Options, error) {
 	// Allow newResourceLock to be mocked
 	if options.newResourceLock == nil {
 		options.newResourceLock = leaderelection.NewResourceLock
@@ -507,14 +512,25 @@ func setOptionsDefaults(options Options) Options {
 	// This is duplicated with pkg/cluster, we need it here
 	// for the leader election and there to provide the user with
 	// an EventBroadcaster
+	httpClient, err := rest.HTTPClientFor(config)
+	if err != nil {
+		return options, err
+	}
+
+	evtCl, err := eventsv1client.NewForConfigAndClient(config, httpClient)
+	if err != nil {
+		return options, err
+	}
+
 	if options.EventBroadcaster == nil {
 		// defer initialization to avoid leaking by default
-		options.makeBroadcaster = func() (record.EventBroadcaster, bool) {
-			return record.NewBroadcaster(), true
+		options.makeBroadcaster = func() (record.EventBroadcaster, events.EventBroadcaster, bool) {
+			return record.NewBroadcaster(), events.NewBroadcaster(&events.EventSinkImpl{Interface: evtCl}), true
 		}
 	} else {
-		options.makeBroadcaster = func() (record.EventBroadcaster, bool) {
-			return options.EventBroadcaster, false
+		// keep supporting the options.EventBroadcaster in the old API, but do not introduce it for the new one.
+		options.makeBroadcaster = func() (record.EventBroadcaster, events.EventBroadcaster, bool) {
+			return options.EventBroadcaster, events.NewBroadcaster(&events.EventSinkImpl{Interface: evtCl}), false
 		}
 	}
 
@@ -571,5 +587,5 @@ func setOptionsDefaults(options Options) Options {
 		options.WebhookServer = webhook.NewServer(webhook.Options{})
 	}
 
-	return options
+	return options, nil
 }

--- a/pkg/recorder/example_test.go
+++ b/pkg/recorder/example_test.go
@@ -18,31 +18,39 @@ package recorder_test
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	_ "github.com/onsi/ginkgo/v2"
 	"sigs.k8s.io/controller-runtime/pkg/recorder"
 )
 
 var (
-	recorderProvider recorder.Provider
-	somePod          *corev1.Pod // the object you're reconciling, for example
+	recorderProvider  recorder.Provider
+	somePod           *corev1.Pod    // the object you're reconciling, for example
+	someRelatedObject runtime.Object // another object related to the reconciled object and the event.
 )
 
 func Example_event() {
 	// recorderProvider is a recorder.Provider
-	recorder := recorderProvider.GetEventRecorderFor("my-controller")
+	deprecatedRecorder := recorderProvider.GetEventRecorderFor("my-controller")
 
 	// emit an event with a fixed message
-	recorder.Event(somePod, corev1.EventTypeWarning,
+	deprecatedRecorder.Event(somePod, corev1.EventTypeWarning,
 		"WrongTrousers", "It's the wrong trousers, Gromit!")
 }
 
 func Example_eventf() {
 	// recorderProvider is a recorder.Provider
-	recorder := recorderProvider.GetEventRecorderFor("my-controller")
+	deprecatedRecorder := recorderProvider.GetEventRecorderFor("my-controller")
 
 	// emit an event with a variable message
 	mildCheese := "Wensleydale"
-	recorder.Eventf(somePod, corev1.EventTypeNormal,
+	deprecatedRecorder.Eventf(somePod, corev1.EventTypeNormal,
 		"DislikesCheese", "Not even %s?", mildCheese)
+
+	recorder := recorderProvider.GetEventRecorder("my-controller")
+
+	// emit an event with a fixed message
+	recorder.Eventf(somePod, someRelatedObject, corev1.EventTypeWarning,
+		"WrongTrousers", "getting dressed", "It's the wrong trousers, Gromit!")
 }

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -21,11 +21,16 @@ limitations under the License.
 package recorder
 
 import (
+	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 )
 
 // Provider knows how to generate new event recorders with given name.
 type Provider interface {
-	// NewRecorder returns an EventRecorder with given name.
+	// GetEventRecorderFor returns an EventRecorder for the old events API.
+	//
+	// Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
 	GetEventRecorderFor(name string) record.EventRecorder
+	// GetEventRecorder returns a EventRecorder with given name.
+	GetEventRecorder(name string) events.EventRecorder
 }


### PR DESCRIPTION
This Pull Request migrates from the old events API (`k8s.io/client-go/tools/record`) to the new API (`k8s.io/client-go/tools/events`).

Closes #2141

