### PR TITLE
:seedling: Stop using context.Background()/TODO() in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - errchkjson
     - errorlint
     - exhaustive
+    - forbidigo
     - ginkgolinter
     - goconst
     - gocritic
@@ -39,6 +40,12 @@ linters:
     - unused
     - whitespace
   settings:
+    forbidigo:
+        forbid:
+          - pattern: context.Background
+            msg: Use ginkgos SpecContext or go testings t.Context instead
+          - pattern: context.TODO
+            msg: Use ginkgos SpecContext or go testings t.Context instead
     govet:
       disable:
         - fieldalignment
@@ -94,6 +101,9 @@ linters:
       - zz_generated.*\.go$
       - .*conversion.*\.go$
     rules:
+      - linters:
+          - forbidigo
+        path-except: _test\.go
       - linters:
           - gosec
         text: 'G108: Profiling endpoint is automatically exposed on /debug/pprof'

--- a/pkg/builder/controller_test.go
+++ b/pkg/builder/controller_test.go
@@ -402,7 +402,7 @@ var _ = Describe("application", func() {
 	})
 
 	Describe("Start with ControllerManagedBy", func() {
-		It("should Reconcile Owns objects", func() {
+		It("should Reconcile Owns objects", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -411,12 +411,10 @@ var _ = Describe("application", func() {
 				Named("deployment-0").
 				Owns(&appsv1.ReplicaSet{})
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "3", m, false, bldr)
 		})
 
-		It("should Reconcile Owns objects for every owner", func() {
+		It("should Reconcile Owns objects for every owner", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -425,12 +423,10 @@ var _ = Describe("application", func() {
 				Named("deployment-1").
 				Owns(&appsv1.ReplicaSet{}, MatchEveryOwner)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "12", m, false, bldr)
 		})
 
-		It("should Reconcile Watches objects", func() {
+		It("should Reconcile Watches objects", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -441,12 +437,10 @@ var _ = Describe("application", func() {
 					handler.EnqueueRequestForOwner(m.GetScheme(), m.GetRESTMapper(), &appsv1.Deployment{}, handler.OnlyControllerOwner()),
 				)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "4", m, true, bldr)
 		})
 
-		It("should Reconcile without For", func() {
+		It("should Reconcile without For", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -460,14 +454,12 @@ var _ = Describe("application", func() {
 					handler.EnqueueRequestForOwner(m.GetScheme(), m.GetRESTMapper(), &appsv1.Deployment{}, handler.OnlyControllerOwner()),
 				)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "9", m, true, bldr)
 		})
 	})
 
 	Describe("Set custom predicates", func() {
-		It("should execute registered predicates only for assigned kind", func() {
+		It("should execute registered predicates only for assigned kind", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -517,8 +509,6 @@ var _ = Describe("application", func() {
 				Owns(&appsv1.ReplicaSet{}, WithPredicates(replicaSetPrct)).
 				WithEventFilter(allPrct)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "5", m, true, bldr)
 
 			Expect(deployPrctExecuted).To(BeTrue(), "Deploy predicated should be called at least once")
@@ -537,17 +527,14 @@ var _ = Describe("application", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should support multiple controllers watching the same metadata kind", func() {
+		It("should support multiple controllers watching the same metadata kind", func(ctx SpecContext) {
 			bldr1 := ControllerManagedBy(mgr).For(&appsv1.Deployment{}, OnlyMetadata).Named("deployment-4")
 			bldr2 := ControllerManagedBy(mgr).For(&appsv1.Deployment{}, OnlyMetadata).Named("deployment-5")
-
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 
 			doReconcileTest(ctx, "6", mgr, true, bldr1, bldr2)
 		})
 
-		It("should support watching For, Owns, and Watch as metadata", func() {
+		It("should support watching For, Owns, and Watch as metadata", func(ctx SpecContext) {
 			statefulSetMaps := make(chan *metav1.PartialObjectMetadata)
 
 			bldr := ControllerManagedBy(mgr).
@@ -571,8 +558,6 @@ var _ = Describe("application", func() {
 					}),
 					OnlyMetadata)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			doReconcileTest(ctx, "8", mgr, true, bldr)
 
 			By("Creating a new stateful set")
@@ -601,7 +586,7 @@ var _ = Describe("application", func() {
 					},
 				},
 			}
-			err := mgr.GetClient().Create(context.TODO(), set)
+			err := mgr.GetClient().Create(ctx, set)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking that the mapping function has been called")

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -79,7 +79,7 @@ func runTests(admissionReviewVersion string) {
 		close(stop)
 	})
 
-	It("should scaffold a custom defaulting webhook", func() {
+	It("should scaffold a custom defaulting webhook", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -124,7 +124,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -155,7 +155,7 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Code).To(Equal(http.StatusNotFound))
 	})
 
-	It("should scaffold a custom defaulting webhook with a custom path", func() {
+	It("should scaffold a custom defaulting webhook with a custom path", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -202,7 +202,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -234,7 +234,7 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Code).To(Equal(http.StatusNotFound))
 	})
 
-	It("should scaffold a custom defaulting webhook which recovers from panics", func() {
+	It("should scaffold a custom defaulting webhook which recovers from panics", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -278,7 +278,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -298,7 +298,7 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Body).To(ContainSubstring(`"message":"panic: fake panic test [recovered]`))
 	})
 
-	It("should scaffold a custom validating webhook", func() {
+	It("should scaffold a custom validating webhook", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -345,7 +345,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -375,7 +375,7 @@ func runTests(admissionReviewVersion string) {
 		EventuallyWithOffset(1, logBuffer).Should(gbytes.Say(`"msg":"Validating object","object":{"name":"foo","namespace":"default"},"namespace":"default","name":"foo","resource":{"group":"foo.test.org","version":"v1","resource":"testvalidator"},"user":"","requestID":"07e52e8d-4513-11e9-a716-42010a800270"`))
 	})
 
-	It("should scaffold a custom validating webhook with a custom path", func() {
+	It("should scaffold a custom validating webhook with a custom path", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -424,7 +424,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -455,7 +455,7 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Code).To(Equal(http.StatusNotFound))
 	})
 
-	It("should scaffold a custom validating webhook which recovers from panics", func() {
+	It("should scaffold a custom validating webhook which recovers from panics", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -497,7 +497,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -519,9 +519,9 @@ func runTests(admissionReviewVersion string) {
 		ExpectWithOffset(1, w.Body).To(ContainSubstring(`"message":"panic: fake panic test [recovered]`))
 	})
 
-	It("should scaffold a custom validating webhook to validate deletes", func() {
+	It("should scaffold a custom validating webhook to validate deletes", func(specCtx SpecContext) {
 		By("creating a controller manager")
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -630,7 +630,7 @@ func runTests(admissionReviewVersion string) {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should scaffold a custom defaulting and validating webhook", func() {
+	It("should scaffold a custom defaulting and validating webhook", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -678,7 +678,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {
@@ -713,7 +713,7 @@ func runTests(admissionReviewVersion string) {
 		EventuallyWithOffset(1, logBuffer).Should(gbytes.Say(`"msg":"Validating object","object":{"name":"foo","namespace":"default"},"namespace":"default","name":"foo","resource":{"group":"foo.test.org","version":"v1","resource":"testdefaultvalidator"},"user":"","requestID":"07e52e8d-4513-11e9-a716-42010a800270"`))
 	})
 
-	It("should scaffold a custom defaulting and validating webhook with a custom path for each of them", func() {
+	It("should scaffold a custom defaulting and validating webhook with a custom path for each of them", func(specCtx SpecContext) {
 		By("creating a controller manager")
 		m, err := manager.New(cfg, manager.Options{})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
@@ -765,7 +765,7 @@ func runTests(admissionReviewVersion string) {
   }
 }`)
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		err = svr.Start(ctx)
 		if err != nil && !os.IsNotExist(err) {

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -55,7 +55,7 @@ const testNamespaceThree = "test-namespace-3"
 
 // TODO(community): Pull these helper functions into testenv.
 // Restart policy is included to allow indexing on that field.
-func createPodWithLabels(name, namespace string, restartPolicy corev1.RestartPolicy, labels map[string]string) client.Object {
+func createPodWithLabels(ctx context.Context, name, namespace string, restartPolicy corev1.RestartPolicy, labels map[string]string) client.Object {
 	three := int64(3)
 	if labels == nil {
 		labels = map[string]string{}
@@ -75,12 +75,12 @@ func createPodWithLabels(name, namespace string, restartPolicy corev1.RestartPol
 	}
 	cl, err := client.New(cfg, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
-	err = cl.Create(context.Background(), pod)
+	err = cl.Create(ctx, pod)
 	Expect(err).NotTo(HaveOccurred())
 	return pod
 }
 
-func createSvc(name, namespace string, cl client.Client) client.Object {
+func createSvc(ctx context.Context, name, namespace string, cl client.Client) client.Object {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -90,31 +90,31 @@ func createSvc(name, namespace string, cl client.Client) client.Object {
 			Ports: []corev1.ServicePort{{Port: 1}},
 		},
 	}
-	err := cl.Create(context.Background(), svc)
+	err := cl.Create(ctx, svc)
 	Expect(err).NotTo(HaveOccurred())
 	return svc
 }
 
-func createSA(name, namespace string, cl client.Client) client.Object {
+func createSA(ctx context.Context, name, namespace string, cl client.Client) client.Object {
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 		},
 	}
-	err := cl.Create(context.Background(), sa)
+	err := cl.Create(ctx, sa)
 	Expect(err).NotTo(HaveOccurred())
 	return sa
 }
 
-func createPod(name, namespace string, restartPolicy corev1.RestartPolicy) client.Object {
-	return createPodWithLabels(name, namespace, restartPolicy, nil)
+func createPod(ctx context.Context, name, namespace string, restartPolicy corev1.RestartPolicy) client.Object {
+	return createPodWithLabels(ctx, name, namespace, restartPolicy, nil)
 }
 
-func deletePod(pod client.Object) {
+func deletePod(ctx context.Context, pod client.Object) {
 	cl, err := client.New(cfg, client.Options{})
 	Expect(err).NotTo(HaveOccurred())
-	err = cl.Delete(context.Background(), pod)
+	err = cl.Delete(ctx, pod)
 	Expect(err).NotTo(HaveOccurred())
 }
 
@@ -156,7 +156,6 @@ var _ = Describe("Informer Cache without global DeepCopy", func() {
 var _ = Describe("Cache with transformers", func() {
 	var (
 		informerCache       cache.Cache
-		informerCacheCtx    context.Context
 		informerCacheCancel context.CancelFunc
 		knownPod1           client.Object
 		knownPod2           client.Object
@@ -177,28 +176,31 @@ var _ = Describe("Cache with transformers", func() {
 		return ""
 	}
 
-	BeforeEach(func() {
-		informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background())
+	BeforeEach(func(ctx SpecContext) {
+		var informerCacheCtx context.Context
+		// Has to be derived from context.Background as it has to stay valid past the
+		// BeforeEach.
+		informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background()) //nolint:forbidigo
 		Expect(cfg).NotTo(BeNil())
 
 		By("creating three pods")
 		cl, err := client.New(cfg, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNode(testNodeOne, cl)
+		err = ensureNode(ctx, testNodeOne, cl)
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNamespace(testNamespaceOne, cl)
+		err = ensureNamespace(ctx, testNamespaceOne, cl)
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNamespace(testNamespaceTwo, cl)
+		err = ensureNamespace(ctx, testNamespaceTwo, cl)
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNamespace(testNamespaceThree, cl)
+		err = ensureNamespace(ctx, testNamespaceThree, cl)
 		Expect(err).NotTo(HaveOccurred())
 		// Includes restart policy since these objects are indexed on this field.
-		knownPod1 = createPod("test-pod-1", testNamespaceOne, corev1.RestartPolicyNever)
-		knownPod2 = createPod("test-pod-2", testNamespaceTwo, corev1.RestartPolicyAlways)
-		knownPod3 = createPodWithLabels("test-pod-3", testNamespaceTwo, corev1.RestartPolicyOnFailure, map[string]string{"common-label": "common"})
-		knownPod4 = createPodWithLabels("test-pod-4", testNamespaceThree, corev1.RestartPolicyNever, map[string]string{"common-label": "common"})
-		knownPod5 = createPod("test-pod-5", testNamespaceOne, corev1.RestartPolicyNever)
-		knownPod6 = createPod("test-pod-6", testNamespaceTwo, corev1.RestartPolicyAlways)
+		knownPod1 = createPod(ctx, "test-pod-1", testNamespaceOne, corev1.RestartPolicyNever)
+		knownPod2 = createPod(ctx, "test-pod-2", testNamespaceTwo, corev1.RestartPolicyAlways)
+		knownPod3 = createPodWithLabels(ctx, "test-pod-3", testNamespaceTwo, corev1.RestartPolicyOnFailure, map[string]string{"common-label": "common"})
+		knownPod4 = createPodWithLabels(ctx, "test-pod-4", testNamespaceThree, corev1.RestartPolicyNever, map[string]string{"common-label": "common"})
+		knownPod5 = createPod(ctx, "test-pod-5", testNamespaceOne, corev1.RestartPolicyNever)
+		knownPod6 = createPod(ctx, "test-pod-6", testNamespaceTwo, corev1.RestartPolicyAlways)
 
 		podGVK := schema.GroupVersionKind{
 			Kind:    "Pod",
@@ -265,26 +267,26 @@ var _ = Describe("Cache with transformers", func() {
 			defer GinkgoRecover()
 			Expect(informerCache.Start(ctx)).To(Succeed())
 		}(informerCacheCtx)
-		Expect(informerCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+		Expect(informerCache.WaitForCacheSync(ctx)).To(BeTrue())
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		By("cleaning up created pods")
-		deletePod(knownPod1)
-		deletePod(knownPod2)
-		deletePod(knownPod3)
-		deletePod(knownPod4)
-		deletePod(knownPod5)
-		deletePod(knownPod6)
+		deletePod(ctx, knownPod1)
+		deletePod(ctx, knownPod2)
+		deletePod(ctx, knownPod3)
+		deletePod(ctx, knownPod4)
+		deletePod(ctx, knownPod5)
+		deletePod(ctx, knownPod6)
 
 		informerCacheCancel()
 	})
 
 	Context("with structured objects", func() {
-		It("should apply transformers to explicitly specified GVKS", func() {
+		It("should apply transformers to explicitly specified GVKS", func(ctx SpecContext) {
 			By("listing pods")
 			out := corev1.PodList{}
-			Expect(informerCache.List(context.Background(), &out)).To(Succeed())
+			Expect(informerCache.List(ctx, &out)).To(Succeed())
 
 			By("verifying that the returned pods were transformed")
 			for i := 0; i < len(out.Items); i++ {
@@ -292,11 +294,11 @@ var _ = Describe("Cache with transformers", func() {
 			}
 		})
 
-		It("should apply default transformer to objects when none is specified", func() {
+		It("should apply default transformer to objects when none is specified", func(ctx SpecContext) {
 			By("getting the Kubernetes service")
 			svc := &corev1.Service{}
 			svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-			Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+			Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 			By("verifying that the returned service was transformed")
 			Expect(getTransformValue(svc)).To(BeIdenticalTo("default"))
@@ -304,7 +306,7 @@ var _ = Describe("Cache with transformers", func() {
 	})
 
 	Context("with unstructured objects", func() {
-		It("should apply transformers to explicitly specified GVKS", func() {
+		It("should apply transformers to explicitly specified GVKS", func(ctx SpecContext) {
 			By("listing pods")
 			out := unstructured.UnstructuredList{}
 			out.SetGroupVersionKind(schema.GroupVersionKind{
@@ -312,7 +314,7 @@ var _ = Describe("Cache with transformers", func() {
 				Version: "v1",
 				Kind:    "PodList",
 			})
-			Expect(informerCache.List(context.Background(), &out)).To(Succeed())
+			Expect(informerCache.List(ctx, &out)).To(Succeed())
 
 			By("verifying that the returned pods were transformed")
 			for i := 0; i < len(out.Items); i++ {
@@ -320,7 +322,7 @@ var _ = Describe("Cache with transformers", func() {
 			}
 		})
 
-		It("should apply default transformer to objects when none is specified", func() {
+		It("should apply default transformer to objects when none is specified", func(ctx SpecContext) {
 			By("getting the Kubernetes service")
 			svc := &unstructured.Unstructured{}
 			svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -329,7 +331,7 @@ var _ = Describe("Cache with transformers", func() {
 				Kind:    "Service",
 			})
 			svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-			Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+			Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 			By("verifying that the returned service was transformed")
 			Expect(getTransformValue(svc)).To(BeIdenticalTo("default"))
@@ -337,7 +339,7 @@ var _ = Describe("Cache with transformers", func() {
 	})
 
 	Context("with metadata-only objects", func() {
-		It("should apply transformers to explicitly specified GVKS", func() {
+		It("should apply transformers to explicitly specified GVKS", func(ctx SpecContext) {
 			By("listing pods")
 			out := metav1.PartialObjectMetadataList{}
 			out.SetGroupVersionKind(schema.GroupVersionKind{
@@ -345,14 +347,14 @@ var _ = Describe("Cache with transformers", func() {
 				Version: "v1",
 				Kind:    "PodList",
 			})
-			Expect(informerCache.List(context.Background(), &out)).To(Succeed())
+			Expect(informerCache.List(ctx, &out)).To(Succeed())
 
 			By("verifying that the returned pods were transformed")
 			for i := 0; i < len(out.Items); i++ {
 				Expect(getTransformValue(&out.Items[i])).To(BeIdenticalTo("explicit"))
 			}
 		})
-		It("should apply default transformer to objects when none is specified", func() {
+		It("should apply default transformer to objects when none is specified", func(ctx SpecContext) {
 			By("getting the Kubernetes service")
 			svc := &metav1.PartialObjectMetadata{}
 			svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -361,7 +363,7 @@ var _ = Describe("Cache with transformers", func() {
 				Kind:    "Service",
 			})
 			svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-			Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+			Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 			By("verifying that the returned service was transformed")
 			Expect(getTransformValue(svc)).To(BeIdenticalTo("default"))
@@ -373,22 +375,24 @@ var _ = Describe("Cache with selectors", func() {
 	defer GinkgoRecover()
 	var (
 		informerCache       cache.Cache
-		informerCacheCtx    context.Context
 		informerCacheCancel context.CancelFunc
 	)
 
-	BeforeEach(func() {
-		informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background())
+	BeforeEach(func(ctx SpecContext) {
+		var informerCacheCtx context.Context
+		// Has to be derived from context.Background as it has to stay valid past the
+		// BeforeEach.
+		informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background()) //nolint:forbidigo
 		Expect(cfg).NotTo(BeNil())
 		cl, err := client.New(cfg, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNamespace(testNamespaceOne, cl)
+		err = ensureNamespace(ctx, testNamespaceOne, cl)
 		Expect(err).NotTo(HaveOccurred())
-		err = ensureNamespace(testNamespaceTwo, cl)
+		err = ensureNamespace(ctx, testNamespaceTwo, cl)
 		Expect(err).NotTo(HaveOccurred())
 		for idx, namespace := range []string{testNamespaceOne, testNamespaceTwo} {
-			_ = createSA("test-sa-"+strconv.Itoa(idx), namespace, cl)
-			_ = createSvc("test-svc-"+strconv.Itoa(idx), namespace, cl)
+			_ = createSA(ctx, "test-sa-"+strconv.Itoa(idx), namespace, cl)
+			_ = createSvc(ctx, "test-svc-"+strconv.Itoa(idx), namespace, cl)
 		}
 
 		opts := cache.Options{
@@ -412,8 +416,7 @@ var _ = Describe("Cache with selectors", func() {
 		Expect(informerCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
 	})
 
-	AfterEach(func() {
-		ctx := context.Background()
+	AfterEach(func(ctx SpecContext) {
 		cl, err := client.New(cfg, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
 		for idx, namespace := range []string{testNamespaceOne, testNamespaceTwo} {
@@ -425,17 +428,17 @@ var _ = Describe("Cache with selectors", func() {
 		informerCacheCancel()
 	})
 
-	It("Should list serviceaccounts and find exactly one in namespace "+testNamespaceOne, func() {
+	It("Should list serviceaccounts and find exactly one in namespace "+testNamespaceOne, func(ctx SpecContext) {
 		var sas corev1.ServiceAccountList
-		err := informerCache.List(informerCacheCtx, &sas)
+		err := informerCache.List(ctx, &sas)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(sas.Items).To(HaveLen(1))
 		Expect(sas.Items[0].Namespace).To(Equal(testNamespaceOne))
 	})
 
-	It("Should list services and find exactly one in namespace "+testNamespaceTwo, func() {
+	It("Should list services and find exactly one in namespace "+testNamespaceTwo, func(ctx SpecContext) {
 		var svcs corev1.ServiceList
-		err := informerCache.List(informerCacheCtx, &svcs)
+		err := informerCache.List(ctx, &svcs)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(svcs.Items).To(HaveLen(1))
 		Expect(svcs.Items[0].Namespace).To(Equal(testNamespaceTwo))
@@ -446,13 +449,15 @@ func CacheTestReaderFailOnMissingInformer(createCacheFunc func(config *rest.Conf
 	Describe("Cache test with ReaderFailOnMissingInformer = true", func() {
 		var (
 			informerCache       cache.Cache
-			informerCacheCtx    context.Context
 			informerCacheCancel context.CancelFunc
 			errNotCached        *cache.ErrResourceNotCached
 		)
 
-		BeforeEach(func() {
-			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background())
+		BeforeEach(func(ctx SpecContext) {
+			var informerCacheCtx context.Context
+			// Has to be derived from context.Background as it has to stay valid past the
+			// BeforeEach.
+			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background()) //nolint:forbidigo
 			Expect(cfg).NotTo(BeNil())
 			By("creating the informer cache")
 			var err error
@@ -464,7 +469,7 @@ func CacheTestReaderFailOnMissingInformer(createCacheFunc func(config *rest.Conf
 				defer GinkgoRecover()
 				Expect(informerCache.Start(ctx)).To(Succeed())
 			}(informerCacheCtx)
-			Expect(informerCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+			Expect(informerCache.WaitForCacheSync(ctx)).To(BeTrue())
 		})
 
 		AfterEach(func() {
@@ -473,27 +478,27 @@ func CacheTestReaderFailOnMissingInformer(createCacheFunc func(config *rest.Conf
 
 		Describe("as a Reader", func() {
 			Context("with structured objects", func() {
-				It("should not be able to list objects that haven't been watched previously", func() {
+				It("should not be able to list objects that haven't been watched previously", func(ctx SpecContext) {
 					By("listing all services in the cluster")
 					listObj := &corev1.ServiceList{}
-					Expect(errors.As(informerCache.List(context.Background(), listObj), &errNotCached)).To(BeTrue())
+					Expect(errors.As(informerCache.List(ctx, listObj), &errNotCached)).To(BeTrue())
 				})
 
-				It("should not be able to get objects that haven't been watched previously", func() {
+				It("should not be able to get objects that haven't been watched previously", func(ctx SpecContext) {
 					By("getting the Kubernetes service")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-					Expect(errors.As(informerCache.Get(context.Background(), svcKey, svc), &errNotCached)).To(BeTrue())
+					Expect(errors.As(informerCache.Get(ctx, svcKey, svc), &errNotCached)).To(BeTrue())
 				})
 
-				It("should be able to list objects that are configured to be watched", func() {
+				It("should be able to list objects that are configured to be watched", func(ctx SpecContext) {
 					By("indicating that we need to watch services")
-					_, err := informerCache.GetInformer(context.Background(), &corev1.Service{})
+					_, err := informerCache.GetInformer(ctx, &corev1.Service{})
 					Expect(err).ToNot(HaveOccurred())
 
 					By("listing all services in the cluster")
 					svcList := &corev1.ServiceList{}
-					Expect(informerCache.List(context.Background(), svcList)).To(Succeed())
+					Expect(informerCache.List(ctx, svcList)).To(Succeed())
 
 					By("verifying that the returned service looks reasonable")
 					Expect(svcList.Items).To(HaveLen(1))
@@ -501,15 +506,15 @@ func CacheTestReaderFailOnMissingInformer(createCacheFunc func(config *rest.Conf
 					Expect(svcList.Items[0].Namespace).To(Equal("default"))
 				})
 
-				It("should be able to get objects that are configured to be watched", func() {
+				It("should be able to get objects that are configured to be watched", func(ctx SpecContext) {
 					By("indicating that we need to watch services")
-					_, err := informerCache.GetInformer(context.Background(), &corev1.Service{})
+					_, err := informerCache.GetInformer(ctx, &corev1.Service{})
 					Expect(err).ToNot(HaveOccurred())
 
 					By("getting the Kubernetes service")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-					Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+					Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 					By("verifying that the returned service looks reasonable")
 					Expect(svc.Name).To(Equal("kubernetes"))
@@ -524,23 +529,25 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 	Describe("non-blocking get test", func() {
 		var (
 			informerCache       cache.Cache
-			informerCacheCtx    context.Context
 			informerCacheCancel context.CancelFunc
 		)
-		BeforeEach(func() {
-			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background())
+		BeforeEach(func(ctx SpecContext) {
+			var informerCacheCtx context.Context
+			// Has to be derived from context.Background as it has to stay valid past the
+			// BeforeEach.
+			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background()) //nolint:forbidigo
 			Expect(cfg).NotTo(BeNil())
 
 			By("creating expected namespaces")
 			cl, err := client.New(cfg, client.Options{})
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNode(testNodeOne, cl)
+			err = ensureNode(ctx, testNodeOne, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceOne, cl)
+			err = ensureNamespace(ctx, testNamespaceOne, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceTwo, cl)
+			err = ensureNamespace(ctx, testNamespaceTwo, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceThree, cl)
+			err = ensureNamespace(ctx, testNamespaceThree, cl)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("creating the informer cache")
@@ -555,7 +562,7 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 				defer GinkgoRecover()
 				Expect(informerCache.Start(ctx)).To(Succeed())
 			}(informerCacheCtx)
-			Expect(informerCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+			Expect(informerCache.WaitForCacheSync(ctx)).To(BeTrue())
 		})
 
 		AfterEach(func() {
@@ -564,7 +571,7 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 		})
 
 		Describe("as an Informer", func() {
-			It("should be able to get informer for the object without blocking", func() {
+			It("should be able to get informer for the object without blocking", func(specCtx SpecContext) {
 				By("getting a shared index informer for a pod")
 				pod := &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -581,7 +588,7 @@ func NonBlockingGetTest(createCacheFunc func(config *rest.Config, opts cache.Opt
 					},
 				}
 
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(specCtx, 5*time.Second)
 				defer cancel()
 				sii, err := informerCache.GetInformer(ctx, pod, cache.BlockUntilSynced(false))
 				Expect(err).NotTo(HaveOccurred())
@@ -596,7 +603,6 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 	Describe("Cache test", func() {
 		var (
 			informerCache       cache.Cache
-			informerCacheCtx    context.Context
 			informerCacheCancel context.CancelFunc
 			knownPod1           client.Object
 			knownPod2           client.Object
@@ -606,30 +612,33 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 			knownPod6           client.Object
 		)
 
-		BeforeEach(func() {
-			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background())
+		BeforeEach(func(ctx SpecContext) {
+			var informerCacheCtx context.Context
+			// Has to be derived from context.Background as it has to stay valid past the
+			// BeforeEach.
+			informerCacheCtx, informerCacheCancel = context.WithCancel(context.Background()) //nolint:forbidigo
 			Expect(cfg).NotTo(BeNil())
 
 			By("creating three pods")
 			cl, err := client.New(cfg, client.Options{})
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNode(testNodeOne, cl)
+			err = ensureNode(ctx, testNodeOne, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNode(testNodeTwo, cl)
+			err = ensureNode(ctx, testNodeTwo, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceOne, cl)
+			err = ensureNamespace(ctx, testNamespaceOne, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceTwo, cl)
+			err = ensureNamespace(ctx, testNamespaceTwo, cl)
 			Expect(err).NotTo(HaveOccurred())
-			err = ensureNamespace(testNamespaceThree, cl)
+			err = ensureNamespace(ctx, testNamespaceThree, cl)
 			Expect(err).NotTo(HaveOccurred())
 			// Includes restart policy since these objects are indexed on this field.
-			knownPod1 = createPod("test-pod-1", testNamespaceOne, corev1.RestartPolicyNever)
-			knownPod2 = createPod("test-pod-2", testNamespaceTwo, corev1.RestartPolicyAlways)
-			knownPod3 = createPodWithLabels("test-pod-3", testNamespaceTwo, corev1.RestartPolicyOnFailure, map[string]string{"common-label": "common"})
-			knownPod4 = createPodWithLabels("test-pod-4", testNamespaceThree, corev1.RestartPolicyNever, map[string]string{"common-label": "common"})
-			knownPod5 = createPod("test-pod-5", testNamespaceOne, corev1.RestartPolicyNever)
-			knownPod6 = createPod("test-pod-6", testNamespaceTwo, corev1.RestartPolicyAlways)
+			knownPod1 = createPod(ctx, "test-pod-1", testNamespaceOne, corev1.RestartPolicyNever)
+			knownPod2 = createPod(ctx, "test-pod-2", testNamespaceTwo, corev1.RestartPolicyAlways)
+			knownPod3 = createPodWithLabels(ctx, "test-pod-3", testNamespaceTwo, corev1.RestartPolicyOnFailure, map[string]string{"common-label": "common"})
+			knownPod4 = createPodWithLabels(ctx, "test-pod-4", testNamespaceThree, corev1.RestartPolicyNever, map[string]string{"common-label": "common"})
+			knownPod5 = createPod(ctx, "test-pod-5", testNamespaceOne, corev1.RestartPolicyNever)
+			knownPod6 = createPod(ctx, "test-pod-6", testNamespaceTwo, corev1.RestartPolicyAlways)
 
 			podGVK := schema.GroupVersionKind{
 				Kind:    "Pod",
@@ -652,27 +661,27 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				defer GinkgoRecover()
 				Expect(informerCache.Start(ctx)).To(Succeed())
 			}(informerCacheCtx)
-			Expect(informerCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+			Expect(informerCache.WaitForCacheSync(ctx)).To(BeTrue())
 		})
 
-		AfterEach(func() {
+		AfterEach(func(ctx SpecContext) {
 			By("cleaning up created pods")
-			deletePod(knownPod1)
-			deletePod(knownPod2)
-			deletePod(knownPod3)
-			deletePod(knownPod4)
-			deletePod(knownPod5)
-			deletePod(knownPod6)
+			deletePod(ctx, knownPod1)
+			deletePod(ctx, knownPod2)
+			deletePod(ctx, knownPod3)
+			deletePod(ctx, knownPod4)
+			deletePod(ctx, knownPod5)
+			deletePod(ctx, knownPod6)
 
 			informerCacheCancel()
 		})
 
 		Describe("as a Reader", func() {
 			Context("with structured objects", func() {
-				It("should be able to list objects that haven't been watched previously", func() {
+				It("should be able to list objects that haven't been watched previously", func(ctx SpecContext) {
 					By("listing all services in the cluster")
 					listObj := &corev1.ServiceList{}
-					Expect(informerCache.List(context.Background(), listObj)).To(Succeed())
+					Expect(informerCache.List(ctx, listObj)).To(Succeed())
 
 					By("verifying that the returned list contains the Kubernetes service")
 					// NB: kubernetes default service is automatically created in testenv.
@@ -688,22 +697,22 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(hasKubeService).To(BeTrue())
 				})
 
-				It("should be able to get objects that haven't been watched previously", func() {
+				It("should be able to get objects that haven't been watched previously", func(ctx SpecContext) {
 					By("getting the Kubernetes service")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-					Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+					Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 					By("verifying that the returned service looks reasonable")
 					Expect(svc.Name).To(Equal("kubernetes"))
 					Expect(svc.Namespace).To(Equal("default"))
 				})
 
-				It("should support filtering by labels in a single namespace", func() {
+				It("should support filtering by labels in a single namespace", func(ctx SpecContext) {
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
 					out := corev1.PodList{}
-					Expect(informerCache.List(context.Background(), &out,
+					Expect(informerCache.List(ctx, &out,
 						client.InNamespace(testNamespaceTwo),
 						client.MatchingLabels(map[string]string{"test-label": "test-pod-2"}))).To(Succeed())
 
@@ -714,16 +723,16 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.Labels["test-label"]).To(Equal("test-pod-2"))
 				})
 
-				It("should support filtering by labels from multiple namespaces", func() {
+				It("should support filtering by labels from multiple namespaces", func(ctx SpecContext) {
 					By("creating another pod with the same label but different namespace")
-					anotherPod := createPod("test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
-					defer deletePod(anotherPod)
+					anotherPod := createPod(ctx, "test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
+					defer deletePod(ctx, anotherPod)
 
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
 					out := corev1.PodList{}
 					labels := map[string]string{"test-label": "test-pod-2"}
-					Expect(informerCache.List(context.Background(), &out, client.MatchingLabels(labels))).To(Succeed())
+					Expect(informerCache.List(ctx, &out, client.MatchingLabels(labels))).To(Succeed())
 
 					By("verifying multiple pods with the same label in different namespaces are returned")
 					Expect(out.Items).NotTo(BeEmpty())
@@ -734,10 +743,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				})
 
 				if !isPodDisableDeepCopy(opts) {
-					It("should be able to list objects with GVK populated", func() {
+					It("should be able to list objects with GVK populated", func(ctx SpecContext) {
 						By("listing pods")
 						out := &corev1.PodList{}
-						Expect(informerCache.List(context.Background(), out)).To(Succeed())
+						Expect(informerCache.List(ctx, out)).To(Succeed())
 
 						By("verifying that the returned pods have GVK populated")
 						Expect(out.Items).NotTo(BeEmpty())
@@ -748,10 +757,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					})
 				}
 
-				It("should be able to list objects by namespace", func() {
+				It("should be able to list objects by namespace", func(ctx SpecContext) {
 					By("listing pods in test-namespace-1")
 					listObj := &corev1.PodList{}
-					Expect(informerCache.List(context.Background(), listObj,
+					Expect(informerCache.List(ctx, listObj,
 						client.InNamespace(testNamespaceOne))).To(Succeed())
 
 					By("verifying that the returned pods are in test-namespace-1")
@@ -763,11 +772,11 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				})
 
 				if !isPodDisableDeepCopy(opts) {
-					It("should deep copy the object unless told otherwise", func() {
+					It("should deep copy the object unless told otherwise", func(ctx SpecContext) {
 						By("retrieving a specific pod from the cache")
 						out := &corev1.Pod{}
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
-						Expect(informerCache.Get(context.Background(), podKey, out)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out)).To(Succeed())
 
 						By("verifying the retrieved pod is equal to a known pod")
 						Expect(out).To(Equal(knownPod2))
@@ -779,13 +788,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Expect(out).NotTo(Equal(knownPod2))
 					})
 				} else {
-					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func() {
+					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func(ctx SpecContext) {
 						By("getting a specific pod from the cache twice")
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
 						out1 := &corev1.Pod{}
-						Expect(informerCache.Get(context.Background(), podKey, out1)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out1)).To(Succeed())
 						out2 := &corev1.Pod{}
-						Expect(informerCache.Get(context.Background(), podKey, out2)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out2)).To(Succeed())
 
 						By("verifying the pointer fields in pod have the same addresses")
 						Expect(out1).To(Equal(out2))
@@ -793,9 +802,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 						By("listing pods from the cache twice")
 						outList1 := &corev1.PodList{}
-						Expect(informerCache.List(context.Background(), outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
 						outList2 := &corev1.PodList{}
-						Expect(informerCache.List(context.Background(), outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
 
 						By("verifying the pointer fields in pod have the same addresses")
 						Expect(outList1.Items).To(HaveLen(len(outList2.Items)))
@@ -810,81 +819,81 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					})
 				}
 
-				It("should return an error if the object is not found", func() {
+				It("should return an error if the object is not found", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: testNamespaceOne, Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				})
 
-				It("should return an error if getting object in unwatched namespace", func() {
+				It("should return an error if getting object in unwatched namespace", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "unknown", Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("should return an error when context is cancelled", func() {
+				It("should return an error when context is cancelled", func(specCtx SpecContext) {
 					By("cancelling the context")
-					informerCacheCancel()
+					ctx := cancelledCtx(specCtx)
 
 					By("listing pods in test-namespace-1 with a cancelled context")
 					listObj := &corev1.PodList{}
-					err := informerCache.List(informerCacheCtx, listObj, client.InNamespace(testNamespaceOne))
+					err := informerCache.List(ctx, listObj, client.InNamespace(testNamespaceOne))
 
 					By("verifying that an error is returned")
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsTimeout(err)).To(BeTrue())
 				})
 
-				It("should set the Limit option and limit number of objects to Limit when List is called", func() {
+				It("should set the Limit option and limit number of objects to Limit when List is called", func(ctx SpecContext) {
 					opts := &client.ListOptions{Limit: int64(3)}
 					By("verifying that only Limit (3) number of objects are retrieved from the cache")
 					listObj := &corev1.PodList{}
-					Expect(informerCache.List(context.Background(), listObj, opts)).To(Succeed())
+					Expect(informerCache.List(ctx, listObj, opts)).To(Succeed())
 					Expect(listObj.Items).Should(HaveLen(3))
 				})
 
-				It("should return a limited result set matching the correct label", func() {
+				It("should return a limited result set matching the correct label", func(ctx SpecContext) {
 					listObj := &corev1.PodList{}
 					labelOpt := client.MatchingLabels(map[string]string{"common-label": "common"})
 					limitOpt := client.Limit(1)
 					By("verifying that only Limit (1) number of objects are retrieved from the cache")
-					Expect(informerCache.List(context.Background(), listObj, labelOpt, limitOpt)).To(Succeed())
+					Expect(informerCache.List(ctx, listObj, labelOpt, limitOpt)).To(Succeed())
 					Expect(listObj.Items).Should(HaveLen(1))
 				})
 
-				It("should return an error if pagination is used", func() {
+				It("should return an error if pagination is used", func(ctx SpecContext) {
 					listObj := &corev1.PodList{}
 					By("verifying that the first list works and returns a sentinel continue")
-					err := informerCache.List(context.Background(), listObj)
+					err := informerCache.List(ctx, listObj)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(listObj.Continue).To(Equal("continue-not-supported"))
 
 					By("verifying that an error is returned")
-					err = informerCache.List(context.Background(), listObj, client.Continue(listObj.Continue))
+					err = informerCache.List(ctx, listObj, client.Continue(listObj.Continue))
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("continue list option is not supported by the cache"))
 				})
 
-				It("should return an error if the continue list options is set", func() {
+				It("should return an error if the continue list options is set", func(ctx SpecContext) {
 					listObj := &corev1.PodList{}
 					continueOpt := client.Continue("token")
 					By("verifying that an error is returned")
-					err := informerCache.List(context.Background(), listObj, continueOpt)
+					err := informerCache.List(ctx, listObj, continueOpt)
 					Expect(err).To(HaveOccurred())
 				})
 			})
 
 			Context("with unstructured objects", func() {
-				It("should be able to list objects that haven't been watched previously", func() {
+				It("should be able to list objects that haven't been watched previously", func(ctx SpecContext) {
 					By("listing all services in the cluster")
 					listObj := &unstructured.UnstructuredList{}
 					listObj.SetGroupVersionKind(schema.GroupVersionKind{
@@ -892,7 +901,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "ServiceList",
 					})
-					err := informerCache.List(context.Background(), listObj)
+					err := informerCache.List(ctx, listObj)
 					Expect(err).To(Succeed())
 
 					By("verifying that the returned list contains the Kubernetes service")
@@ -908,7 +917,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 					Expect(hasKubeService).To(BeTrue())
 				})
-				It("should be able to get objects that haven't been watched previously", func() {
+				It("should be able to get objects that haven't been watched previously", func(ctx SpecContext) {
 					By("getting the Kubernetes service")
 					svc := &unstructured.Unstructured{}
 					svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -917,14 +926,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "Service",
 					})
 					svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-					Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+					Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 					By("verifying that the returned service looks reasonable")
 					Expect(svc.GetName()).To(Equal("kubernetes"))
 					Expect(svc.GetNamespace()).To(Equal("default"))
 				})
 
-				It("should support filtering by labels in a single namespace", func() {
+				It("should support filtering by labels in a single namespace", func(ctx SpecContext) {
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
 					out := unstructured.UnstructuredList{}
@@ -933,7 +942,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					err := informerCache.List(context.Background(), &out,
+					err := informerCache.List(ctx, &out,
 						client.InNamespace(testNamespaceTwo),
 						client.MatchingLabels(map[string]string{"test-label": "test-pod-2"}))
 					Expect(err).To(Succeed())
@@ -945,10 +954,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.GetLabels()["test-label"]).To(Equal("test-pod-2"))
 				})
 
-				It("should support filtering by labels from multiple namespaces", func() {
+				It("should support filtering by labels from multiple namespaces", func(ctx SpecContext) {
 					By("creating another pod with the same label but different namespace")
-					anotherPod := createPod("test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
-					defer deletePod(anotherPod)
+					anotherPod := createPod(ctx, "test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
+					defer deletePod(ctx, anotherPod)
 
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
@@ -959,7 +968,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "PodList",
 					})
 					labels := map[string]string{"test-label": "test-pod-2"}
-					err := informerCache.List(context.Background(), &out, client.MatchingLabels(labels))
+					err := informerCache.List(ctx, &out, client.MatchingLabels(labels))
 					Expect(err).To(Succeed())
 
 					By("verifying multiple pods with the same label in different namespaces are returned")
@@ -970,7 +979,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 				})
 
-				It("should be able to list objects by namespace", func() {
+				It("should be able to list objects by namespace", func(ctx SpecContext) {
 					By("listing pods in test-namespace-1")
 					listObj := &unstructured.UnstructuredList{}
 					listObj.SetGroupVersionKind(schema.GroupVersionKind{
@@ -978,7 +987,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					err := informerCache.List(context.Background(), listObj, client.InNamespace(testNamespaceOne))
+					err := informerCache.List(ctx, listObj, client.InNamespace(testNamespaceOne))
 					Expect(err).To(Succeed())
 
 					By("verifying that the returned pods are in test-namespace-1")
@@ -1016,7 +1025,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				}
 
 				for _, tc := range cacheRestrictSubTests {
-					It("should be able to restrict cache to a namespace "+tc.nameSuffix, func() {
+					It("should be able to restrict cache to a namespace "+tc.nameSuffix, func(ctx SpecContext) {
 						By("creating a namespaced cache")
 						namespacedCache, err := cache.New(cfg, tc.cacheOpts)
 						Expect(err).NotTo(HaveOccurred())
@@ -1024,9 +1033,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						By("running the cache and waiting for it to sync")
 						go func() {
 							defer GinkgoRecover()
-							Expect(namespacedCache.Start(informerCacheCtx)).To(Succeed())
+							Expect(namespacedCache.Start(ctx)).To(Succeed())
 						}()
-						Expect(namespacedCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+						Expect(namespacedCache.WaitForCacheSync(ctx)).To(BeTrue())
 
 						By("listing pods in all namespaces")
 						out := &unstructured.UnstructuredList{}
@@ -1036,7 +1045,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							Kind:    "PodList",
 						})
 						for range 2 {
-							Expect(namespacedCache.List(context.Background(), out)).To(Succeed())
+							Expect(namespacedCache.List(ctx, out)).To(Succeed())
 
 							By("verifying the returned pod is from the watched namespace")
 							Expect(out.Items).NotTo(BeEmpty())
@@ -1052,7 +1061,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							Version: "v1",
 							Kind:    "NodeList",
 						})
-						Expect(namespacedCache.List(context.Background(), nodeList)).To(Succeed())
+						Expect(namespacedCache.List(ctx, nodeList)).To(Succeed())
 
 						By("verifying the node list is not empty")
 						Expect(nodeList.Items).NotTo(BeEmpty())
@@ -1067,16 +1076,16 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 						By("verifying that getting the node works with an empty namespace")
 						key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-						Expect(namespacedCache.Get(context.Background(), key1, node)).To(Succeed())
+						Expect(namespacedCache.Get(ctx, key1, node)).To(Succeed())
 
 						By("verifying that the namespace is ignored when getting a cluster-scoped resource")
 						key2 := client.ObjectKey{Namespace: "random", Name: testNodeOne}
-						Expect(namespacedCache.Get(context.Background(), key2, node)).To(Succeed())
+						Expect(namespacedCache.Get(ctx, key2, node)).To(Succeed())
 					})
 				}
 
 				if !isPodDisableDeepCopy(opts) {
-					It("should deep copy the object unless told otherwise", func() {
+					It("should deep copy the object unless told otherwise", func(ctx SpecContext) {
 						By("retrieving a specific pod from the cache")
 						out := &unstructured.Unstructured{}
 						out.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1088,7 +1097,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Expect(kscheme.Scheme.Convert(knownPod2, uKnownPod2, nil)).To(Succeed())
 
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
-						Expect(informerCache.Get(context.Background(), podKey, out)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out)).To(Succeed())
 
 						By("verifying the retrieved pod is equal to a known pod")
 						Expect(out).To(Equal(uKnownPod2))
@@ -1101,15 +1110,15 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Expect(out).NotTo(Equal(knownPod2))
 					})
 				} else {
-					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func() {
+					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func(ctx SpecContext) {
 						By("getting a specific pod from the cache twice")
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
 						out1 := &unstructured.Unstructured{}
 						out1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-						Expect(informerCache.Get(context.Background(), podKey, out1)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out1)).To(Succeed())
 						out2 := &unstructured.Unstructured{}
 						out2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-						Expect(informerCache.Get(context.Background(), podKey, out2)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out2)).To(Succeed())
 
 						By("verifying the pointer fields in pod have the same addresses")
 						Expect(out1).To(Equal(out2))
@@ -1118,10 +1127,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						By("listing pods from the cache twice")
 						outList1 := &unstructured.UnstructuredList{}
 						outList1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"})
-						Expect(informerCache.List(context.Background(), outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
 						outList2 := &unstructured.UnstructuredList{}
 						outList2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"})
-						Expect(informerCache.List(context.Background(), outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
 
 						By("verifying the pointer fields in pod have the same addresses")
 						Expect(outList1.Items).To(HaveLen(len(outList2.Items)))
@@ -1136,7 +1145,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					})
 				}
 
-				It("should return an error if the object is not found", func() {
+				It("should return an error if the object is not found", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &unstructured.Unstructured{}
 					svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1147,20 +1156,20 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					svcKey := client.ObjectKey{Namespace: testNamespaceOne, Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				})
-				It("should return an error if getting object in unwatched namespace", func() {
+				It("should return an error if getting object in unwatched namespace", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "unknown", Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 				})
-				It("test multinamespaced cache for cluster scoped resources", func() {
+				It("test multinamespaced cache for cluster scoped resources", func(ctx SpecContext) {
 					By("creating a multinamespaced cache to watch specific namespaces")
 					m, err := cache.New(cfg, cache.Options{
 						DefaultNamespaces: map[string]cache.Config{
@@ -1173,16 +1182,16 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("running the cache and waiting it for sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(m.Start(informerCacheCtx)).To(Succeed())
+						Expect(m.Start(ctx)).To(Succeed())
 					}()
-					Expect(m.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(m.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("should be able to fetch cluster scoped resource")
 					node := &corev1.Node{}
 
 					By("verifying that getting the node works with an empty namespace")
 					key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-					Expect(m.Get(context.Background(), key1, node)).To(Succeed())
+					Expect(m.Get(ctx, key1, node)).To(Succeed())
 
 					By("verifying if the cluster scoped resources are not duplicated")
 					nodeList := &unstructured.UnstructuredList{}
@@ -1191,14 +1200,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "NodeList",
 					})
-					Expect(m.List(context.Background(), nodeList)).To(Succeed())
+					Expect(m.List(ctx, nodeList)).To(Succeed())
 
 					By("verifying the node list is not empty")
 					Expect(nodeList.Items).NotTo(BeEmpty())
 					Expect(len(nodeList.Items)).To(BeEquivalentTo(2))
 				})
 
-				It("should return an error if pagination is used", func() {
+				It("should return an error if pagination is used", func(ctx SpecContext) {
 					nodeList := &unstructured.UnstructuredList{}
 					nodeList.SetGroupVersionKind(schema.GroupVersionKind{
 						Group:   "",
@@ -1206,26 +1215,26 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "NodeList",
 					})
 					By("verifying that the first list works and returns a sentinel continue")
-					err := informerCache.List(context.Background(), nodeList)
+					err := informerCache.List(ctx, nodeList)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(nodeList.GetContinue()).To(Equal("continue-not-supported"))
 
 					By("verifying that an error is returned")
-					err = informerCache.List(context.Background(), nodeList, client.Continue(nodeList.GetContinue()))
+					err = informerCache.List(ctx, nodeList, client.Continue(nodeList.GetContinue()))
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("continue list option is not supported by the cache"))
 				})
 
-				It("should return an error if the continue list options is set", func() {
+				It("should return an error if the continue list options is set", func(ctx SpecContext) {
 					podList := &unstructured.Unstructured{}
 					continueOpt := client.Continue("token")
 					By("verifying that an error is returned")
-					err := informerCache.List(context.Background(), podList, continueOpt)
+					err := informerCache.List(ctx, podList, continueOpt)
 					Expect(err).To(HaveOccurred())
 				})
 			})
 			Context("with metadata-only objects", func() {
-				It("should be able to list objects that haven't been watched previously", func() {
+				It("should be able to list objects that haven't been watched previously", func(ctx SpecContext) {
 					By("listing all services in the cluster")
 					listObj := &metav1.PartialObjectMetadataList{}
 					listObj.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1233,7 +1242,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "ServiceList",
 					})
-					err := informerCache.List(context.Background(), listObj)
+					err := informerCache.List(ctx, listObj)
 					Expect(err).To(Succeed())
 
 					By("verifying that the returned list contains the Kubernetes service")
@@ -1249,7 +1258,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 					Expect(hasKubeService).To(BeTrue())
 				})
-				It("should be able to get objects that haven't been watched previously", func() {
+				It("should be able to get objects that haven't been watched previously", func(ctx SpecContext) {
 					By("getting the Kubernetes service")
 					svc := &metav1.PartialObjectMetadata{}
 					svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1258,14 +1267,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "Service",
 					})
 					svcKey := client.ObjectKey{Namespace: "default", Name: "kubernetes"}
-					Expect(informerCache.Get(context.Background(), svcKey, svc)).To(Succeed())
+					Expect(informerCache.Get(ctx, svcKey, svc)).To(Succeed())
 
 					By("verifying that the returned service looks reasonable")
 					Expect(svc.GetName()).To(Equal("kubernetes"))
 					Expect(svc.GetNamespace()).To(Equal("default"))
 				})
 
-				It("should support filtering by labels in a single namespace", func() {
+				It("should support filtering by labels in a single namespace", func(ctx SpecContext) {
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
 					out := metav1.PartialObjectMetadataList{}
@@ -1274,7 +1283,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					err := informerCache.List(context.Background(), &out,
+					err := informerCache.List(ctx, &out,
 						client.InNamespace(testNamespaceTwo),
 						client.MatchingLabels(map[string]string{"test-label": "test-pod-2"}))
 					Expect(err).To(Succeed())
@@ -1286,10 +1295,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.GetLabels()["test-label"]).To(Equal("test-pod-2"))
 				})
 
-				It("should support filtering by labels from multiple namespaces", func() {
+				It("should support filtering by labels from multiple namespaces", func(ctx SpecContext) {
 					By("creating another pod with the same label but different namespace")
-					anotherPod := createPod("test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
-					defer deletePod(anotherPod)
+					anotherPod := createPod(ctx, "test-pod-2", testNamespaceOne, corev1.RestartPolicyAlways)
+					defer deletePod(ctx, anotherPod)
 
 					By("listing pods with a particular label")
 					// NB: each pod has a "test-label": <pod-name>
@@ -1300,7 +1309,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "PodList",
 					})
 					labels := map[string]string{"test-label": "test-pod-2"}
-					err := informerCache.List(context.Background(), &out, client.MatchingLabels(labels))
+					err := informerCache.List(ctx, &out, client.MatchingLabels(labels))
 					Expect(err).To(Succeed())
 
 					By("verifying multiple pods with the same label in different namespaces are returned")
@@ -1311,7 +1320,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 				})
 
-				It("should be able to list objects by namespace", func() {
+				It("should be able to list objects by namespace", func(ctx SpecContext) {
 					By("listing pods in test-namespace-1")
 					listObj := &metav1.PartialObjectMetadataList{}
 					listObj.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1319,7 +1328,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					err := informerCache.List(context.Background(), listObj, client.InNamespace(testNamespaceOne))
+					err := informerCache.List(ctx, listObj, client.InNamespace(testNamespaceOne))
 					Expect(err).To(Succeed())
 
 					By("verifying that the returned pods are in test-namespace-1")
@@ -1330,7 +1339,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}
 				})
 
-				It("should be able to restrict cache to a namespace", func() {
+				It("should be able to restrict cache to a namespace", func(ctx SpecContext) {
 					By("creating a namespaced cache")
 					namespacedCache, err := cache.New(cfg, cache.Options{DefaultNamespaces: map[string]cache.Config{testNamespaceOne: {}}})
 					Expect(err).NotTo(HaveOccurred())
@@ -1338,9 +1347,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(namespacedCache.Start(informerCacheCtx)).To(Succeed())
+						Expect(namespacedCache.Start(ctx)).To(Succeed())
 					}()
-					Expect(namespacedCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(namespacedCache.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing pods in all namespaces")
 					out := &metav1.PartialObjectMetadataList{}
@@ -1349,7 +1358,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					Expect(namespacedCache.List(context.Background(), out)).To(Succeed())
+					Expect(namespacedCache.List(ctx, out)).To(Succeed())
 
 					By("verifying the returned pod is from the watched namespace")
 					Expect(out.Items).NotTo(BeEmpty())
@@ -1364,7 +1373,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "NodeList",
 					})
-					Expect(namespacedCache.List(context.Background(), nodeList)).To(Succeed())
+					Expect(namespacedCache.List(ctx, nodeList)).To(Succeed())
 
 					By("verifying the node list is not empty")
 					Expect(nodeList.Items).NotTo(BeEmpty())
@@ -1379,14 +1388,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying that getting the node works with an empty namespace")
 					key1 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-					Expect(namespacedCache.Get(context.Background(), key1, node)).To(Succeed())
+					Expect(namespacedCache.Get(ctx, key1, node)).To(Succeed())
 
 					By("verifying that the namespace is ignored when getting a cluster-scoped resource")
 					key2 := client.ObjectKey{Namespace: "random", Name: testNodeOne}
-					Expect(namespacedCache.Get(context.Background(), key2, node)).To(Succeed())
+					Expect(namespacedCache.Get(ctx, key2, node)).To(Succeed())
 				})
 
-				It("should be able to restrict cache to a namespace for namespaced object and to given selectors for non namespaced object", func() {
+				It("should be able to restrict cache to a namespace for namespaced object and to given selectors for non namespaced object", func(ctx SpecContext) {
 					By("creating a namespaced cache")
 					namespacedCache, err := cache.New(cfg, cache.Options{
 						DefaultNamespaces: map[string]cache.Config{testNamespaceOne: {}},
@@ -1401,9 +1410,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(namespacedCache.Start(informerCacheCtx)).To(Succeed())
+						Expect(namespacedCache.Start(ctx)).To(Succeed())
 					}()
-					Expect(namespacedCache.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(namespacedCache.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing pods in all namespaces")
 					out := &metav1.PartialObjectMetadataList{}
@@ -1412,7 +1421,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					Expect(namespacedCache.List(context.Background(), out)).To(Succeed())
+					Expect(namespacedCache.List(ctx, out)).To(Succeed())
 
 					By("verifying the returned pod is from the watched namespace")
 					Expect(out.Items).NotTo(BeEmpty())
@@ -1427,7 +1436,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "NodeList",
 					})
-					Expect(namespacedCache.List(context.Background(), nodeList)).To(Succeed())
+					Expect(namespacedCache.List(ctx, nodeList)).To(Succeed())
 
 					By("verifying the node list is not empty")
 					Expect(nodeList.Items).NotTo(BeEmpty())
@@ -1442,21 +1451,21 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying that getting the node works with an empty namespace")
 					key1 := client.ObjectKey{Namespace: "", Name: testNodeTwo}
-					Expect(namespacedCache.Get(context.Background(), key1, node)).To(Succeed())
+					Expect(namespacedCache.Get(ctx, key1, node)).To(Succeed())
 
 					By("verifying that the namespace is ignored when getting a cluster-scoped resource")
 					key2 := client.ObjectKey{Namespace: "random", Name: testNodeTwo}
-					Expect(namespacedCache.Get(context.Background(), key2, node)).To(Succeed())
+					Expect(namespacedCache.Get(ctx, key2, node)).To(Succeed())
 
 					By("verifying that an error is returned for node with not matching label")
 					key3 := client.ObjectKey{Namespace: "", Name: testNodeOne}
-					err = namespacedCache.Get(context.Background(), key3, node)
+					err = namespacedCache.Get(ctx, key3, node)
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				})
 
 				if !isPodDisableDeepCopy(opts) {
-					It("should deep copy the object unless told otherwise", func() {
+					It("should deep copy the object unless told otherwise", func(ctx SpecContext) {
 						By("retrieving a specific pod from the cache")
 						out := &metav1.PartialObjectMetadata{}
 						out.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1473,7 +1482,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						})
 
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
-						Expect(informerCache.Get(context.Background(), podKey, out)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out)).To(Succeed())
 
 						By("verifying the retrieved pod is equal to a known pod")
 						Expect(out).To(Equal(uKnownPod2))
@@ -1485,15 +1494,15 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Expect(out).NotTo(Equal(knownPod2))
 					})
 				} else {
-					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func() {
+					It("should not deep copy the object if UnsafeDisableDeepCopy is enabled", func(ctx SpecContext) {
 						By("getting a specific pod from the cache twice")
 						podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
 						out1 := &metav1.PartialObjectMetadata{}
 						out1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-						Expect(informerCache.Get(context.Background(), podKey, out1)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out1)).To(Succeed())
 						out2 := &metav1.PartialObjectMetadata{}
 						out2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
-						Expect(informerCache.Get(context.Background(), podKey, out2)).To(Succeed())
+						Expect(informerCache.Get(ctx, podKey, out2)).To(Succeed())
 
 						By("verifying the pods have the same pointer addresses")
 						By("verifying the pointer fields in pod have the same addresses")
@@ -1503,10 +1512,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						By("listing pods from the cache twice")
 						outList1 := &metav1.PartialObjectMetadataList{}
 						outList1.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"})
-						Expect(informerCache.List(context.Background(), outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList1, client.InNamespace(testNamespaceOne))).To(Succeed())
 						outList2 := &metav1.PartialObjectMetadataList{}
 						outList2.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PodList"})
-						Expect(informerCache.List(context.Background(), outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
+						Expect(informerCache.List(ctx, outList2, client.InNamespace(testNamespaceOne))).To(Succeed())
 
 						By("verifying the pointer fields in pod have the same addresses")
 						Expect(outList1.Items).To(HaveLen(len(outList2.Items)))
@@ -1521,7 +1530,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					})
 				}
 
-				It("should return an error if the object is not found", func() {
+				It("should return an error if the object is not found", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &metav1.PartialObjectMetadata{}
 					svc.SetGroupVersionKind(schema.GroupVersionKind{
@@ -1532,21 +1541,21 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					svcKey := client.ObjectKey{Namespace: testNamespaceOne, Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				})
-				It("should return an error if getting object in unwatched namespace", func() {
+				It("should return an error if getting object in unwatched namespace", func(ctx SpecContext) {
 					By("getting a service that does not exists")
 					svc := &corev1.Service{}
 					svcKey := client.ObjectKey{Namespace: "unknown", Name: "unknown"}
 
 					By("verifying that an error is returned")
-					err := informerCache.Get(context.Background(), svcKey, svc)
+					err := informerCache.Get(ctx, svcKey, svc)
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("should return an error if pagination is used", func() {
+				It("should return an error if pagination is used", func(ctx SpecContext) {
 					nodeList := &metav1.PartialObjectMetadataList{}
 					nodeList.SetGroupVersionKind(schema.GroupVersionKind{
 						Group:   "",
@@ -1554,12 +1563,12 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "NodeList",
 					})
 					By("verifying that the first list works and returns a sentinel continue")
-					err := informerCache.List(context.Background(), nodeList)
+					err := informerCache.List(ctx, nodeList)
 					Expect(err).ToNot(HaveOccurred())
 					Expect(nodeList.GetContinue()).To(Equal("continue-not-supported"))
 
 					By("verifying that an error is returned")
-					err = informerCache.List(context.Background(), nodeList, client.Continue(nodeList.GetContinue()))
+					err = informerCache.List(ctx, nodeList, client.Continue(nodeList.GetContinue()))
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("continue list option is not supported by the cache"))
 				})
@@ -1568,7 +1577,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				options      cache.Options
 				expectedPods []string
 			}
-			DescribeTable(" and cache with selectors", func(tc selectorsTestCase) {
+			DescribeTable(" and cache with selectors", func(ctx SpecContext, tc selectorsTestCase) {
 				By("creating the cache")
 				informer, err := cache.New(cfg, tc.options)
 				Expect(err).NotTo(HaveOccurred())
@@ -1576,13 +1585,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				By("running the cache and waiting for it to sync")
 				go func() {
 					defer GinkgoRecover()
-					Expect(informer.Start(informerCacheCtx)).To(Succeed())
+					Expect(informer.Start(ctx)).To(Succeed())
 				}()
-				Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+				Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 				By("Checking with structured")
 				obtainedStructuredPodList := corev1.PodList{}
-				Expect(informer.List(context.Background(), &obtainedStructuredPodList)).To(Succeed())
+				Expect(informer.List(ctx, &obtainedStructuredPodList)).To(Succeed())
 				Expect(obtainedStructuredPodList.Items).Should(WithTransform(func(pods []corev1.Pod) []string {
 					obtainedPodNames := []string{}
 					for _, pod := range pods {
@@ -1591,7 +1600,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					return obtainedPodNames
 				}, ConsistOf(tc.expectedPods)))
 				for _, pod := range obtainedStructuredPodList.Items {
-					Expect(informer.Get(context.Background(), client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
+					Expect(informer.Get(ctx, client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
 				}
 
 				By("Checking with unstructured")
@@ -1601,7 +1610,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Version: "v1",
 					Kind:    "PodList",
 				})
-				err = informer.List(context.Background(), &obtainedUnstructuredPodList)
+				err = informer.List(ctx, &obtainedUnstructuredPodList)
 				Expect(err).To(Succeed())
 				Expect(obtainedUnstructuredPodList.Items).Should(WithTransform(func(pods []unstructured.Unstructured) []string {
 					obtainedPodNames := []string{}
@@ -1611,7 +1620,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					return obtainedPodNames
 				}, ConsistOf(tc.expectedPods)))
 				for _, pod := range obtainedUnstructuredPodList.Items {
-					Expect(informer.Get(context.Background(), client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
+					Expect(informer.Get(ctx, client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
 				}
 
 				By("Checking with metadata")
@@ -1621,7 +1630,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Version: "v1",
 					Kind:    "PodList",
 				})
-				err = informer.List(context.Background(), &obtainedMetadataPodList)
+				err = informer.List(ctx, &obtainedMetadataPodList)
 				Expect(err).To(Succeed())
 				Expect(obtainedMetadataPodList.Items).Should(WithTransform(func(pods []metav1.PartialObjectMetadata) []string {
 					obtainedPodNames := []string{}
@@ -1631,7 +1640,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					return obtainedPodNames
 				}, ConsistOf(tc.expectedPods)))
 				for _, pod := range obtainedMetadataPodList.Items {
-					Expect(informer.Get(context.Background(), client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
+					Expect(informer.Get(ctx, client.ObjectKeyFromObject(&pod), &pod)).To(Succeed())
 				}
 			},
 				Entry("when selectors are empty it has to inform about all the pods", selectorsTestCase{
@@ -1916,14 +1925,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 			)
 		})
 		Describe("as an Informer", func() {
-			It("should error when starting the cache a second time", func() {
-				err := informerCache.Start(context.Background())
+			It("should error when starting the cache a second time", func(ctx SpecContext) {
+				err := informerCache.Start(ctx)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("informer already started"))
 			})
 
 			Context("with structured objects", func() {
-				It("should be able to get informer for the object", func() {
+				It("should be able to get informer for the object", func(ctx SpecContext) {
 					By("getting a shared index informer for a pod")
 					pod := &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1939,7 +1948,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							},
 						},
 					}
-					sii, err := informerCache.GetInformer(context.TODO(), pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
@@ -1954,13 +1963,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("adding an object")
 					cl, err := client.New(cfg, client.Options{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(cl.Create(context.Background(), pod)).To(Succeed())
-					defer deletePod(pod)
+					Expect(cl.Create(ctx, pod)).To(Succeed())
+					defer deletePod(ctx, pod)
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
 				})
-				It("should be able to stop and restart informers", func() {
+				It("should be able to stop and restart informers", func(ctx SpecContext) {
 					By("getting a shared index informer for a pod")
 					pod := &corev1.Pod{
 						ObjectMeta: metav1.ObjectMeta{
@@ -1976,18 +1985,18 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							},
 						},
 					}
-					sii, err := informerCache.GetInformer(context.TODO(), pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
 
 					By("removing the existing informer")
-					Expect(informerCache.RemoveInformer(context.TODO(), pod)).To(Succeed())
+					Expect(informerCache.RemoveInformer(ctx, pod)).To(Succeed())
 					Eventually(sii.IsStopped).WithTimeout(5 * time.Second).Should(BeTrue())
 
 					By("recreating the informer")
 
-					sii2, err := informerCache.GetInformer(context.TODO(), pod)
+					sii2, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii2).NotTo(BeNil())
 					Expect(sii2.HasSynced()).To(BeTrue())
@@ -1996,10 +2005,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(sii.IsStopped()).To(BeTrue())
 					Expect(sii2.IsStopped()).To(BeFalse())
 				})
-				It("should be able to get an informer by group/version/kind", func() {
+				It("should be able to get an informer by group/version/kind", func(ctx SpecContext) {
 					By("getting an shared index informer for gvk = core/v1/pod")
 					gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-					sii, err := informerCache.GetInformerForKind(context.TODO(), gvk)
+					sii, err := informerCache.GetInformerForKind(ctx, gvk)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
@@ -2028,13 +2037,13 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							},
 						},
 					}
-					Expect(cl.Create(context.Background(), pod)).To(Succeed())
-					defer deletePod(pod)
+					Expect(cl.Create(ctx, pod)).To(Succeed())
+					defer deletePod(ctx, pod)
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
 				})
-				It("should be able to index an object field then retrieve objects by that field", func() {
+				It("should be able to index an object field then retrieve objects by that field", func(ctx SpecContext) {
 					By("creating the cache")
 					informer, err := cache.New(cfg, cache.Options{})
 					Expect(err).NotTo(HaveOccurred())
@@ -2044,18 +2053,18 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					indexFunc := func(obj client.Object) []string {
 						return []string{string(obj.(*corev1.Pod).Spec.RestartPolicy)}
 					}
-					Expect(informer.IndexField(context.TODO(), pod, "spec.restartPolicy", indexFunc)).To(Succeed())
+					Expect(informer.IndexField(ctx, pod, "spec.restartPolicy", indexFunc)).To(Succeed())
 
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(informer.Start(informerCacheCtx)).To(Succeed())
+						Expect(informer.Start(ctx)).To(Succeed())
 					}()
-					Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing Pods with restartPolicyOnFailure")
 					listObj := &corev1.PodList{}
-					Expect(informer.List(context.Background(), listObj,
+					Expect(informer.List(ctx, listObj,
 						client.MatchingFields{"spec.restartPolicy": "OnFailure"})).To(Succeed())
 					By("verifying that the returned pods have correct restart policy")
 					Expect(listObj.Items).NotTo(BeEmpty())
@@ -2064,9 +2073,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.Name).To(Equal("test-pod-3"))
 				})
 
-				It("should allow for get informer to be cancelled", func() {
+				It("should allow for get informer to be cancelled", func(specCtx SpecContext) {
 					By("creating a context and cancelling it")
-					informerCacheCancel()
+					ctx, cancel := context.WithCancel(specCtx)
+					cancel()
 
 					By("getting a shared index informer for a pod with a cancelled context")
 					pod := &corev1.Pod{
@@ -2083,25 +2093,26 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 							},
 						},
 					}
-					sii, err := informerCache.GetInformer(informerCacheCtx, pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).To(HaveOccurred())
 					Expect(sii).To(BeNil())
 					Expect(apierrors.IsTimeout(err)).To(BeTrue())
 				})
 
-				It("should allow getting an informer by group/version/kind to be cancelled", func() {
+				It("should allow getting an informer by group/version/kind to be cancelled", func(specCtx SpecContext) {
 					By("creating a context and cancelling it")
-					informerCacheCancel()
+					ctx, cancel := context.WithCancel(specCtx)
+					cancel()
 
 					By("getting an shared index informer for gvk = core/v1/pod with a cancelled context")
 					gvk := schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}
-					sii, err := informerCache.GetInformerForKind(informerCacheCtx, gvk)
+					sii, err := informerCache.GetInformerForKind(ctx, gvk)
 					Expect(err).To(HaveOccurred())
 					Expect(sii).To(BeNil())
 					Expect(apierrors.IsTimeout(err)).To(BeTrue())
 				})
 
-				It("should be able not to change indexer values after indexing cluster-scope objects", func() {
+				It("should be able not to change indexer values after indexing cluster-scope objects", func(ctx SpecContext) {
 					By("creating the cache")
 					informer, err := cache.New(cfg, cache.Options{})
 					Expect(err).NotTo(HaveOccurred())
@@ -2113,18 +2124,18 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					indexFunc := func(obj client.Object) []string {
 						return indexerValues
 					}
-					Expect(informer.IndexField(context.TODO(), ns, fieldName, indexFunc)).To(Succeed())
+					Expect(informer.IndexField(ctx, ns, fieldName, indexFunc)).To(Succeed())
 
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(informer.Start(informerCacheCtx)).To(Succeed())
+						Expect(informer.Start(ctx)).To(Succeed())
 					}()
-					Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing Namespaces with fixed indexer")
 					listObj := &corev1.NamespaceList{}
-					Expect(informer.List(context.Background(), listObj,
+					Expect(informer.List(ctx, listObj,
 						client.MatchingFields{fieldName: "a"})).To(Succeed())
 					Expect(listObj.Items).NotTo(BeZero())
 
@@ -2135,7 +2146,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(indexerValues[2]).To(Equal("c"))
 				})
 
-				It("should be able to matching fields with multiple indexes", func() {
+				It("should be able to matching fields with multiple indexes", func(ctx SpecContext) {
 					By("creating the cache")
 					informer, err := cache.New(cfg, cache.Options{})
 					Expect(err).NotTo(HaveOccurred())
@@ -2146,42 +2157,42 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					indexFunc1 := func(obj client.Object) []string {
 						return []string{obj.(*corev1.Pod).Labels["common-label"]}
 					}
-					Expect(informer.IndexField(context.TODO(), pod, fieldName1, indexFunc1)).To(Succeed())
+					Expect(informer.IndexField(ctx, pod, fieldName1, indexFunc1)).To(Succeed())
 					By("indexing pods with restart policy before starting")
 					fieldName2 := "indexByPolicy"
 					indexFunc2 := func(obj client.Object) []string {
 						return []string{string(obj.(*corev1.Pod).Spec.RestartPolicy)}
 					}
-					Expect(informer.IndexField(context.TODO(), pod, fieldName2, indexFunc2)).To(Succeed())
+					Expect(informer.IndexField(ctx, pod, fieldName2, indexFunc2)).To(Succeed())
 
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(informer.Start(informerCacheCtx)).To(Succeed())
+						Expect(informer.Start(ctx)).To(Succeed())
 					}()
-					Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing pods with label index")
 					listObj := &corev1.PodList{}
-					Expect(informer.List(context.Background(), listObj,
+					Expect(informer.List(ctx, listObj,
 						client.MatchingFields{fieldName1: "common"})).To(Succeed())
 					Expect(listObj.Items).To(HaveLen(2))
 
 					By("listing pods with restart policy index")
 					listObj = &corev1.PodList{}
-					Expect(informer.List(context.Background(), listObj,
+					Expect(informer.List(ctx, listObj,
 						client.MatchingFields{fieldName2: string(corev1.RestartPolicyNever)})).To(Succeed())
 					Expect(listObj.Items).To(HaveLen(3))
 
 					By("listing pods with both fixed indexers 1 and 2")
 					listObj = &corev1.PodList{}
-					Expect(informer.List(context.Background(), listObj,
+					Expect(informer.List(ctx, listObj,
 						client.MatchingFields{fieldName1: "common", fieldName2: string(corev1.RestartPolicyNever)})).To(Succeed())
 					Expect(listObj.Items).To(HaveLen(1))
 				})
 			})
 			Context("with unstructured objects", func() {
-				It("should be able to get informer for the object", func() {
+				It("should be able to get informer for the object", func(ctx SpecContext) {
 					By("getting a shared index informer for a pod")
 
 					pod := &unstructured.Unstructured{
@@ -2203,7 +2214,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "Pod",
 					})
-					sii, err := informerCache.GetInformer(context.TODO(), pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
@@ -2218,14 +2229,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("adding an object")
 					cl, err := client.New(cfg, client.Options{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(cl.Create(context.Background(), pod)).To(Succeed())
-					defer deletePod(pod)
+					Expect(cl.Create(ctx, pod)).To(Succeed())
+					defer deletePod(ctx, pod)
 
 					By("verifying the object is received on the channel")
 					Eventually(out).Should(Receive(Equal(pod)))
 				})
 
-				It("should be able to stop and restart informers", func() {
+				It("should be able to stop and restart informers", func(ctx SpecContext) {
 					By("getting a shared index informer for a pod")
 					pod := &unstructured.Unstructured{
 						Object: map[string]interface{}{
@@ -2246,18 +2257,17 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "Pod",
 					})
-					sii, err := informerCache.GetInformer(context.TODO(), pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
 
 					By("removing the existing informer")
-					Expect(informerCache.RemoveInformer(context.TODO(), pod)).To(Succeed())
+					Expect(informerCache.RemoveInformer(ctx, pod)).To(Succeed())
 					Eventually(sii.IsStopped).WithTimeout(5 * time.Second).Should(BeTrue())
 
 					By("recreating the informer")
-
-					sii2, err := informerCache.GetInformer(context.TODO(), pod)
+					sii2, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii2).NotTo(BeNil())
 					Expect(sii2.HasSynced()).To(BeTrue())
@@ -2267,7 +2277,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(sii2.IsStopped()).To(BeFalse())
 				})
 
-				It("should be able to index an object field then retrieve objects by that field", func() {
+				It("should be able to index an object field then retrieve objects by that field", func(ctx SpecContext) {
 					By("creating the cache")
 					informer, err := cache.New(cfg, cache.Options{})
 					Expect(err).NotTo(HaveOccurred())
@@ -2290,14 +2300,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						}
 						return []string{fmt.Sprintf("%v", m["restartPolicy"])}
 					}
-					Expect(informer.IndexField(context.TODO(), pod, "spec.restartPolicy", indexFunc)).To(Succeed())
+					Expect(informer.IndexField(ctx, pod, "spec.restartPolicy", indexFunc)).To(Succeed())
 
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(informer.Start(informerCacheCtx)).To(Succeed())
+						Expect(informer.Start(ctx)).To(Succeed())
 					}()
-					Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing Pods with restartPolicyOnFailure")
 					listObj := &unstructured.UnstructuredList{}
@@ -2306,7 +2316,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "PodList",
 					})
-					err = informer.List(context.Background(), listObj,
+					err = informer.List(ctx, listObj,
 						client.MatchingFields{"spec.restartPolicy": "OnFailure"})
 					Expect(err).To(Succeed())
 
@@ -2317,9 +2327,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Expect(actual.GetName()).To(Equal("test-pod-3"))
 				})
 
-				It("should allow for get informer to be cancelled", func() {
+				It("should allow for get informer to be cancelled", func(specCtx SpecContext) {
 					By("cancelling the context")
-					informerCacheCancel()
+					ctx := cancelledCtx(specCtx)
 
 					By("getting a shared index informer for a pod with a cancelled context")
 					pod := &unstructured.Unstructured{}
@@ -2330,14 +2340,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Version: "v1",
 						Kind:    "Pod",
 					})
-					sii, err := informerCache.GetInformer(informerCacheCtx, pod)
+					sii, err := informerCache.GetInformer(ctx, pod)
 					Expect(err).To(HaveOccurred())
 					Expect(sii).To(BeNil())
 					Expect(apierrors.IsTimeout(err)).To(BeTrue())
 				})
 			})
 			Context("with metadata-only objects", func() {
-				It("should be able to get informer for the object", func() {
+				It("should be able to get informer for the object", func(ctx SpecContext) {
 					By("getting a shared index informer for a pod")
 
 					pod := &corev1.Pod{
@@ -2363,7 +2373,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "Pod",
 					})
 
-					sii, err := informerCache.GetInformer(context.TODO(), podMeta)
+					sii, err := informerCache.GetInformer(ctx, podMeta)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(sii).NotTo(BeNil())
 					Expect(sii.HasSynced()).To(BeTrue())
@@ -2378,8 +2388,8 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					By("adding an object")
 					cl, err := client.New(cfg, client.Options{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(cl.Create(context.Background(), pod)).To(Succeed())
-					defer deletePod(pod)
+					Expect(cl.Create(ctx, pod)).To(Succeed())
+					defer deletePod(ctx, pod)
 					// re-copy the result in so that we can match on it properly
 					pod.ObjectMeta.DeepCopyInto(&podMeta.ObjectMeta)
 
@@ -2387,7 +2397,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					Eventually(out).Should(Receive(Equal(podMeta)))
 				})
 
-				It("should be able to index an object field then retrieve objects by that field", func() {
+				It("should be able to index an object field then retrieve objects by that field", func(ctx SpecContext) {
 					By("creating the cache")
 					informer, err := cache.New(cfg, cache.Options{})
 					Expect(err).NotTo(HaveOccurred())
@@ -2403,14 +2413,14 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						metadata := obj.(*metav1.PartialObjectMetadata)
 						return []string{metadata.Labels["test-label"]}
 					}
-					Expect(informer.IndexField(context.TODO(), pod, "metadata.labels.test-label", indexFunc)).To(Succeed())
+					Expect(informer.IndexField(ctx, pod, "metadata.labels.test-label", indexFunc)).To(Succeed())
 
 					By("running the cache and waiting for it to sync")
 					go func() {
 						defer GinkgoRecover()
-						Expect(informer.Start(informerCacheCtx)).To(Succeed())
+						Expect(informer.Start(ctx)).To(Succeed())
 					}()
-					Expect(informer.WaitForCacheSync(informerCacheCtx)).To(BeTrue())
+					Expect(informer.WaitForCacheSync(ctx)).To(BeTrue())
 
 					By("listing Pods with restartPolicyOnFailure")
 					listObj := &metav1.PartialObjectMetadataList{}
@@ -2420,7 +2430,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 						Kind:    "PodList",
 					}
 					listObj.SetGroupVersionKind(gvk)
-					err = informer.List(context.Background(), listObj,
+					err = informer.List(ctx, listObj,
 						client.MatchingFields{"metadata.labels.test-label": "test-pod-3"})
 					Expect(err).To(Succeed())
 
@@ -2441,10 +2451,9 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 					}))
 				})
 
-				It("should allow for get informer to be cancelled", func() {
+				It("should allow for get informer to be cancelled", func(specContext SpecContext) {
 					By("creating a context and cancelling it")
-					ctx, cancel := context.WithCancel(context.Background())
-					cancel()
+					ctx := cancelledCtx(specContext)
 
 					By("getting a shared index informer for a pod with a cancelled context")
 					pod := &metav1.PartialObjectMetadata{}
@@ -2464,10 +2473,10 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 		})
 		Context("using UnsafeDisableDeepCopy", func() {
 			Describe("with ListOptions", func() {
-				It("should be able to change object in informer cache", func() {
+				It("should be able to change object in informer cache", func(ctx SpecContext) {
 					By("listing pods")
 					out := corev1.PodList{}
-					Expect(informerCache.List(context.Background(), &out, client.UnsafeDisableDeepCopy)).To(Succeed())
+					Expect(informerCache.List(ctx, &out, client.UnsafeDisableDeepCopy)).To(Succeed())
 					for _, item := range out.Items {
 						if strings.Compare(item.Name, "test-pod-3") == 0 { // test-pod-3 has labels
 							item.Labels["UnsafeDisableDeepCopy"] = "true"
@@ -2477,7 +2486,7 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 
 					By("verifying that the returned pods were changed")
 					out2 := corev1.PodList{}
-					Expect(informerCache.List(context.Background(), &out, client.UnsafeDisableDeepCopy)).To(Succeed())
+					Expect(informerCache.List(ctx, &out, client.UnsafeDisableDeepCopy)).To(Succeed())
 					for _, item := range out2.Items {
 						if strings.Compare(item.Name, "test-pod-3") == 0 {
 							Expect(item.Labels["UnsafeDisableDeepCopy"]).To(Equal("true"))
@@ -2487,16 +2496,16 @@ func CacheTest(createCacheFunc func(config *rest.Config, opts cache.Options) (ca
 				})
 			})
 			Describe("with GetOptions", func() {
-				It("should be able to change object in informer cache", func() {
+				It("should be able to change object in informer cache", func(ctx SpecContext) {
 					out := corev1.Pod{}
 					podKey := client.ObjectKey{Name: "test-pod-2", Namespace: testNamespaceTwo}
-					Expect(informerCache.Get(context.Background(), podKey, &out, client.UnsafeDisableDeepCopy)).To(Succeed())
+					Expect(informerCache.Get(ctx, podKey, &out, client.UnsafeDisableDeepCopy)).To(Succeed())
 
 					out.Labels["UnsafeDisableDeepCopy"] = "true"
 
 					By("verifying that the returned pod was changed")
 					out2 := corev1.Pod{}
-					Expect(informerCache.Get(context.Background(), podKey, &out2, client.UnsafeDisableDeepCopy)).To(Succeed())
+					Expect(informerCache.Get(ctx, podKey, &out2, client.UnsafeDisableDeepCopy)).To(Succeed())
 					Expect(out2.Labels["UnsafeDisableDeepCopy"]).To(Equal("true"))
 				})
 			})
@@ -2524,7 +2533,7 @@ var _ = Describe("TransformStripManagedFields", func() {
 })
 
 // ensureNamespace installs namespace of a given name if not exists.
-func ensureNamespace(namespace string, client client.Client) error {
+func ensureNamespace(ctx context.Context, namespace string, client client.Client) error {
 	ns := corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
@@ -2534,14 +2543,14 @@ func ensureNamespace(namespace string, client client.Client) error {
 			APIVersion: "v1",
 		},
 	}
-	err := client.Create(context.TODO(), &ns)
+	err := client.Create(ctx, &ns)
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}
 	return err
 }
 
-func ensureNode(name string, client client.Client) error {
+func ensureNode(ctx context.Context, name string, client client.Client) error {
 	node := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -2552,7 +2561,7 @@ func ensureNode(name string, client client.Client) error {
 			APIVersion: "v1",
 		},
 	}
-	err := client.Create(context.TODO(), &node)
+	err := client.Create(ctx, &node)
 	if apierrors.IsAlreadyExists(err) {
 		return nil
 	}
@@ -2573,4 +2582,10 @@ func isPodDisableDeepCopy(opts cache.Options) bool {
 		return *opts.DefaultUnsafeDisableDeepCopy
 	}
 	return false
+}
+
+func cancelledCtx(ctx context.Context) context.Context {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	return cancelCtx
 }

--- a/pkg/client/apiutil/apimachinery_test.go
+++ b/pkg/client/apiutil/apimachinery_test.go
@@ -104,7 +104,6 @@ func TestApiMachinery(t *testing.T) {
 			for _, runtimeGvk := range runtimeGvks {
 				t.Run("IsGVKNamespaced should report scope for "+runtimeGvk.name, func(t *testing.T) {
 					g := gmg.NewWithT(t)
-					ctx := context.Background()
 
 					httpClient, err := rest.HTTPClientFor(restCfg)
 					g.Expect(err).NotTo(gmg.HaveOccurred())
@@ -128,7 +127,7 @@ func TestApiMachinery(t *testing.T) {
 					g.Expect(scope).To(gmg.BeTrue())
 
 					// Register a new CRD at runtime.
-					crd := newCRD(ctx, g, c, runtimeGvk.gvk.Group, runtimeGvk.gvk.Kind, runtimeGvk.plural)
+					crd := newCRD(t.Context(), g, c, runtimeGvk.gvk.Group, runtimeGvk.gvk.Kind, runtimeGvk.plural)
 					version := crd.Spec.Versions[0]
 					version.Name = runtimeGvk.gvk.Version
 					version.Storage = true
@@ -136,9 +135,9 @@ func TestApiMachinery(t *testing.T) {
 					crd.Spec.Versions = []apiextensionsv1.CustomResourceDefinitionVersion{version}
 					crd.Spec.Scope = apiextensionsv1.NamespaceScoped
 
-					g.Expect(c.Create(ctx, crd)).To(gmg.Succeed())
+					g.Expect(c.Create(t.Context(), crd)).To(gmg.Succeed())
 					t.Cleanup(func() {
-						g.Expect(c.Delete(ctx, crd)).To(gmg.Succeed())
+						g.Expect(c.Delete(context.Background(), crd)).To(gmg.Succeed()) //nolint:forbidigo //t.Context is cancelled in t.Cleanup
 					})
 
 					// Wait until the CRD is registered.

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -107,19 +107,19 @@ var _ = Describe("Fake client", func() {
 	})
 
 	AssertClientWithoutIndexBehavior := func() {
-		It("should be able to Get", func() {
+		It("should be able to Get", func(ctx SpecContext) {
 			By("Getting a deployment")
 			namespacedName := types.NamespacedName{
 				Name:      "test-deployment",
 				Namespace: "ns1",
 			}
 			obj := &appsv1.Deployment{}
-			err := cl.Get(context.Background(), namespacedName, obj)
+			err := cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).To(Equal(dep))
 		})
 
-		It("should be able to Get using unstructured", func() {
+		It("should be able to Get using unstructured", func(ctx SpecContext) {
 			By("Getting a deployment")
 			namespacedName := types.NamespacedName{
 				Name:      "test-deployment",
@@ -128,50 +128,50 @@ var _ = Describe("Fake client", func() {
 			obj := &unstructured.Unstructured{}
 			obj.SetAPIVersion("apps/v1")
 			obj.SetKind("Deployment")
-			err := cl.Get(context.Background(), namespacedName, obj)
+			err := cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to List", func() {
+		It("should be able to List", func(ctx SpecContext) {
 			By("Listing all deployments in a namespace")
 			list := &appsv1.DeploymentList{}
-			err := cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err := cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(2))
 			Expect(list.Items).To(ConsistOf(*dep, *dep2))
 		})
 
-		It("should be able to List using unstructured list", func() {
+		It("should be able to List using unstructured list", func(ctx SpecContext) {
 			By("Listing all deployments in a namespace")
 			list := &unstructured.UnstructuredList{}
 			list.SetAPIVersion("apps/v1")
 			list.SetKind("DeploymentList")
-			err := cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err := cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("apps/v1"))
 			Expect(list.GetKind()).To(Equal("DeploymentList"))
 			Expect(list.Items).To(HaveLen(2))
 		})
 
-		It("should be able to List using unstructured list when setting a non-list kind", func() {
+		It("should be able to List using unstructured list when setting a non-list kind", func(ctx SpecContext) {
 			By("Listing all deployments in a namespace")
 			list := &unstructured.UnstructuredList{}
 			list.SetAPIVersion("apps/v1")
 			list.SetKind("Deployment")
-			err := cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err := cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("apps/v1"))
 			Expect(list.GetKind()).To(Equal("Deployment"))
 			Expect(list.Items).To(HaveLen(2))
 		})
 
-		It("should be able to retrieve registered objects that got manipulated as unstructured", func() {
+		It("should be able to retrieve registered objects that got manipulated as unstructured", func(ctx SpecContext) {
 			list := func() {
 				By("Listing all endpoints in a namespace")
 				list := &unstructured.UnstructuredList{}
 				list.SetAPIVersion("v1")
 				list.SetKind("EndpointsList")
-				err := cl.List(context.Background(), list, client.InNamespace("ns1"))
+				err := cl.List(ctx, list, client.InNamespace("ns1"))
 				Expect(err).ToNot(HaveOccurred())
 				Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("v1"))
 				Expect(list.GetKind()).To(Equal("EndpointsList"))
@@ -190,44 +190,44 @@ var _ = Describe("Fake client", func() {
 			By("Adding the object during client initialization")
 			cl = NewClientBuilder().WithRuntimeObjects(unstructuredEndpoint()).Build()
 			list()
-			Expect(cl.Delete(context.Background(), unstructuredEndpoint())).To(Succeed())
+			Expect(cl.Delete(ctx, unstructuredEndpoint())).To(Succeed())
 
 			By("Creating an object")
 			item := unstructuredEndpoint()
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 			list()
 
 			By("Updating the object")
 			item.SetAnnotations(map[string]string{"foo": "bar"})
-			err = cl.Update(context.Background(), item)
+			err = cl.Update(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 			list()
 
 			By("Patching the object")
 			old := item.DeepCopy()
 			item.SetAnnotations(map[string]string{"bar": "baz"})
-			err = cl.Patch(context.Background(), item, client.MergeFrom(old))
+			err = cl.Patch(ctx, item, client.MergeFrom(old))
 			Expect(err).ToNot(HaveOccurred())
 			list()
 		})
 
-		It("should be able to Create an unregistered type using unstructured", func() {
+		It("should be able to Create an unregistered type using unstructured", func(ctx SpecContext) {
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v1")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to Get an unregisted type using unstructured", func() {
+		It("should be able to Get an unregisted type using unstructured", func(ctx SpecContext) {
 			By("Creating an object of an unregistered type")
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v2")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting and the object")
@@ -235,43 +235,43 @@ var _ = Describe("Fake client", func() {
 			item.SetAPIVersion("custom/v2")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(item), item)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to List an unregistered type using unstructured with ListKind", func() {
+		It("should be able to List an unregistered type using unstructured with ListKind", func(ctx SpecContext) {
 			list := &unstructured.UnstructuredList{}
 			list.SetAPIVersion("custom/v3")
 			list.SetKind("ImageList")
-			err := cl.List(context.Background(), list)
+			err := cl.List(ctx, list)
 			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("custom/v3"))
 			Expect(list.GetKind()).To(Equal("ImageList"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to List an unregistered type using unstructured with Kind", func() {
+		It("should be able to List an unregistered type using unstructured with Kind", func(ctx SpecContext) {
 			list := &unstructured.UnstructuredList{}
 			list.SetAPIVersion("custom/v4")
 			list.SetKind("Image")
-			err := cl.List(context.Background(), list)
+			err := cl.List(ctx, list)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("custom/v4"))
 			Expect(list.GetKind()).To(Equal("Image"))
 		})
 
-		It("should be able to Update an unregistered type using unstructured", func() {
+		It("should be able to Update an unregistered type using unstructured", func(ctx SpecContext) {
 			By("Creating an object of an unregistered type")
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v5")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Updating the object")
 			err = unstructured.SetNestedField(item.Object, int64(2), "spec", "replicas")
 			Expect(err).ToNot(HaveOccurred())
-			err = cl.Update(context.Background(), item)
+			err = cl.Update(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
@@ -279,7 +279,7 @@ var _ = Describe("Fake client", func() {
 			item.SetAPIVersion("custom/v5")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(item), item)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Inspecting the object")
@@ -289,20 +289,20 @@ var _ = Describe("Fake client", func() {
 			Expect(value).To(Equal(int64(2)))
 		})
 
-		It("should be able to Patch an unregistered type using unstructured", func() {
+		It("should be able to Patch an unregistered type using unstructured", func(ctx SpecContext) {
 			By("Creating an object of an unregistered type")
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v6")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Updating the object")
 			original := item.DeepCopy()
 			err = unstructured.SetNestedField(item.Object, int64(2), "spec", "replicas")
 			Expect(err).ToNot(HaveOccurred())
-			err = cl.Patch(context.Background(), item, client.MergeFrom(original))
+			err = cl.Patch(ctx, item, client.MergeFrom(original))
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
@@ -310,7 +310,7 @@ var _ = Describe("Fake client", func() {
 			item.SetAPIVersion("custom/v6")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(item), item)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Inspecting the object")
@@ -320,17 +320,17 @@ var _ = Describe("Fake client", func() {
 			Expect(value).To(Equal(int64(2)))
 		})
 
-		It("should be able to Delete an unregistered type using unstructured", func() {
+		It("should be able to Delete an unregistered type using unstructured", func(ctx SpecContext) {
 			By("Creating an object of an unregistered type")
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v7")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err := cl.Create(context.Background(), item)
+			err := cl.Create(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting the object")
-			err = cl.Delete(context.Background(), item)
+			err = cl.Delete(ctx, item)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
@@ -338,11 +338,11 @@ var _ = Describe("Fake client", func() {
 			item.SetAPIVersion("custom/v7")
 			item.SetKind("Image")
 			item.SetName("my-item")
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(item), item)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should be able to retrieve objects by PartialObjectMetadata", func() {
+		It("should be able to retrieve objects by PartialObjectMetadata", func(ctx SpecContext) {
 			By("Creating a Resource")
 			secret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -350,7 +350,7 @@ var _ = Describe("Fake client", func() {
 					Namespace: "bar",
 				},
 			}
-			err := cl.Create(context.Background(), secret)
+			err := cl.Create(ctx, secret)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Fetching the resource using a PartialObjectMeta")
@@ -362,17 +362,17 @@ var _ = Describe("Fake client", func() {
 			}
 			partialObjMeta.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Secret"))
 
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(partialObjMeta), partialObjMeta)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(partialObjMeta), partialObjMeta)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(partialObjMeta.Kind).To(Equal("Secret"))
 			Expect(partialObjMeta.APIVersion).To(Equal("v1"))
 		})
 
-		It("should support filtering by labels and their values", func() {
+		It("should support filtering by labels and their values", func(ctx SpecContext) {
 			By("Listing deployments with a particular label and value")
 			list := &appsv1.DeploymentList{}
-			err := cl.List(context.Background(), list, client.InNamespace("ns1"),
+			err := cl.List(ctx, list, client.InNamespace("ns1"),
 				client.MatchingLabels(map[string]string{
 					"test-label": "label-value",
 				}))
@@ -381,17 +381,17 @@ var _ = Describe("Fake client", func() {
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
-		It("should support filtering by label existence", func() {
+		It("should support filtering by label existence", func(ctx SpecContext) {
 			By("Listing deployments with a particular label")
 			list := &appsv1.DeploymentList{}
-			err := cl.List(context.Background(), list, client.InNamespace("ns1"),
+			err := cl.List(ctx, list, client.InNamespace("ns1"),
 				client.HasLabels{"test-label"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
-		It("should be able to Create", func() {
+		It("should be able to Create", func(ctx SpecContext) {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -399,7 +399,7 @@ var _ = Describe("Fake client", func() {
 					Namespace: "ns2",
 				},
 			}
-			err := cl.Create(context.Background(), newcm)
+			err := cl.Create(ctx, newcm)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the new configmap")
@@ -408,13 +408,13 @@ var _ = Describe("Fake client", func() {
 				Namespace: "ns2",
 			}
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).To(Equal(newcm))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1"))
 		})
 
-		It("should error on create with set resourceVersion", func() {
+		It("should error on create with set resourceVersion", func(ctx SpecContext) {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -423,44 +423,44 @@ var _ = Describe("Fake client", func() {
 					ResourceVersion: "1",
 				},
 			}
-			err := cl.Create(context.Background(), newcm)
+			err := cl.Create(ctx, newcm)
 			Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 		})
 
-		It("should not change the submitted object if Create failed", func() {
+		It("should not change the submitted object if Create failed", func(ctx SpecContext) {
 			By("Trying to create an existing configmap")
 			submitted := cm.DeepCopy()
 			submitted.ResourceVersion = ""
 			submittedReference := submitted.DeepCopy()
-			err := cl.Create(context.Background(), submitted)
+			err := cl.Create(ctx, submitted)
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
 			Expect(submitted).To(BeComparableTo(submittedReference))
 		})
 
-		It("should error on Create with empty Name", func() {
+		It("should error on Create with empty Name", func(ctx SpecContext) {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns2",
 				},
 			}
-			err := cl.Create(context.Background(), newcm)
+			err := cl.Create(ctx, newcm)
 			Expect(err.Error()).To(Equal("ConfigMap \"\" is invalid: metadata.name: Required value: name is required"))
 		})
 
-		It("should error on Update with empty Name", func() {
+		It("should error on Update with empty Name", func(ctx SpecContext) {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "ns2",
 				},
 			}
-			err := cl.Update(context.Background(), newcm)
+			err := cl.Update(ctx, newcm)
 			Expect(err.Error()).To(Equal("ConfigMap \"\" is invalid: metadata.name: Required value: name is required"))
 		})
 
-		It("should be able to Create with GenerateName", func() {
+		It("should be able to Create with GenerateName", func(ctx SpecContext) {
 			By("Creating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -471,12 +471,12 @@ var _ = Describe("Fake client", func() {
 					},
 				},
 			}
-			err := cl.Create(context.Background(), newcm)
+			err := cl.Create(ctx, newcm)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Listing configmaps with a particular label")
 			list := &corev1.ConfigMapList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns2"),
+			err = cl.List(ctx, list, client.InNamespace("ns2"),
 				client.MatchingLabels(map[string]string{
 					"test-label": "label-value",
 				}))
@@ -485,7 +485,7 @@ var _ = Describe("Fake client", func() {
 			Expect(list.Items[0].Name).NotTo(BeEmpty())
 		})
 
-		It("should be able to Update", func() {
+		It("should be able to Update", func(ctx SpecContext) {
 			By("Updating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -497,7 +497,7 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Update(context.Background(), newcm)
+			err := cl.Update(ctx, newcm)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the new configmap")
@@ -506,13 +506,13 @@ var _ = Describe("Fake client", func() {
 				Namespace: "ns2",
 			}
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).To(Equal(newcm))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1000"))
 		})
 
-		It("should allow updates with non-set ResourceVersion for a resource that allows unconditional updates", func() {
+		It("should allow updates with non-set ResourceVersion for a resource that allows unconditional updates", func(ctx SpecContext) {
 			By("Updating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -523,7 +523,7 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Update(context.Background(), newcm)
+			err := cl.Update(ctx, newcm)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the configmap")
@@ -532,13 +532,13 @@ var _ = Describe("Fake client", func() {
 				Namespace: "ns2",
 			}
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).To(Equal(newcm))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1000"))
 		})
 
-		It("should allow patch when the patch sets RV to 'null'", func() {
+		It("should allow patch when the patch sets RV to 'null'", func(ctx SpecContext) {
 			cl := NewClientBuilder().Build()
 			original := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -546,7 +546,7 @@ var _ = Describe("Fake client", func() {
 					Namespace: "ns2",
 				}}
 
-			err := cl.Create(context.Background(), original)
+			err := cl.Create(ctx, original)
 			Expect(err).ToNot(HaveOccurred())
 
 			newObj := &corev1.ConfigMap{
@@ -558,14 +558,14 @@ var _ = Describe("Fake client", func() {
 					},
 				}}
 
-			Expect(cl.Patch(context.Background(), newObj, client.MergeFrom(original))).To(Succeed())
+			Expect(cl.Patch(ctx, newObj, client.MergeFrom(original))).To(Succeed())
 
 			patched := &corev1.ConfigMap{}
-			Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(original), patched)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(original), patched)).To(Succeed())
 			Expect(patched.Annotations).To(Equal(map[string]string{"foo": "bar"}))
 		})
 
-		It("should reject updates with non-set ResourceVersion for a resource that doesn't allow unconditional updates", func() {
+		It("should reject updates with non-set ResourceVersion for a resource that doesn't allow unconditional updates", func(ctx SpecContext) {
 			By("Creating a new binding")
 			binding := &corev1.Binding{
 				ObjectMeta: metav1.ObjectMeta{
@@ -579,7 +579,7 @@ var _ = Describe("Fake client", func() {
 					Name:       cm.Name,
 				},
 			}
-			Expect(cl.Create(context.Background(), binding)).To(Succeed())
+			Expect(cl.Create(ctx, binding)).To(Succeed())
 
 			By("Updating the binding with a new resource lacking resource version")
 			newBinding := &corev1.Binding{
@@ -592,10 +592,10 @@ var _ = Describe("Fake client", func() {
 					Name:      "blue",
 				},
 			}
-			Expect(cl.Update(context.Background(), newBinding)).NotTo(Succeed())
+			Expect(cl.Update(ctx, newBinding)).NotTo(Succeed())
 		})
 
-		It("should allow create on update for a resource that allows create on update", func() {
+		It("should allow create on update for a resource that allows create on update", func(ctx SpecContext) {
 			By("Creating a new lease with update")
 			lease := &coordinationv1.Lease{
 				ObjectMeta: metav1.ObjectMeta{
@@ -604,7 +604,7 @@ var _ = Describe("Fake client", func() {
 				},
 				Spec: coordinationv1.LeaseSpec{},
 			}
-			Expect(cl.Create(context.Background(), lease)).To(Succeed())
+			Expect(cl.Create(ctx, lease)).To(Succeed())
 
 			By("Getting the lease")
 			namespacedName := types.NamespacedName{
@@ -612,12 +612,12 @@ var _ = Describe("Fake client", func() {
 				Namespace: lease.Namespace,
 			}
 			obj := &coordinationv1.Lease{}
-			Expect(cl.Get(context.Background(), namespacedName, obj)).To(Succeed())
+			Expect(cl.Get(ctx, namespacedName, obj)).To(Succeed())
 			Expect(obj).To(Equal(lease))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1"))
 		})
 
-		It("should reject create on update for a resource that does not allow create on update", func() {
+		It("should reject create on update for a resource that does not allow create on update", func(ctx SpecContext) {
 			By("Attemping to create a new configmap with update")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -628,10 +628,10 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			Expect(cl.Update(context.Background(), newcm)).NotTo(Succeed())
+			Expect(cl.Update(ctx, newcm)).NotTo(Succeed())
 		})
 
-		It("should reject updates with non-matching ResourceVersion", func() {
+		It("should reject updates with non-matching ResourceVersion", func(ctx SpecContext) {
 			By("Updating a new configmap")
 			newcm := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -643,7 +643,7 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Update(context.Background(), newcm)
+			err := cl.Update(ctx, newcm)
 			Expect(apierrors.IsConflict(err)).To(BeTrue())
 
 			By("Getting the configmap")
@@ -652,67 +652,67 @@ var _ = Describe("Fake client", func() {
 				Namespace: "ns2",
 			}
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj).To(Equal(cm))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal(trackerAddResourceVersion))
 		})
 
-		It("should reject Delete with a mismatched ResourceVersion", func() {
+		It("should reject Delete with a mismatched ResourceVersion", func(ctx SpecContext) {
 			bogusRV := "bogus"
 			By("Deleting with a mismatched ResourceVersion Precondition")
-			err := cl.Delete(context.Background(), dep, client.Preconditions{ResourceVersion: &bogusRV})
+			err := cl.Delete(ctx, dep, client.Preconditions{ResourceVersion: &bogusRV})
 			Expect(apierrors.IsConflict(err)).To(BeTrue())
 
 			list := &appsv1.DeploymentList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err = cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(2))
 			Expect(list.Items).To(ConsistOf(*dep, *dep2))
 		})
 
-		It("should successfully Delete with a matching ResourceVersion", func() {
+		It("should successfully Delete with a matching ResourceVersion", func(ctx SpecContext) {
 			goodRV := trackerAddResourceVersion
 			By("Deleting with a matching ResourceVersion Precondition")
-			err := cl.Delete(context.Background(), dep, client.Preconditions{ResourceVersion: &goodRV})
+			err := cl.Delete(ctx, dep, client.Preconditions{ResourceVersion: &goodRV})
 			Expect(err).ToNot(HaveOccurred())
 
 			list := &appsv1.DeploymentList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err = cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
-		It("should be able to Delete with no ResourceVersion Precondition", func() {
+		It("should be able to Delete with no ResourceVersion Precondition", func(ctx SpecContext) {
 			By("Deleting a deployment")
-			err := cl.Delete(context.Background(), dep)
+			err := cl.Delete(ctx, dep)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Listing all deployments in the namespace")
 			list := &appsv1.DeploymentList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err = cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
-		It("should be able to Delete with no opts even if object's ResourceVersion doesn't match server", func() {
+		It("should be able to Delete with no opts even if object's ResourceVersion doesn't match server", func(ctx SpecContext) {
 			By("Deleting a deployment")
 			depCopy := dep.DeepCopy()
 			depCopy.ResourceVersion = "bogus"
-			err := cl.Delete(context.Background(), depCopy)
+			err := cl.Delete(ctx, depCopy)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Listing all deployments in the namespace")
 			list := &appsv1.DeploymentList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err = cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(HaveLen(1))
 			Expect(list.Items).To(ConsistOf(*dep2))
 		})
 
-		It("should handle finalizers on Update", func() {
+		It("should handle finalizers on Update", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "delete-with-finalizers",
@@ -728,31 +728,31 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Create(context.Background(), newObj)
+			err := cl.Create(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting the object")
-			err = cl.Delete(context.Background(), newObj)
+			err = cl.Delete(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj.DeletionTimestamp).NotTo(BeNil())
 
 			By("Removing the finalizer")
 			obj.Finalizers = []string{}
-			err = cl.Update(context.Background(), obj)
+			err = cl.Update(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj = &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should reject changes to deletionTimestamp on Update", func() {
+		It("should reject changes to deletionTimestamp on Update", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "reject-with-deletiontimestamp",
@@ -767,52 +767,52 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Create(context.Background(), newObj)
+			err := cl.Create(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj.DeletionTimestamp).To(BeNil())
 
 			By("Adding deletionTimestamp")
 			now := metav1.Now()
 			obj.DeletionTimestamp = &now
-			err = cl.Update(context.Background(), obj)
+			err = cl.Update(ctx, obj)
 			Expect(err).To(HaveOccurred())
 
 			By("Deleting the object")
-			err = cl.Delete(context.Background(), newObj)
+			err = cl.Delete(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Changing the deletionTimestamp to new value")
 			obj = &corev1.ConfigMap{}
 			t := metav1.NewTime(time.Now().Add(time.Second))
 			obj.DeletionTimestamp = &t
-			err = cl.Update(context.Background(), obj)
+			err = cl.Update(ctx, obj)
 			Expect(err).To(HaveOccurred())
 
 			By("Removing deletionTimestamp")
 			obj.DeletionTimestamp = nil
-			err = cl.Update(context.Background(), obj)
+			err = cl.Update(ctx, obj)
 			Expect(err).To(HaveOccurred())
 
 		})
 
-		It("should be able to Delete a Collection", func() {
+		It("should be able to Delete a Collection", func(ctx SpecContext) {
 			By("Deleting a deploymentList")
-			err := cl.DeleteAllOf(context.Background(), &appsv1.Deployment{}, client.InNamespace("ns1"))
+			err := cl.DeleteAllOf(ctx, &appsv1.Deployment{}, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Listing all deployments in the namespace")
 			list := &appsv1.DeploymentList{}
-			err = cl.List(context.Background(), list, client.InNamespace("ns1"))
+			err = cl.List(ctx, list, client.InNamespace("ns1"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(list.Items).To(BeEmpty())
 		})
 
-		It("should handle finalizers deleting a collection", func() {
+		It("should handle finalizers deleting a collection", func(ctx SpecContext) {
 			for i := 0; i < 5; i++ {
 				namespacedName := types.NamespacedName{
 					Name:      fmt.Sprintf("test-cm-%d", i),
@@ -829,16 +829,16 @@ var _ = Describe("Fake client", func() {
 						"test-key": "new-value",
 					},
 				}
-				err := cl.Create(context.Background(), newObj)
+				err := cl.Create(ctx, newObj)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
 			By("Deleting the object")
-			err := cl.DeleteAllOf(context.Background(), &corev1.ConfigMap{}, client.InNamespace("delete-collection-with-finalizers"))
+			err := cl.DeleteAllOf(ctx, &corev1.ConfigMap{}, client.InNamespace("delete-collection-with-finalizers"))
 			Expect(err).ToNot(HaveOccurred())
 
 			configmaps := corev1.ConfigMapList{}
-			err = cl.List(context.Background(), &configmaps, client.InNamespace("delete-collection-with-finalizers"))
+			err = cl.List(ctx, &configmaps, client.InNamespace("delete-collection-with-finalizers"))
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(configmaps.Items).To(HaveLen(5))
@@ -847,9 +847,9 @@ var _ = Describe("Fake client", func() {
 			}
 		})
 
-		It("should be able to watch", func() {
+		It("should be able to watch", func(ctx SpecContext) {
 			By("Creating a watch")
-			objWatch, err := cl.Watch(context.Background(), &corev1.ServiceList{})
+			objWatch, err := cl.Watch(ctx, &corev1.ServiceList{})
 			Expect(err).NotTo(HaveOccurred())
 
 			defer objWatch.Stop()
@@ -860,7 +860,7 @@ var _ = Describe("Fake client", func() {
 				// in the outer routine, sleep to make sure this is always true
 				time.Sleep(100 * time.Millisecond)
 
-				err := cl.Create(context.Background(), &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "for-watch"}})
+				err := cl.Create(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "for-watch"}})
 				Expect(err).ToNot(HaveOccurred())
 			}()
 
@@ -874,7 +874,7 @@ var _ = Describe("Fake client", func() {
 		})
 
 		Context("with the DryRun option", func() {
-			It("should not create a new object", func() {
+			It("should not create a new object", func(ctx SpecContext) {
 				By("Creating a new configmap with DryRun")
 				newcm := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -882,7 +882,7 @@ var _ = Describe("Fake client", func() {
 						Namespace: "ns2",
 					},
 				}
-				err := cl.Create(context.Background(), newcm, client.DryRunAll)
+				err := cl.Create(ctx, newcm, client.DryRunAll)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Getting the new configmap")
@@ -891,13 +891,13 @@ var _ = Describe("Fake client", func() {
 					Namespace: "ns2",
 				}
 				obj := &corev1.ConfigMap{}
-				err = cl.Get(context.Background(), namespacedName, obj)
+				err = cl.Get(ctx, namespacedName, obj)
 				Expect(err).To(HaveOccurred())
 				Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				Expect(obj).NotTo(Equal(newcm))
 			})
 
-			It("should not Update the object", func() {
+			It("should not Update the object", func(ctx SpecContext) {
 				By("Updating a new configmap with DryRun")
 				newcm := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -909,7 +909,7 @@ var _ = Describe("Fake client", func() {
 						"test-key": "new-value",
 					},
 				}
-				err := cl.Update(context.Background(), newcm, client.DryRunAll)
+				err := cl.Update(ctx, newcm, client.DryRunAll)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Getting the new configmap")
@@ -918,19 +918,19 @@ var _ = Describe("Fake client", func() {
 					Namespace: "ns2",
 				}
 				obj := &corev1.ConfigMap{}
-				err = cl.Get(context.Background(), namespacedName, obj)
+				err = cl.Get(ctx, namespacedName, obj)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(obj).To(Equal(cm))
 				Expect(obj.ObjectMeta.ResourceVersion).To(Equal(trackerAddResourceVersion))
 			})
 
-			It("Should not Delete the object", func() {
+			It("Should not Delete the object", func(ctx SpecContext) {
 				By("Deleting a configmap with DryRun with Delete()")
-				err := cl.Delete(context.Background(), cm, client.DryRunAll)
+				err := cl.Delete(ctx, cm, client.DryRunAll)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Deleting a configmap with DryRun with DeleteAllOf()")
-				err = cl.DeleteAllOf(context.Background(), cm, client.DryRunAll)
+				err = cl.DeleteAllOf(ctx, cm, client.DryRunAll)
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Getting the configmap")
@@ -939,14 +939,14 @@ var _ = Describe("Fake client", func() {
 					Namespace: "ns2",
 				}
 				obj := &corev1.ConfigMap{}
-				err = cl.Get(context.Background(), namespacedName, obj)
+				err = cl.Get(ctx, namespacedName, obj)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(obj).To(Equal(cm))
 				Expect(obj.ObjectMeta.ResourceVersion).To(Equal(trackerAddResourceVersion))
 			})
 		})
 
-		It("should be able to Patch", func() {
+		It("should be able to Patch", func(ctx SpecContext) {
 			By("Patching a deployment")
 			mergePatch, err := json.Marshal(map[string]interface{}{
 				"metadata": map[string]interface{}{
@@ -956,7 +956,7 @@ var _ = Describe("Fake client", func() {
 				},
 			})
 			Expect(err).NotTo(HaveOccurred())
-			err = cl.Patch(context.Background(), dep, client.RawPatch(types.StrategicMergePatchType, mergePatch))
+			err = cl.Patch(ctx, dep, client.RawPatch(types.StrategicMergePatchType, mergePatch))
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Getting the patched deployment")
@@ -965,13 +965,13 @@ var _ = Describe("Fake client", func() {
 				Namespace: "ns1",
 			}
 			obj := &appsv1.Deployment{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(obj.Annotations["foo"]).To(Equal("bar"))
 			Expect(obj.ObjectMeta.ResourceVersion).To(Equal("1000"))
 		})
 
-		It("should ignore deletionTimestamp without finalizer on Create", func() {
+		It("should ignore deletionTimestamp without finalizer on Create", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "ignore-deletiontimestamp",
@@ -990,18 +990,18 @@ var _ = Describe("Fake client", func() {
 				},
 			}
 
-			err := cl.Create(context.Background(), newObj)
+			err := cl.Create(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj.DeletionTimestamp).To(BeNil())
 
 		})
 
-		It("should reject deletionTimestamp without finalizers on Build", func() {
+		It("should reject deletionTimestamp without finalizers on Build", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "reject-deletiontimestamp-no-finalizers",
@@ -1038,12 +1038,12 @@ var _ = Describe("Fake client", func() {
 
 			By("Getting the object")
 			obj = &corev1.ConfigMap{}
-			err := cl.Get(context.Background(), namespacedName, obj)
+			err := cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 
 		})
 
-		It("should reject changes to deletionTimestamp on Patch", func() {
+		It("should reject changes to deletionTimestamp on Patch", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "reject-deletiontimestamp",
@@ -1060,7 +1060,7 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Create(context.Background(), newObj)
+			err := cl.Create(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Add a deletionTimestamp")
@@ -1072,16 +1072,16 @@ var _ = Describe("Fake client", func() {
 					DeletionTimestamp: &now,
 				},
 			}
-			err = cl.Patch(context.Background(), obj, client.MergeFrom(newObj))
+			err = cl.Patch(ctx, obj, client.MergeFrom(newObj))
 			Expect(err).To(HaveOccurred())
 
 			By("Deleting the object")
-			err = cl.Delete(context.Background(), newObj)
+			err = cl.Delete(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj = &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(obj.DeletionTimestamp).NotTo(BeNil())
 
@@ -1089,7 +1089,7 @@ var _ = Describe("Fake client", func() {
 			newObj = &corev1.ConfigMap{}
 			t := metav1.NewTime(time.Now().Add(time.Second))
 			newObj.DeletionTimestamp = &t
-			err = cl.Patch(context.Background(), newObj, client.MergeFrom(obj))
+			err = cl.Patch(ctx, newObj, client.MergeFrom(obj))
 			Expect(err).To(HaveOccurred())
 
 			By("Removing deletionTimestamp")
@@ -1100,12 +1100,12 @@ var _ = Describe("Fake client", func() {
 					DeletionTimestamp: nil,
 				},
 			}
-			err = cl.Patch(context.Background(), newObj, client.MergeFrom(obj))
+			err = cl.Patch(ctx, newObj, client.MergeFrom(obj))
 			Expect(err).To(HaveOccurred())
 
 		})
 
-		It("should handle finalizers on Patch", func() {
+		It("should handle finalizers on Patch", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "delete-with-finalizers",
@@ -1121,11 +1121,11 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Create(context.Background(), newObj)
+			err := cl.Create(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Deleting the object")
-			err = cl.Delete(context.Background(), newObj)
+			err = cl.Delete(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Removing the finalizer")
@@ -1136,16 +1136,16 @@ var _ = Describe("Fake client", func() {
 					Finalizers: []string{},
 				},
 			}
-			err = cl.Patch(context.Background(), obj, client.MergeFrom(newObj))
+			err = cl.Patch(ctx, obj, client.MergeFrom(newObj))
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Getting the object")
 			obj = &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, obj)
+			err = cl.Get(ctx, namespacedName, obj)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should remove finalizers of the object on Patch", func() {
+		It("should remove finalizers of the object on Patch", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
 				Namespace: "patch-finalizers-in-obj",
@@ -1161,7 +1161,7 @@ var _ = Describe("Fake client", func() {
 					"test-key": "new-value",
 				},
 			}
-			err := cl.Create(context.Background(), obj)
+			err := cl.Create(ctx, obj)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Removing the finalizer")
@@ -1173,7 +1173,7 @@ var _ = Describe("Fake client", func() {
 				},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			err = cl.Patch(context.Background(), obj, client.RawPatch(types.StrategicMergePatchType, mergePatch))
+			err = cl.Patch(ctx, obj, client.RawPatch(types.StrategicMergePatchType, mergePatch))
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Check the finalizer has been removed in the object")
@@ -1181,7 +1181,7 @@ var _ = Describe("Fake client", func() {
 
 			By("Check the finalizer has been removed in client")
 			newObj := &corev1.ConfigMap{}
-			err = cl.Get(context.Background(), namespacedName, newObj)
+			err = cl.Get(ctx, namespacedName, newObj)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newObj.Finalizers).To(BeEmpty())
 		})
@@ -1250,106 +1250,106 @@ var _ = Describe("Fake client", func() {
 			})
 
 			Context("filtered List using field selector", func() {
-				It("errors when there's no Index for the GroupVersionResource", func() {
+				It("errors when there's no Index for the GroupVersionResource", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("key", "val"),
 					}
 					list := &corev1.ConfigMapList{}
-					err := cl.List(context.Background(), list, listOpts)
+					err := cl.List(ctx, list, listOpts)
 					Expect(err).To(HaveOccurred())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("errors when there's no Index for the GroupVersionResource with UnstructuredList", func() {
+				It("errors when there's no Index for the GroupVersionResource with UnstructuredList", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("key", "val"),
 					}
 					list := &unstructured.UnstructuredList{}
 					list.SetAPIVersion("v1")
 					list.SetKind("ConfigMapList")
-					err := cl.List(context.Background(), list, listOpts)
+					err := cl.List(ctx, list, listOpts)
 					Expect(err).To(HaveOccurred())
 					Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("v1"))
 					Expect(list.GetKind()).To(Equal("ConfigMapList"))
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("errors when there's no Index matching the field name", func() {
+				It("errors when there's no Index matching the field name", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.paused", "false"),
 					}
 					list := &appsv1.DeploymentList{}
-					err := cl.List(context.Background(), list, listOpts)
+					err := cl.List(ctx, list, listOpts)
 					Expect(err).To(HaveOccurred())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("errors when field selector uses two requirements", func() {
+				It("errors when field selector uses two requirements", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.AndSelectors(
 							fields.OneTermEqualSelector("spec.replicas", "1"),
 							fields.OneTermEqualSelector("spec.strategy.type", string(appsv1.RecreateDeploymentStrategyType)),
 						)}
 					list := &appsv1.DeploymentList{}
-					err := cl.List(context.Background(), list, listOpts)
+					err := cl.List(ctx, list, listOpts)
 					Expect(err).To(HaveOccurred())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("returns two deployments that match the only field selector requirement", func() {
+				It("returns two deployments that match the only field selector requirement", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.replicas", "1"),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(ConsistOf(*dep, *dep2))
 				})
 
-				It("returns no object because no object matches the only field selector requirement", func() {
+				It("returns no object because no object matches the only field selector requirement", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.replicas", "2"),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("returns deployment that matches both the field and label selectors", func() {
+				It("returns deployment that matches both the field and label selectors", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.replicas", "1"),
 						LabelSelector: labels.SelectorFromSet(dep2.Labels),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(ConsistOf(*dep2))
 				})
 
-				It("returns no object even if field selector matches because label selector doesn't", func() {
+				It("returns no object even if field selector matches because label selector doesn't", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.replicas", "1"),
 						LabelSelector: labels.Nothing(),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("returns no object even if label selector matches because field selector doesn't", func() {
+				It("returns no object even if label selector matches because field selector doesn't", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.replicas", "2"),
 						LabelSelector: labels.Everything(),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("supports adding an index at runtime", func() {
+				It("supports adding an index at runtime", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("metadata.name", "test-deployment-2"),
 					}
 					list := &appsv1.DeploymentList{}
-					err := cl.List(context.Background(), list, listOpts)
+					err := cl.List(ctx, list, listOpts)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("no index with name metadata.name has been registered"))
 
@@ -1358,11 +1358,11 @@ var _ = Describe("Fake client", func() {
 					})
 					Expect(err).To(Succeed())
 
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(ConsistOf(*dep2))
 				})
 
-				It("Is not a datarace to add and use indexes in parallel", func() {
+				It("Is not a datarace to add and use indexes in parallel", func(ctx SpecContext) {
 					wg := sync.WaitGroup{}
 					wg.Add(2)
 
@@ -1372,7 +1372,7 @@ var _ = Describe("Fake client", func() {
 					go func() {
 						defer wg.Done()
 						defer GinkgoRecover()
-						Expect(cl.List(context.Background(), &appsv1.DeploymentList{}, listOpts)).To(Succeed())
+						Expect(cl.List(ctx, &appsv1.DeploymentList{}, listOpts)).To(Succeed())
 					}()
 					go func() {
 						defer wg.Done()
@@ -1397,43 +1397,43 @@ var _ = Describe("Fake client", func() {
 			})
 
 			Context("filtered List using field selector", func() {
-				It("uses the second index to retrieve the indexed objects when there are matches", func() {
+				It("uses the second index to retrieve the indexed objects when there are matches", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.strategy.type", string(appsv1.RecreateDeploymentStrategyType)),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(ConsistOf(*dep))
 				})
 
-				It("uses the second index to retrieve the indexed objects when there are no matches", func() {
+				It("uses the second index to retrieve the indexed objects when there are no matches", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.OneTermEqualSelector("spec.strategy.type", string(appsv1.RollingUpdateDeploymentStrategyType)),
 					}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(BeEmpty())
 				})
 
-				It("no error when field selector uses two requirements", func() {
+				It("no error when field selector uses two requirements", func(ctx SpecContext) {
 					listOpts := &client.ListOptions{
 						FieldSelector: fields.AndSelectors(
 							fields.OneTermEqualSelector("spec.replicas", "1"),
 							fields.OneTermEqualSelector("spec.strategy.type", string(appsv1.RecreateDeploymentStrategyType)),
 						)}
 					list := &appsv1.DeploymentList{}
-					Expect(cl.List(context.Background(), list, listOpts)).To(Succeed())
+					Expect(cl.List(ctx, list, listOpts)).To(Succeed())
 					Expect(list.Items).To(ConsistOf(*dep))
 				})
 			})
 		})
 	})
 
-	It("should set the ResourceVersion to 999 when adding an object to the tracker", func() {
+	It("should set the ResourceVersion to 999 when adding an object to the tracker", func(ctx SpecContext) {
 		cl := NewClientBuilder().WithObjects(&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "cm"}}).Build()
 
 		retrieved := &corev1.Secret{}
-		Expect(cl.Get(context.Background(), types.NamespacedName{Name: "cm"}, retrieved)).To(Succeed())
+		Expect(cl.Get(ctx, types.NamespacedName{Name: "cm"}, retrieved)).To(Succeed())
 
 		reference := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1444,7 +1444,7 @@ var _ = Describe("Fake client", func() {
 		Expect(retrieved).To(Equal(reference))
 	})
 
-	It("should be able to build with given tracker and get resource", func() {
+	It("should be able to build with given tracker and get resource", func(ctx SpecContext) {
 		clientSet := fake.NewSimpleClientset(dep)
 		cl := NewClientBuilder().WithRuntimeObjects(dep2).WithObjectTracker(clientSet.Tracker()).Build()
 
@@ -1454,12 +1454,12 @@ var _ = Describe("Fake client", func() {
 			Namespace: "ns1",
 		}
 		obj := &appsv1.Deployment{}
-		err := cl.Get(context.Background(), namespacedName, obj)
+		err := cl.Get(ctx, namespacedName, obj)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(obj).To(BeComparableTo(dep))
 
 		By("Getting a deployment from clientSet")
-		csDep2, err := clientSet.AppsV1().Deployments("ns1").Get(context.Background(), "test-deployment-2", metav1.GetOptions{})
+		csDep2, err := clientSet.AppsV1().Deployments("ns1").Get(ctx, "test-deployment-2", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(csDep2).To(Equal(dep2))
 
@@ -1480,16 +1480,16 @@ var _ = Describe("Fake client", func() {
 			},
 		}
 
-		_, err = clientSet.AppsV1().Deployments("ns1").Create(context.Background(), dep3, metav1.CreateOptions{})
+		_, err = clientSet.AppsV1().Deployments("ns1").Create(ctx, dep3, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		obj = &appsv1.Deployment{}
-		err = cl.Get(context.Background(), namespacedName3, obj)
+		err = cl.Get(ctx, namespacedName3, obj)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(obj).To(BeComparableTo(dep3))
 	})
 
-	It("should not change the status of typed objects that have a status subresource on update", func() {
+	It("should not change the status of typed objects that have a status subresource on update", func(ctx SpecContext) {
 		obj := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod",
@@ -1498,14 +1498,14 @@ var _ = Describe("Fake client", func() {
 		cl := NewClientBuilder().WithStatusSubresource(obj).WithObjects(obj).Build()
 
 		obj.Status.Phase = "Running"
-		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+		Expect(cl.Update(ctx, obj)).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Status).To(BeEquivalentTo(corev1.PodStatus{}))
 	})
 
-	It("should return a conflict error when an incorrect RV is used on status update", func() {
+	It("should return a conflict error when an incorrect RV is used on status update", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            "node",
@@ -1516,11 +1516,11 @@ var _ = Describe("Fake client", func() {
 
 		obj.Status.Phase = corev1.NodeRunning
 		obj.ResourceVersion = "invalid"
-		err := cl.Status().Update(context.Background(), obj)
+		err := cl.Status().Update(ctx, obj)
 		Expect(apierrors.IsConflict(err)).To(BeTrue())
 	})
 
-	It("should not change non-status field of typed objects that have a status subresource on status update", func() {
+	It("should not change non-status field of typed objects that have a status subresource on status update", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
@@ -1546,10 +1546,10 @@ var _ = Describe("Fake client", func() {
 		}
 
 		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
-		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Status().Update(ctx, obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
 
 		objOriginal.APIVersion = actual.APIVersion
 		objOriginal.Kind = actual.Kind
@@ -1558,7 +1558,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cmp.Diff(objOriginal, actual)).To(BeEmpty())
 	})
 
-	It("should be able to update an object after updating an object's status", func() {
+	It("should be able to update an object after updating an object's status", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
@@ -1576,7 +1576,7 @@ var _ = Describe("Fake client", func() {
 		expectedObj := obj.DeepCopy()
 
 		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
-		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Status().Update(ctx, obj)).NotTo(HaveOccurred())
 
 		obj.Annotations = map[string]string{
 			"some-annotation-key": "some",
@@ -1584,10 +1584,10 @@ var _ = Describe("Fake client", func() {
 		expectedObj.Annotations = map[string]string{
 			"some-annotation-key": "some",
 		}
-		Expect(cl.Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Update(ctx, obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
 
 		expectedObj.APIVersion = actual.APIVersion
 		expectedObj.Kind = actual.Kind
@@ -1596,7 +1596,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cmp.Diff(expectedObj, actual)).To(BeEmpty())
 	})
 
-	It("should be able to update an object's status after updating an object", func() {
+	It("should be able to update an object's status after updating an object", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
@@ -1619,14 +1619,14 @@ var _ = Describe("Fake client", func() {
 		expectedObj.Annotations = map[string]string{
 			"some-annotation-key": "some",
 		}
-		Expect(cl.Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Update(ctx, obj)).NotTo(HaveOccurred())
 
 		obj.Spec.PodCIDR = cidrFromStatusUpdate
 		obj.Status.NodeInfo.MachineID = machineIDFromStatusUpdate
-		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Status().Update(ctx, obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
 
 		expectedObj.APIVersion = actual.APIVersion
 		expectedObj.Kind = actual.Kind
@@ -1635,7 +1635,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cmp.Diff(expectedObj, actual)).To(BeEmpty())
 	})
 
-	It("Should only override status fields of typed objects that have a status subresource on status update", func() {
+	It("Should only override status fields of typed objects that have a status subresource on status update", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
@@ -1653,10 +1653,10 @@ var _ = Describe("Fake client", func() {
 		objOriginal := obj.DeepCopy()
 
 		obj.Status.Phase = corev1.NodeRunning
-		Expect(cl.Status().Update(context.Background(), obj)).NotTo(HaveOccurred())
+		Expect(cl.Status().Update(ctx, obj)).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
 
 		objOriginal.APIVersion = actual.APIVersion
 		objOriginal.Kind = actual.Kind
@@ -1666,7 +1666,7 @@ var _ = Describe("Fake client", func() {
 		Expect(objOriginal.Status.Phase).ToNot(Equal(actual.Status.Phase))
 	})
 
-	It("should be able to change typed objects that have a scale subresource on patch", func() {
+	It("should be able to change typed objects that have a scale subresource on patch", func(ctx SpecContext) {
 		obj := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "deploy",
@@ -1676,10 +1676,10 @@ var _ = Describe("Fake client", func() {
 		objOriginal := obj.DeepCopy()
 
 		patch := []byte(fmt.Sprintf(`{"spec":{"replicas":%d}}`, 2))
-		Expect(cl.SubResource("scale").Patch(context.Background(), obj, client.RawPatch(types.MergePatchType, patch))).NotTo(HaveOccurred())
+		Expect(cl.SubResource("scale").Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))).NotTo(HaveOccurred())
 
 		actual := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).To(Succeed())
 
 		objOriginal.APIVersion = actual.APIVersion
 		objOriginal.Kind = actual.Kind
@@ -1688,24 +1688,24 @@ var _ = Describe("Fake client", func() {
 		Expect(cmp.Diff(objOriginal, actual)).To(BeEmpty())
 	})
 
-	It("should not change the status of typed objects that have a status subresource on patch", func() {
+	It("should not change the status of typed objects that have a status subresource on patch", func(ctx SpecContext) {
 		obj := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
 			},
 		}
-		Expect(cl.Create(context.Background(), obj)).To(Succeed())
+		Expect(cl.Create(ctx, obj)).To(Succeed())
 		original := obj.DeepCopy()
 
 		obj.Status.Phase = "Running"
-		Expect(cl.Patch(context.Background(), obj, client.MergeFrom(original))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.MergeFrom(original))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Status).To(BeEquivalentTo(corev1.PodStatus{}))
 	})
 
-	It("should not change non-status field of typed objects that have a status subresource on status patch", func() {
+	It("should not change non-status field of typed objects that have a status subresource on status patch", func(ctx SpecContext) {
 		obj := &corev1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node",
@@ -1719,10 +1719,10 @@ var _ = Describe("Fake client", func() {
 
 		obj.Spec.PodCIDR = cidrFromStatusUpdate
 		obj.Status.NodeInfo.MachineID = "machine-id"
-		Expect(cl.Status().Patch(context.Background(), obj, client.MergeFrom(objOriginal))).NotTo(HaveOccurred())
+		Expect(cl.Status().Patch(ctx, obj, client.MergeFrom(objOriginal))).NotTo(HaveOccurred())
 
 		actual := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: obj.Name}}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(actual), actual)).NotTo(HaveOccurred())
 
 		objOriginal.APIVersion = actual.APIVersion
 		objOriginal.Kind = actual.Kind
@@ -1731,7 +1731,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cmp.Diff(objOriginal, actual)).To(BeEmpty())
 	})
 
-	It("should Unmarshal the schemaless object with int64 to preserve ints", func() {
+	It("should Unmarshal the schemaless object with int64 to preserve ints", func(ctx SpecContext) {
 		schemeBuilder := &scheme.Builder{GroupVersion: schema.GroupVersion{Group: "test", Version: "v1"}}
 		schemeBuilder.Register(&WithSchemalessSpec{})
 
@@ -1750,13 +1750,13 @@ var _ = Describe("Fake client", func() {
 		}
 		cl := NewClientBuilder().WithScheme(scheme).WithStatusSubresource(obj).WithObjects(obj).Build()
 
-		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+		Expect(cl.Update(ctx, obj)).To(Succeed())
 		Expect(obj.Spec).To(BeEquivalentTo(spec))
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 		Expect(obj.Spec).To(BeEquivalentTo(spec))
 	})
 
-	It("should Unmarshal the schemaless object with float64 to preserve ints", func() {
+	It("should Unmarshal the schemaless object with float64 to preserve ints", func(ctx SpecContext) {
 		schemeBuilder := &scheme.Builder{GroupVersion: schema.GroupVersion{Group: "test", Version: "v1"}}
 		schemeBuilder.Register(&WithSchemalessSpec{})
 
@@ -1775,13 +1775,13 @@ var _ = Describe("Fake client", func() {
 		}
 		cl := NewClientBuilder().WithScheme(scheme).WithStatusSubresource(obj).WithObjects(obj).Build()
 
-		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+		Expect(cl.Update(ctx, obj)).To(Succeed())
 		Expect(obj.Spec).To(BeEquivalentTo(spec))
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 		Expect(obj.Spec).To(BeEquivalentTo(spec))
 	})
 
-	It("should not change the status of unstructured objects that are configured to have a status subresource on update", func() {
+	It("should not change the status of unstructured objects that are configured to have a status subresource on update", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("foo/v1")
 		obj.SetKind("Foo")
@@ -1795,14 +1795,14 @@ var _ = Describe("Fake client", func() {
 		err = unstructured.SetNestedField(obj.Object, map[string]any{"state": "new"}, "status")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+		Expect(cl.Update(ctx, obj)).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Object["status"]).To(BeEquivalentTo(map[string]any{"state": "old"}))
 	})
 
-	It("should not change non-status fields of unstructured objects that are configured to have a status subresource on status update", func() {
+	It("should not change non-status fields of unstructured objects that are configured to have a status subresource on status update", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("foo/v1")
 		obj.SetKind("Foo")
@@ -1818,14 +1818,14 @@ var _ = Describe("Fake client", func() {
 		err = unstructured.SetNestedField(obj.Object, map[string]any{"state": "new"}, "status")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cl.Status().Update(context.Background(), obj)).To(Succeed())
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Status().Update(ctx, obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Object["status"]).To(BeEquivalentTo(map[string]any{"state": "new"}))
 		Expect(obj.Object["spec"]).To(BeEquivalentTo("original"))
 	})
 
-	It("should not change the status of known unstructured objects that have a status subresource on update", func() {
+	It("should not change the status of known unstructured objects that have a status subresource on update", func(ctx SpecContext) {
 		obj := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod",
@@ -1844,7 +1844,7 @@ var _ = Describe("Fake client", func() {
 		u.SetAPIVersion("v1")
 		u.SetKind("Pod")
 		u.SetName(obj.Name)
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(u), u)
+		err := cl.Get(ctx, client.ObjectKeyFromObject(u), u)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = unstructured.SetNestedField(u.Object, string(corev1.RestartPolicyNever), "spec", "restartPolicy")
@@ -1852,17 +1852,17 @@ var _ = Describe("Fake client", func() {
 		err = unstructured.SetNestedField(u.Object, string(corev1.PodRunning), "status", "phase")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(cl.Update(context.Background(), u)).To(Succeed())
+		Expect(cl.Update(ctx, u)).To(Succeed())
 
 		actual := &corev1.Pod{}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), actual)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), actual)).To(Succeed())
 		obj.ResourceVersion = actual.ResourceVersion
 		// only the spec mutation should persist
 		obj.Spec.RestartPolicy = corev1.RestartPolicyNever
 		Expect(cmp.Diff(obj, actual)).To(BeEmpty())
 	})
 
-	It("should not change non-status field of known unstructured objects that have a status subresource on status update", func() {
+	It("should not change non-status field of known unstructured objects that have a status subresource on status update", func(ctx SpecContext) {
 		obj := &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "pod",
@@ -1881,7 +1881,7 @@ var _ = Describe("Fake client", func() {
 		u.SetAPIVersion("v1")
 		u.SetKind("Pod")
 		u.SetName(obj.Name)
-		err := cl.Get(context.Background(), client.ObjectKeyFromObject(u), u)
+		err := cl.Get(ctx, client.ObjectKeyFromObject(u), u)
 		Expect(err).NotTo(HaveOccurred())
 
 		err = unstructured.SetNestedField(u.Object, string(corev1.RestartPolicyNever), "spec", "restartPolicy")
@@ -1889,37 +1889,37 @@ var _ = Describe("Fake client", func() {
 		err = unstructured.SetNestedField(u.Object, string(corev1.PodRunning), "status", "phase")
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(cl.Status().Update(context.Background(), u)).To(Succeed())
+		Expect(cl.Status().Update(ctx, u)).To(Succeed())
 
 		actual := &corev1.Pod{}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), actual)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), actual)).To(Succeed())
 		obj.ResourceVersion = actual.ResourceVersion
 		// only the status mutation should persist
 		obj.Status.Phase = corev1.PodRunning
 		Expect(cmp.Diff(obj, actual)).To(BeEmpty())
 	})
 
-	It("should not change the status of unstructured objects that are configured to have a status subresource on patch", func() {
+	It("should not change the status of unstructured objects that are configured to have a status subresource on patch", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("foo/v1")
 		obj.SetKind("Foo")
 		obj.SetName("a-foo")
 		cl := NewClientBuilder().WithStatusSubresource(obj).Build()
 
-		Expect(cl.Create(context.Background(), obj)).To(Succeed())
+		Expect(cl.Create(ctx, obj)).To(Succeed())
 		original := obj.DeepCopy()
 
 		err := unstructured.SetNestedField(obj.Object, map[string]interface{}{"count": int64(2)}, "status")
 		Expect(err).ToNot(HaveOccurred())
-		Expect(cl.Patch(context.Background(), obj, client.MergeFrom(original))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.MergeFrom(original))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Object["status"]).To(BeNil())
 
 	})
 
-	It("should not change non-status fields of unstructured objects that are configured to have a status subresource on status patch", func() {
+	It("should not change non-status fields of unstructured objects that are configured to have a status subresource on status patch", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("foo/v1")
 		obj.SetKind("Foo")
@@ -1936,14 +1936,14 @@ var _ = Describe("Fake client", func() {
 		err = unstructured.SetNestedField(obj.Object, map[string]any{"state": "new"}, "status")
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(cl.Status().Patch(context.Background(), obj, client.MergeFrom(original))).To(Succeed())
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), obj)).To(Succeed())
+		Expect(cl.Status().Patch(ctx, obj, client.MergeFrom(original))).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)).To(Succeed())
 
 		Expect(obj.Object["status"]).To(BeEquivalentTo(map[string]any{"state": "new"}))
 		Expect(obj.Object["spec"]).To(BeEquivalentTo("original"))
 	})
 
-	It("should return not found on status update of resources that don't have a status subresource", func() {
+	It("should return not found on status update of resources that don't have a status subresource", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("foo/v1")
 		obj.SetKind("Foo")
@@ -1951,7 +1951,7 @@ var _ = Describe("Fake client", func() {
 
 		cl := NewClientBuilder().WithObjects(obj).Build()
 
-		err := cl.Status().Update(context.Background(), obj)
+		err := cl.Status().Update(ctx, obj)
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -1960,108 +1960,108 @@ var _ = Describe("Fake client", func() {
 		&policyv1.Eviction{},
 	}
 	for _, tp := range evictionTypes {
-		It("should delete a pod through the eviction subresource", func() {
+		It("should delete a pod through the eviction subresource", func(ctx SpecContext) {
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
 			cl := NewClientBuilder().WithObjects(pod).Build()
 
-			err := cl.SubResource("eviction").Create(context.Background(), pod, tp)
+			err := cl.SubResource("eviction").Create(ctx, pod, tp)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = cl.Get(context.Background(), client.ObjectKeyFromObject(pod), pod)
+			err = cl.Get(ctx, client.ObjectKeyFromObject(pod), pod)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should return not found when attempting to evict a pod that doesn't exist", func() {
+		It("should return not found when attempting to evict a pod that doesn't exist", func(ctx SpecContext) {
 			cl := NewClientBuilder().Build()
 
 			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
-			err := cl.SubResource("eviction").Create(context.Background(), pod, tp)
+			err := cl.SubResource("eviction").Create(ctx, pod, tp)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should return not found when attempting to evict something other than a pod", func() {
+		It("should return not found when attempting to evict something other than a pod", func(ctx SpecContext) {
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 			cl := NewClientBuilder().WithObjects(ns).Build()
 
-			err := cl.SubResource("eviction").Create(context.Background(), ns, tp)
+			err := cl.SubResource("eviction").Create(ctx, ns, tp)
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
-		It("should return an error when using the wrong subresource", func() {
+		It("should return an error when using the wrong subresource", func(ctx SpecContext) {
 			cl := NewClientBuilder().Build()
 
-			err := cl.SubResource("eviction-subresource").Create(context.Background(), &corev1.Namespace{}, tp)
+			err := cl.SubResource("eviction-subresource").Create(ctx, &corev1.Namespace{}, tp)
 			Expect(err).To(HaveOccurred())
 		})
 	}
 
-	It("should error when creating an eviction with the wrong type", func() {
+	It("should error when creating an eviction with the wrong type", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
-		err := cl.SubResource("eviction").Create(context.Background(), &corev1.Pod{}, &corev1.Namespace{})
+		err := cl.SubResource("eviction").Create(ctx, &corev1.Pod{}, &corev1.Namespace{})
 		Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 	})
 
-	It("should create a ServiceAccount token through the token subresource", func() {
+	It("should create a ServiceAccount token through the token subresource", func(ctx SpecContext) {
 		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		cl := NewClientBuilder().WithObjects(sa).Build()
 
 		tokenRequest := &authenticationv1.TokenRequest{}
-		err := cl.SubResource("token").Create(context.Background(), sa, tokenRequest)
+		err := cl.SubResource("token").Create(ctx, sa, tokenRequest)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(tokenRequest.Status.Token).NotTo(Equal(""))
 		Expect(tokenRequest.Status.ExpirationTimestamp).NotTo(Equal(metav1.Time{}))
 	})
 
-	It("should return not found when creating a token for a ServiceAccount that doesn't exist", func() {
+	It("should return not found when creating a token for a ServiceAccount that doesn't exist", func(ctx SpecContext) {
 		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		cl := NewClientBuilder().Build()
 
-		err := cl.SubResource("token").Create(context.Background(), sa, &authenticationv1.TokenRequest{})
+		err := cl.SubResource("token").Create(ctx, sa, &authenticationv1.TokenRequest{})
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("should error when creating a token with the wrong subresource type", func() {
+	It("should error when creating a token with the wrong subresource type", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
-		err := cl.SubResource("token").Create(context.Background(), &corev1.ServiceAccount{}, &corev1.Namespace{})
+		err := cl.SubResource("token").Create(ctx, &corev1.ServiceAccount{}, &corev1.Namespace{})
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsBadRequest(err)).To(BeTrue())
 	})
 
-	It("should error when creating a token with the wrong type", func() {
+	It("should error when creating a token with the wrong type", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
-		err := cl.SubResource("token").Create(context.Background(), &corev1.Secret{}, &authenticationv1.TokenRequest{})
+		err := cl.SubResource("token").Create(ctx, &corev1.Secret{}, &authenticationv1.TokenRequest{})
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("should leave typemeta empty on typed get", func() {
+	It("should leave typemeta empty on typed get", func(ctx SpecContext) {
 		cl := NewClientBuilder().WithObjects(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "foo",
 		}}).Build()
 
 		var pod corev1.Pod
-		Expect(cl.Get(context.Background(), client.ObjectKey{Namespace: "default", Name: "foo"}, &pod)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKey{Namespace: "default", Name: "foo"}, &pod)).NotTo(HaveOccurred())
 
 		Expect(pod.TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("should leave typemeta empty on typed list", func() {
+	It("should leave typemeta empty on typed list", func(ctx SpecContext) {
 		cl := NewClientBuilder().WithObjects(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
 			Name:      "foo",
 		}}).Build()
 
 		var podList corev1.PodList
-		Expect(cl.List(context.Background(), &podList)).NotTo(HaveOccurred())
+		Expect(cl.List(ctx, &podList)).NotTo(HaveOccurred())
 		Expect(podList.ListMeta).To(Equal(metav1.ListMeta{}))
 		Expect(podList.Items[0].TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("should allow concurrent patches to a configMap", func() {
+	It("should allow concurrent patches to a configMap", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2084,18 +2084,18 @@ var _ = Describe("Fake client", func() {
 
 				newObj := obj.DeepCopy()
 				newObj.Data = map[string]string{"foo": strconv.Itoa(i)}
-				Expect(cl.Patch(context.Background(), newObj, client.MergeFrom(obj))).To(Succeed())
+				Expect(cl.Patch(ctx, newObj, client.MergeFrom(obj))).To(Succeed())
 			}()
 		}
 		wg.Wait()
 
 		// While the order is not deterministic, there must be $tries distinct updates
 		// that each increment the resource version by one
-		Expect(cl.Get(context.Background(), client.ObjectKey{Name: "foo"}, obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: "foo"}, obj)).To(Succeed())
 		Expect(obj.ResourceVersion).To(Equal(strconv.Itoa(tries)))
 	})
 
-	It("should not allow concurrent patches to a configMap if the patch contains a ResourceVersion", func() {
+	It("should not allow concurrent patches to a configMap if the patch contains a ResourceVersion", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2117,13 +2117,13 @@ var _ = Describe("Fake client", func() {
 				newObj := obj.DeepCopy()
 				newObj.ResourceVersion = "1" // include an invalid RV to cause a conflict
 				newObj.Data = map[string]string{"foo": strconv.Itoa(i)}
-				Expect(apierrors.IsConflict(cl.Patch(context.Background(), newObj, client.MergeFrom(obj)))).To(BeTrue())
+				Expect(apierrors.IsConflict(cl.Patch(ctx, newObj, client.MergeFrom(obj)))).To(BeTrue())
 			}()
 		}
 		wg.Wait()
 	})
 
-	It("should allow concurrent updates to an object that allows unconditionalUpdate if the incoming request has no RV", func() {
+	It("should allow concurrent updates to an object that allows unconditionalUpdate if the incoming request has no RV", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2147,18 +2147,18 @@ var _ = Describe("Fake client", func() {
 				newObj := obj.DeepCopy()
 				newObj.Data = map[string]string{"foo": strconv.Itoa(i)}
 				newObj.ResourceVersion = ""
-				Expect(cl.Update(context.Background(), newObj)).To(Succeed())
+				Expect(cl.Update(ctx, newObj)).To(Succeed())
 			}()
 		}
 		wg.Wait()
 
 		// While the order is not deterministic, there must be $tries distinct updates
 		// that each increment the resource version by one
-		Expect(cl.Get(context.Background(), client.ObjectKey{Name: "foo"}, obj)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKey{Name: "foo"}, obj)).To(Succeed())
 		Expect(obj.ResourceVersion).To(Equal(strconv.Itoa(tries)))
 	})
 
-	It("If a create races with an update for an object that allows createOnUpdate, the update should always succeed", func() {
+	It("If a create races with an update for an object that allows createOnUpdate, the update should always succeed", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2180,7 +2180,7 @@ var _ = Describe("Fake client", func() {
 
 				// this may or may not succeed depending on if we win the race. Either is acceptable,
 				// but if it fails, it must fail due to an AlreadyExists.
-				err := cl.Create(context.Background(), obj.DeepCopy())
+				err := cl.Create(ctx, obj.DeepCopy())
 				if err != nil {
 					Expect(apierrors.IsAlreadyExists(err)).To(BeTrue())
 				}
@@ -2191,14 +2191,14 @@ var _ = Describe("Fake client", func() {
 				defer GinkgoRecover()
 
 				// This must always succeed, regardless of the outcome of the create.
-				Expect(cl.Update(context.Background(), obj.DeepCopy())).To(Succeed())
+				Expect(cl.Update(ctx, obj.DeepCopy())).To(Succeed())
 			}()
 		}
 
 		wg.Wait()
 	})
 
-	It("If a delete races with an update for an object that allows createOnUpdate, the update should always succeed", func() {
+	It("If a delete races with an update for an object that allows createOnUpdate, the update should always succeed", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2214,13 +2214,13 @@ var _ = Describe("Fake client", func() {
 					Name: strconv.Itoa(i),
 				},
 			}
-			Expect(cl.Create(context.Background(), obj.DeepCopy())).To(Succeed())
+			Expect(cl.Create(ctx, obj.DeepCopy())).To(Succeed())
 
 			go func() {
 				defer wg.Done()
 				defer GinkgoRecover()
 
-				Expect(cl.Delete(context.Background(), obj.DeepCopy())).To(Succeed())
+				Expect(cl.Delete(ctx, obj.DeepCopy())).To(Succeed())
 			}()
 
 			go func() {
@@ -2229,14 +2229,14 @@ var _ = Describe("Fake client", func() {
 
 				// This must always succeed, regardless of if the delete came before or
 				// after us.
-				Expect(cl.Update(context.Background(), obj.DeepCopy())).To(Succeed())
+				Expect(cl.Update(ctx, obj.DeepCopy())).To(Succeed())
 			}()
 		}
 
 		wg.Wait()
 	})
 
-	It("If a DeleteAllOf races with a delete, the DeleteAllOf should always succeed", func() {
+	It("If a DeleteAllOf races with a delete, the DeleteAllOf should always succeed", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
@@ -2252,7 +2252,7 @@ var _ = Describe("Fake client", func() {
 					Name: strconv.Itoa(i),
 				},
 			}
-			Expect(cl.Create(context.Background(), obj.DeepCopy())).To(Succeed())
+			Expect(cl.Create(ctx, obj.DeepCopy())).To(Succeed())
 		}
 
 		for i := range objects {
@@ -2268,18 +2268,18 @@ var _ = Describe("Fake client", func() {
 
 				// This may or may not succeed depending on if the DeleteAllOf is faster,
 				// but if it fails, it should be a not found.
-				err := cl.Delete(context.Background(), obj)
+				err := cl.Delete(ctx, obj)
 				if err != nil {
 					Expect(apierrors.IsNotFound(err)).To(BeTrue())
 				}
 			}()
 		}
-		Expect(cl.DeleteAllOf(context.Background(), &corev1.Service{})).To(Succeed())
+		Expect(cl.DeleteAllOf(ctx, &corev1.Service{})).To(Succeed())
 
 		wg.Wait()
 	})
 
-	It("If an update races with a scale update, only one of them succeeds", func() {
+	It("If an update races with a scale update, only one of them succeeds", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(appsv1.AddToScheme(scheme)).To(Succeed())
 
@@ -2292,7 +2292,7 @@ var _ = Describe("Fake client", func() {
 					Name: strconv.Itoa(i),
 				},
 			}
-			Expect(cl.Create(context.Background(), dep)).To(Succeed())
+			Expect(cl.Create(ctx, dep)).To(Succeed())
 
 			wg := sync.WaitGroup{}
 			wg.Add(2)
@@ -2307,7 +2307,7 @@ var _ = Describe("Fake client", func() {
 				dep.Annotations = map[string]string{"foo": "bar"}
 
 				// This may or may not fail. If it does fail, it must be a conflict.
-				err := cl.Update(context.Background(), dep)
+				err := cl.Update(ctx, dep)
 				if err != nil {
 					Expect(apierrors.IsConflict(err)).To(BeTrue())
 				} else {
@@ -2321,7 +2321,7 @@ var _ = Describe("Fake client", func() {
 
 				// This may or may not fail. If it does fail, it must be a conflict.
 				scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 10}}
-				err := cl.SubResource("scale").Update(context.Background(), dep.DeepCopy(), client.WithSubResourceBody(scale))
+				err := cl.SubResource("scale").Update(ctx, dep.DeepCopy(), client.WithSubResourceBody(scale))
 				if err != nil {
 					Expect(apierrors.IsConflict(err)).To(BeTrue())
 				} else {
@@ -2335,7 +2335,7 @@ var _ = Describe("Fake client", func() {
 
 	})
 
-	It("disallows scale subresources on unsupported built-in types", func() {
+	It("disallows scale subresources on unsupported built-in types", func(ctx SpecContext) {
 		scheme := runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).To(Succeed())
 		Expect(apiextensions.AddToScheme(scheme)).To(Succeed())
@@ -2349,11 +2349,11 @@ var _ = Describe("Fake client", func() {
 
 		scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 2}}
 		expectedErr := "unimplemented scale subresource for resource *v1.Pod"
-		Expect(cl.SubResource(subResourceScale).Get(context.Background(), obj, scale).Error()).To(Equal(expectedErr))
-		Expect(cl.SubResource(subResourceScale).Update(context.Background(), obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scale).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
 	})
 
-	It("disallows scale subresources on non-existing objects", func() {
+	It("disallows scale subresources on non-existing objects", func(ctx SpecContext) {
 		obj := &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2366,11 +2366,11 @@ var _ = Describe("Fake client", func() {
 
 		scale := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 2}}
 		expectedErr := "deployments.apps \"foo\" not found"
-		Expect(cl.SubResource(subResourceScale).Get(context.Background(), obj, scale).Error()).To(Equal(expectedErr))
-		Expect(cl.SubResource(subResourceScale).Update(context.Background(), obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scale).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
 	})
 
-	It("clears typemeta from structured objects on create", func() {
+	It("clears typemeta from structured objects on create", func(ctx SpecContext) {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2381,11 +2381,11 @@ var _ = Describe("Fake client", func() {
 			},
 		}
 		cl := NewClientBuilder().Build()
-		Expect(cl.Create(context.Background(), obj)).To(Succeed())
+		Expect(cl.Create(ctx, obj)).To(Succeed())
 		Expect(obj.TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("clears typemeta from structured objects on update", func() {
+	It("clears typemeta from structured objects on update", func(ctx SpecContext) {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2396,11 +2396,11 @@ var _ = Describe("Fake client", func() {
 			},
 		}
 		cl := NewClientBuilder().WithObjects(obj).Build()
-		Expect(cl.Update(context.Background(), obj)).To(Succeed())
+		Expect(cl.Update(ctx, obj)).To(Succeed())
 		Expect(obj.TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("clears typemeta from structured objects on patch", func() {
+	It("clears typemeta from structured objects on patch", func(ctx SpecContext) {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2412,11 +2412,11 @@ var _ = Describe("Fake client", func() {
 			APIVersion: "v1",
 			Kind:       "ConfigMap",
 		}
-		Expect(cl.Patch(context.Background(), obj, client.MergeFrom(original))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.MergeFrom(original))).To(Succeed())
 		Expect(obj.TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("clears typemeta from structured objects on get", func() {
+	It("clears typemeta from structured objects on get", func(ctx SpecContext) {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2428,11 +2428,11 @@ var _ = Describe("Fake client", func() {
 		}
 		cl := NewClientBuilder().WithObjects(obj).Build()
 		target := &corev1.ConfigMap{}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(obj), target)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(obj), target)).To(Succeed())
 		Expect(target.TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("clears typemeta from structured objects on list", func() {
+	It("clears typemeta from structured objects on list", func(ctx SpecContext) {
 		obj := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "foo",
@@ -2449,12 +2449,12 @@ var _ = Describe("Fake client", func() {
 				Kind:       "ConfigMap",
 			},
 		}
-		Expect(cl.List(context.Background(), target)).To(Succeed())
+		Expect(cl.List(ctx, target)).To(Succeed())
 		Expect(target.TypeMeta).To(Equal(metav1.TypeMeta{}))
 		Expect(target.Items[0].TypeMeta).To(Equal(metav1.TypeMeta{}))
 	})
 
-	It("is threadsafe", func() {
+	It("is threadsafe", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 
 		u := func() *unstructured.Unstructured {
@@ -2502,7 +2502,6 @@ var _ = Describe("Fake client", func() {
 			}}
 		}
 
-		ctx := context.Background()
 		ops := []func(){
 			func() { _ = cl.Create(ctx, u()) },
 			func() { _ = cl.Get(ctx, client.ObjectKeyFromObject(u()), u()) },
@@ -2541,7 +2540,7 @@ var _ = Describe("Fake client", func() {
 		wg.Wait()
 	})
 
-	It("supports server-side apply of a client-go resource", func() {
+	It("supports server-side apply of a client-go resource", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("v1")
@@ -2549,21 +2548,21 @@ var _ = Describe("Fake client", func() {
 		obj.SetName("foo")
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "data")).To(Succeed())
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"other": "data"}))
 	})
 
-	It("supports server-side apply of a custom resource", func() {
+	It("supports server-side apply of a custom resource", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("custom/v1")
@@ -2573,19 +2572,19 @@ var _ = Describe("Fake client", func() {
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "spec")).To(Succeed())
 
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(result), result)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "spec")).To(Succeed())
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(result), result)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"other": "data"}))
 	})
 
-	It("errors out when doing SSA with managedFields set", func() {
+	It("errors out when doing SSA with managedFields set", func(ctx SpecContext) {
 		cl := NewClientBuilder().WithReturnManagedFields().Build()
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("v1")
@@ -2593,14 +2592,14 @@ var _ = Describe("Fake client", func() {
 		obj.SetName("foo")
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
-		err := cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))
+		err := cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("metadata.managedFields must be nil"))
 	})
 
-	It("supports server-side apply using a custom type converter", func() {
+	It("supports server-side apply using a custom type converter", func(ctx SpecContext) {
 		cl := NewClientBuilder().
 			WithTypeConverters(clientgoapplyconfigurations.NewTypeConverter(clientgoscheme.Scheme)).
 			Build()
@@ -2611,21 +2610,21 @@ var _ = Describe("Fake client", func() {
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "data")).To(Succeed())
-		Expect(cl.Patch(context.Background(), obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"other": "data"}))
 	})
 
-	It("returns managedFields if configured to do so", func() {
+	It("returns managedFields if configured to do so", func(ctx SpecContext) {
 		cl := NewClientBuilder().WithReturnManagedFields().Build()
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -2636,22 +2635,22 @@ var _ = Describe("Fake client", func() {
 				"initial": "data",
 			},
 		}
-		Expect(cl.Create(context.Background(), cm)).NotTo(HaveOccurred())
+		Expect(cl.Create(ctx, cm)).NotTo(HaveOccurred())
 		Expect(cm.ManagedFields).NotTo(BeNil())
 
 		retrieved := &corev1.ConfigMap{}
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), retrieved)).NotTo(HaveOccurred())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), retrieved)).NotTo(HaveOccurred())
 		Expect(retrieved.ManagedFields).NotTo(BeNil())
 
 		cm.Data["another"] = "value"
 		cm.SetManagedFields(nil)
-		Expect(cl.Update(context.Background(), cm)).NotTo(HaveOccurred())
+		Expect(cl.Update(ctx, cm)).NotTo(HaveOccurred())
 		Expect(cm.ManagedFields).NotTo(BeNil())
 
 		cm.SetManagedFields(nil)
 		beforePatch := cm.DeepCopy()
 		cm.Data["a-third"] = "value"
-		Expect(cl.Patch(context.Background(), cm, client.MergeFrom(beforePatch))).NotTo(HaveOccurred())
+		Expect(cl.Patch(ctx, cm, client.MergeFrom(beforePatch))).NotTo(HaveOccurred())
 		Expect(cm.ManagedFields).NotTo(BeNil())
 
 		u := &unstructured.Unstructured{Object: map[string]any{
@@ -2665,55 +2664,55 @@ var _ = Describe("Fake client", func() {
 				"ssa": "value",
 			},
 		}}
-		Expect(cl.Patch(context.Background(), u, client.Apply, client.FieldOwner("foo"))).NotTo(HaveOccurred())
+		Expect(cl.Patch(ctx, u, client.Apply, client.FieldOwner("foo"))).NotTo(HaveOccurred())
 		_, exists, err := unstructured.NestedFieldNoCopy(u.Object, "metadata", "managedFields")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(exists).To(BeTrue())
 	})
 
-	It("supports server-side apply of a client-go resource via Apply method", func() {
+	It("supports server-side apply of a client-go resource via Apply method", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := corev1applyconfigurations.
 			ConfigMap("foo", "default").
 			WithData(map[string]string{"some": "data"})
 
-		Expect(cl.Apply(context.Background(), obj, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
+		Expect(cl.Apply(ctx, obj, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}}
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(BeComparableTo(map[string]string{"some": "data"}))
 
 		obj.Data = map[string]string{"other": "data"}
-		Expect(cl.Apply(context.Background(), obj, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
+		Expect(cl.Apply(ctx, obj, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(cm), cm)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(BeComparableTo(map[string]string{"other": "data"}))
 	})
 
-	It("errors when trying to server-side apply an object without configuring a FieldManager", func() {
+	It("errors when trying to server-side apply an object without configuring a FieldManager", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := corev1applyconfigurations.
 			ConfigMap("foo", "default").
 			WithData(map[string]string{"some": "data"})
 
-		err := cl.Apply(context.Background(), obj)
+		err := cl.Apply(ctx, obj)
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "Expected error to be an invalid error")
 	})
 
-	It("errors when trying to server-side apply an object with an invalid FieldManager", func() {
+	It("errors when trying to server-side apply an object with an invalid FieldManager", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := corev1applyconfigurations.
 			ConfigMap("foo", "default").
 			WithData(map[string]string{"some": "data"})
 
-		err := cl.Apply(context.Background(), obj, client.FieldOwner("\x00"))
+		err := cl.Apply(ctx, obj, client.FieldOwner("\x00"))
 		Expect(err).To(HaveOccurred())
 		Expect(apierrors.IsInvalid(err)).To(BeTrue(), "Expected error to be an invalid error")
 	})
 
-	It("supports server-side apply of a custom resource via Apply method", func() {
+	It("supports server-side apply of a custom resource via Apply method", func(ctx SpecContext) {
 		cl := NewClientBuilder().Build()
 		obj := &unstructured.Unstructured{}
 		obj.SetAPIVersion("custom/v1")
@@ -2724,16 +2723,16 @@ var _ = Describe("Fake client", func() {
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "spec")).To(Succeed())
 
 		applyConfig := client.ApplyConfigurationFromUnstructured(obj)
-		Expect(cl.Apply(context.Background(), applyConfig, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
+		Expect(cl.Apply(ctx, applyConfig, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(result), result)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "spec")).To(Succeed())
 		applyConfig2 := client.ApplyConfigurationFromUnstructured(obj)
-		Expect(cl.Apply(context.Background(), applyConfig2, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
+		Expect(cl.Apply(ctx, applyConfig2, &client.ApplyOptions{FieldManager: "test-manager"})).To(Succeed())
 
-		Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(result), result)).To(Succeed())
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"other": "data"}))
 	})
 
@@ -2772,11 +2771,11 @@ var _ = Describe("Fake client", func() {
 		},
 	}
 	for _, obj := range scalableObjs {
-		It(fmt.Sprintf("should be able to Get scale subresources for resource %T", obj), func() {
+		It(fmt.Sprintf("should be able to Get scale subresources for resource %T", obj), func(ctx SpecContext) {
 			cl := NewClientBuilder().WithObjects(obj).Build()
 
 			scaleActual := &autoscalingv1.Scale{}
-			Expect(cl.SubResource(subResourceScale).Get(context.Background(), obj, scaleActual)).NotTo(HaveOccurred())
+			Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scaleActual)).NotTo(HaveOccurred())
 
 			scaleExpected := &autoscalingv1.Scale{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2791,14 +2790,14 @@ var _ = Describe("Fake client", func() {
 			Expect(cmp.Diff(scaleExpected, scaleActual)).To(BeEmpty())
 		})
 
-		It(fmt.Sprintf("should be able to Update scale subresources for resource %T", obj), func() {
+		It(fmt.Sprintf("should be able to Update scale subresources for resource %T", obj), func(ctx SpecContext) {
 			cl := NewClientBuilder().WithObjects(obj).Build()
 
 			scaleExpected := &autoscalingv1.Scale{Spec: autoscalingv1.ScaleSpec{Replicas: 3}}
-			Expect(cl.SubResource(subResourceScale).Update(context.Background(), obj, client.WithSubResourceBody(scaleExpected))).NotTo(HaveOccurred())
+			Expect(cl.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scaleExpected))).NotTo(HaveOccurred())
 
 			objActual := obj.DeepCopyObject().(client.Object)
-			Expect(cl.Get(context.Background(), client.ObjectKeyFromObject(objActual), objActual)).To(Succeed())
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(objActual), objActual)).To(Succeed())
 
 			objExpected := obj.DeepCopyObject().(client.Object)
 			switch expected := objExpected.(type) {
@@ -2818,7 +2817,7 @@ var _ = Describe("Fake client", func() {
 			Expect(cmp.Diff(objExpected, objActual)).To(BeEmpty())
 
 			scaleActual := &autoscalingv1.Scale{}
-			Expect(cl.SubResource(subResourceScale).Get(context.Background(), obj, scaleActual)).NotTo(HaveOccurred())
+			Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scaleActual)).NotTo(HaveOccurred())
 
 			// When we called Update, these were derived but we need them now to compare.
 			scaleExpected.Name = scaleActual.Name
@@ -2876,7 +2875,7 @@ func (in *Schemaless) DeepCopy() *Schemaless {
 }
 
 var _ = Describe("Fake client builder", func() {
-	It("panics when an index with the same name and GroupVersionKind is registered twice", func() {
+	It("panics when an index with the same name and GroupVersionKind is registered twice", func(ctx SpecContext) {
 		// We need any realistic GroupVersionKind, the choice of apps/v1 Deployment is arbitrary.
 		cb := NewClientBuilder().WithIndex(&appsv1.Deployment{},
 			"test-name",
@@ -2889,7 +2888,7 @@ var _ = Describe("Fake client builder", func() {
 		}).To(Panic())
 	})
 
-	It("should wrap the fake client with an interceptor when WithInterceptorFuncs is called", func() {
+	It("should wrap the fake client with an interceptor when WithInterceptorFuncs is called", func(ctx SpecContext) {
 		var called bool
 		cli := NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -2897,7 +2896,7 @@ var _ = Describe("Fake client builder", func() {
 				return nil
 			},
 		}).Build()
-		err := cli.Get(context.Background(), client.ObjectKey{}, &corev1.Pod{})
+		err := cli.Get(ctx, client.ObjectKey{}, &corev1.Pod{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(called).To(BeTrue())
 	})

--- a/pkg/client/fieldowner_test.go
+++ b/pkg/client/fieldowner_test.go
@@ -31,7 +31,7 @@ func TestWithFieldOwner(t *testing.T) {
 	fakeClient := testClient(t, "custom-field-mgr", func() { calls++ })
 	wrappedClient := client.WithFieldOwner(fakeClient, "custom-field-mgr")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dummyObj := &corev1.Namespace{}
 
 	_ = wrappedClient.Create(ctx, dummyObj)
@@ -55,7 +55,7 @@ func TestWithFieldOwnerOverridden(t *testing.T) {
 	fakeClient := testClient(t, "new-field-manager", func() { calls++ })
 	wrappedClient := client.WithFieldOwner(fakeClient, "old-field-manager")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dummyObj := &corev1.Namespace{}
 
 	_ = wrappedClient.Create(ctx, dummyObj, client.FieldOwner("new-field-manager"))

--- a/pkg/client/fieldvalidation_test.go
+++ b/pkg/client/fieldvalidation_test.go
@@ -34,13 +34,12 @@ import (
 )
 
 var _ = Describe("ClientWithFieldValidation", func() {
-	It("should return errors for invalid fields when using strict validation", func() {
+	It("should return errors for invalid fields when using strict validation", func(ctx SpecContext) {
 		cl, err := client.New(cfg, client.Options{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(cl).NotTo(BeNil())
 
 		wrappedClient := client.WithFieldValidation(cl, metav1.FieldValidationStrict)
-		ctx := context.Background()
 
 		baseNode := &unstructured.Unstructured{}
 		baseNode.SetGroupVersionKind(schema.GroupVersionKind{
@@ -101,7 +100,7 @@ func TestWithStrictFieldValidation(t *testing.T) {
 	fakeClient := testFieldValidationClient(t, metav1.FieldValidationStrict, func() { calls++ })
 	wrappedClient := client.WithFieldValidation(fakeClient, metav1.FieldValidationStrict)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dummyObj := &corev1.Namespace{}
 
 	_ = wrappedClient.Create(ctx, dummyObj)
@@ -126,7 +125,7 @@ func TestWithStrictFieldValidationOverridden(t *testing.T) {
 	fakeClient := testFieldValidationClient(t, metav1.FieldValidationWarn, func() { calls++ })
 	wrappedClient := client.WithFieldValidation(fakeClient, metav1.FieldValidationStrict)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	dummyObj := &corev1.Namespace{}
 
 	_ = wrappedClient.Create(ctx, dummyObj, client.FieldValidation(metav1.FieldValidationWarn))

--- a/pkg/client/interceptor/intercept_test.go
+++ b/pkg/client/interceptor/intercept_test.go
@@ -16,8 +16,7 @@ import (
 
 var _ = Describe("NewClient", func() {
 	wrappedClient := dummyClient{}
-	ctx := context.Background()
-	It("should call the provided Get function", func() {
+	It("should call the provided Get function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -28,7 +27,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Get(ctx, types.NamespacedName{}, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Get function is nil", func() {
+	It("should call the underlying client if the provided Get function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
@@ -40,7 +39,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Get(ctx, types.NamespacedName{}, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided List function", func() {
+	It("should call the provided List function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
@@ -51,7 +50,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.List(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided List function is nil", func() {
+	It("should call the underlying client if the provided List function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			List: func(ctx context.Context, client client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
@@ -63,7 +62,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.List(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Apply function", func() {
+	It("should call the provided Apply function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Apply: func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
@@ -74,7 +73,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Apply(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Apply function is nil", func() {
+	It("should call the underlying client if the provided Apply function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Apply: func(ctx context.Context, client client.WithWatch, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
@@ -86,7 +85,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Apply(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Create function", func() {
+	It("should call the provided Create function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
@@ -97,7 +96,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Create(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Create function is nil", func() {
+	It("should call the underlying client if the provided Create function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Create: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
@@ -109,7 +108,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Create(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Delete function", func() {
+	It("should call the provided Delete function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
@@ -120,7 +119,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Delete(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Delete function is nil", func() {
+	It("should call the underlying client if the provided Delete function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Delete: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
@@ -132,7 +131,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Delete(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided DeleteAllOf function", func() {
+	It("should call the provided DeleteAllOf function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			DeleteAllOf: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error {
@@ -143,7 +142,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.DeleteAllOf(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided DeleteAllOf function is nil", func() {
+	It("should call the underlying client if the provided DeleteAllOf function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			DeleteAllOf: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error {
@@ -155,7 +154,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.DeleteAllOf(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Update function", func() {
+	It("should call the provided Update function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
@@ -166,7 +165,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Update(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Update function is nil", func() {
+	It("should call the underlying client if the provided Update function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Update: func(ctx context.Context, client client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
@@ -178,7 +177,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Update(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Patch function", func() {
+	It("should call the provided Patch function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
@@ -189,7 +188,7 @@ var _ = Describe("NewClient", func() {
 		_ = client.Patch(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Patch function is nil", func() {
+	It("should call the underlying client if the provided Patch function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Patch: func(ctx context.Context, client client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
@@ -201,7 +200,7 @@ var _ = Describe("NewClient", func() {
 		_ = client2.Patch(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Watch function", func() {
+	It("should call the provided Watch function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(wrappedClient, Funcs{
 			Watch: func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
@@ -212,7 +211,7 @@ var _ = Describe("NewClient", func() {
 		_, _ = client.Watch(ctx, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Watch function is nil", func() {
+	It("should call the underlying client if the provided Watch function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(wrappedClient, Funcs{
 			Watch: func(ctx context.Context, client client.WithWatch, obj client.ObjectList, opts ...client.ListOption) (watch.Interface, error) {
@@ -252,8 +251,7 @@ var _ = Describe("NewClient", func() {
 
 var _ = Describe("NewSubResourceClient", func() {
 	c := dummyClient{}
-	ctx := context.Background()
-	It("should call the provided Get function", func() {
+	It("should call the provided Get function", func(ctx SpecContext) {
 		var called bool
 		c := NewClient(c, Funcs{
 			SubResourceGet: func(_ context.Context, client client.Client, subResourceName string, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
@@ -265,7 +263,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = c.SubResource("foo").Get(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Get function is nil", func() {
+	It("should call the underlying client if the provided Get function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(c, Funcs{
 			SubResourceGet: func(_ context.Context, client client.Client, subResourceName string, obj, subResource client.Object, opts ...client.SubResourceGetOption) error {
@@ -278,7 +276,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client2.SubResource("foo").Get(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Update function", func() {
+	It("should call the provided Update function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(c, Funcs{
 			SubResourceUpdate: func(_ context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
@@ -290,7 +288,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client.SubResource("foo").Update(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Update function is nil", func() {
+	It("should call the underlying client if the provided Update function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(c, Funcs{
 			SubResourceUpdate: func(_ context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
@@ -303,7 +301,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client2.SubResource("foo").Update(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Patch function", func() {
+	It("should call the provided Patch function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(c, Funcs{
 			SubResourcePatch: func(_ context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
@@ -315,7 +313,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client.SubResource("foo").Patch(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Patch function is nil", func() {
+	It("should call the underlying client if the provided Patch function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(c, Funcs{
 			SubResourcePatch: func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
@@ -328,7 +326,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client2.SubResource("foo").Patch(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the provided Create function", func() {
+	It("should call the provided Create function", func(ctx SpecContext) {
 		var called bool
 		client := NewClient(c, Funcs{
 			SubResourceCreate: func(_ context.Context, client client.Client, subResourceName string, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {
@@ -340,7 +338,7 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client.SubResource("foo").Create(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
-	It("should call the underlying client if the provided Create function is nil", func() {
+	It("should call the underlying client if the provided Create function is nil", func(ctx SpecContext) {
 		var called bool
 		client1 := NewClient(c, Funcs{
 			SubResourceCreate: func(_ context.Context, client client.Client, subResourceName string, obj, subResource client.Object, opts ...client.SubResourceCreateOption) error {

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -100,22 +100,22 @@ var _ = Describe("cluster.Cluster", func() {
 	})
 
 	Describe("Start", func() {
-		It("should stop when context is cancelled", func() {
+		It("should stop when context is cancelled", func(specCtx SpecContext) {
 			c, err := New(cfg)
 			Expect(err).NotTo(HaveOccurred())
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(specCtx)
 			cancel()
 			Expect(c.Start(ctx)).NotTo(HaveOccurred())
 		})
 	})
 
-	It("should not leak goroutines when stopped", func() {
+	It("should not leak goroutines when stopped", func(specCtx SpecContext) {
 		currentGRs := goleak.IgnoreCurrent()
 
 		c, err := New(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(specCtx)
 		cancel()
 		Expect(c.Start(ctx)).NotTo(HaveOccurred())
 

--- a/pkg/controller/controller_integration_test.go
+++ b/pkg/controller/controller_integration_test.go
@@ -43,7 +43,6 @@ import (
 
 var _ = Describe("controller", func() {
 	var reconciled chan reconcile.Request
-	ctx := context.Background()
 
 	BeforeEach(func() {
 		reconciled = make(chan reconcile.Request)
@@ -58,7 +57,7 @@ var _ = Describe("controller", func() {
 		// test, as it causes flakes with the api-server termination timing out.
 		// See https://github.com/kubernetes-sigs/controller-runtime/issues/1571 for a description
 		// of the issue, and a discussion here: https://github.com/kubernetes-sigs/controller-runtime/pull/3192#discussion_r2186967799
-		DescribeTable("should reconcile", func(enableWarmup bool) {
+		DescribeTable("should reconcile", func(ctx SpecContext, enableWarmup bool) {
 			By("Creating the Manager")
 			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
@@ -103,8 +102,6 @@ var _ = Describe("controller", func() {
 			Expect(err).To(Equal(&cache.ErrCacheNotStarted{}))
 
 			By("Starting the Manager")
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			go func() {
 				defer GinkgoRecover()
 				Expect(cm.Start(ctx)).NotTo(HaveOccurred())
@@ -198,7 +195,7 @@ var _ = Describe("controller", func() {
 
 			By("Listing a type with a slice of pointers as items field")
 			err = cm.GetClient().
-				List(context.Background(), &controllertest.UnconventionalListTypeList{})
+				List(ctx, &controllertest.UnconventionalListTypeList{})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Invoking Reconciling for a pod when it is created when adding watcher dynamically")

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -136,10 +136,10 @@ var _ = Describe("controller.Controller", func() {
 			Expect(c2).ToNot(BeNil())
 		})
 
-		It("should not leak goroutines when stopped", func() {
+		It("should not leak goroutines when stopped", func(specCtx SpecContext) {
 			currentGRs := goleak.IgnoreCurrent()
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(specCtx)
 			watchChan := make(chan event.GenericEvent, 1)
 			watch := source.Channel(watchChan, &handler.EnqueueRequestForObject{})
 			watchChan <- event.GenericEvent{Object: &corev1.Pod{}}

--- a/pkg/envtest/binaries_test.go
+++ b/pkg/envtest/binaries_test.go
@@ -20,7 +20,6 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"context"
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/hex"
@@ -50,8 +49,8 @@ var _ = Describe("Test download binaries", func() {
 		setupServer(server)
 	})
 
-	It("should download binaries of latest stable version", func() {
-		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(context.Background(), downloadDirectory, "", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
+	It("should download binaries of latest stable version", func(ctx SpecContext) {
+		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(ctx, downloadDirectory, "", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify latest stable version (v1.32.0) was downloaded
@@ -69,8 +68,8 @@ var _ = Describe("Test download binaries", func() {
 		Expect(actualFiles).To(ConsistOf("some-file"))
 	})
 
-	It("should download v1.32.0 binaries", func() {
-		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(context.Background(), downloadDirectory, "v1.31.0", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
+	It("should download v1.32.0 binaries", func(ctx SpecContext) {
+		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(ctx, downloadDirectory, "v1.31.0", fmt.Sprintf("http://%s/%s", server.Addr(), "envtest-releases.yaml"))
 		Expect(err).ToNot(HaveOccurred())
 
 		// Verify latest stable version (v1.32.0) was downloaded

--- a/pkg/envtest/envtest_test.go
+++ b/pkg/envtest/envtest_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package envtest
 
 import (
-	"context"
 	"path/filepath"
 	"time"
 
@@ -55,29 +54,29 @@ var _ = Describe("Test", func() {
 	})
 
 	// Cleanup CRDs
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		for _, crd := range crds {
 			// Delete only if CRD exists.
 			crdObjectKey := client.ObjectKey{
 				Name: crd.GetName(),
 			}
 			var placeholder apiextensionsv1.CustomResourceDefinition
-			if err = c.Get(context.TODO(), crdObjectKey, &placeholder); err != nil &&
+			if err = c.Get(ctx, crdObjectKey, &placeholder); err != nil &&
 				apierrors.IsNotFound(err) {
 				// CRD doesn't need to be deleted.
 				continue
 			}
 			Expect(err).NotTo(HaveOccurred())
-			Expect(c.Delete(context.TODO(), crd)).To(Succeed())
+			Expect(c.Delete(ctx, crd)).To(Succeed())
 			Eventually(func() bool {
-				err := c.Get(context.TODO(), crdObjectKey, &placeholder)
+				err := c.Get(ctx, crdObjectKey, &placeholder)
 				return apierrors.IsNotFound(err)
 			}, 5*time.Second).Should(BeTrue())
 		}
 	}, teardownTimeoutSeconds)
 
 	Describe("InstallCRDs", func() {
-		It("should install the unserved CRDs into the cluster", func() {
+		It("should install the unserved CRDs into the cluster", func(ctx SpecContext) {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "examplecrd_unserved.yaml")},
 			})
@@ -86,7 +85,7 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "frigates.ship.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "frigates.ship.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Frigate"))
 
@@ -115,7 +114,7 @@ var _ = Describe("Test", func() {
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
-		It("should install the CRDs into the cluster using directory", func() {
+		It("should install the CRDs into the cluster using directory", func(ctx SpecContext) {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
@@ -124,27 +123,27 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
@@ -244,14 +243,14 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should install the CRDs into the cluster using file", func() {
+		It("should install the CRDs into the cluster using file", func(ctx SpecContext) {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "examplecrd3.yaml")},
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "configs.foo.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "configs.foo.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Config"))
 
@@ -290,7 +289,7 @@ var _ = Describe("Test", func() {
 			Expect(crds).To(HaveLen(2))
 		})
 
-		It("should filter out already existent CRD", func() {
+		It("should filter out already existent CRD", func(ctx SpecContext) {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{
 					filepath.Join(".", "testdata"),
@@ -300,7 +299,7 @@ var _ = Describe("Test", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
@@ -422,7 +421,7 @@ var _ = Describe("Test", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should reinstall the CRDs if already present in the cluster", func() {
+		It("should reinstall the CRDs if already present in the cluster", func(ctx SpecContext) {
 
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata")},
@@ -432,27 +431,27 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
@@ -561,27 +560,27 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
@@ -682,15 +681,15 @@ var _ = Describe("Test", func() {
 		})
 	})
 
-	It("should set a working KubeConfig", func() {
+	It("should set a working KubeConfig", func(ctx SpecContext) {
 		kubeconfigRESTConfig, err := clientcmd.RESTConfigFromKubeConfig(env.KubeConfig)
 		Expect(err).ToNot(HaveOccurred())
 		kubeconfigClient, err := client.New(kubeconfigRESTConfig, client.Options{Scheme: s})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(kubeconfigClient.List(context.Background(), &apiextensionsv1.CustomResourceDefinitionList{})).To(Succeed())
+		Expect(kubeconfigClient.List(ctx, &apiextensionsv1.CustomResourceDefinitionList{})).To(Succeed())
 	})
 
-	It("should update CRDs if already present in the cluster", func() {
+	It("should update CRDs if already present in the cluster", func(ctx SpecContext) {
 
 		// Install only the CRDv1 multi-version example
 		crds, err = InstallCRDs(env.Config, CRDInstallOptions{
@@ -701,7 +700,7 @@ var _ = Describe("Test", func() {
 		// Expect to find the CRDs
 
 		crd := &apiextensionsv1.CustomResourceDefinition{}
-		err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+		err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 		Expect(len(crd.Spec.Versions)).To(BeEquivalentTo(2))
@@ -743,7 +742,7 @@ var _ = Describe("Test", func() {
 		// Expect to find updated CRD
 
 		crd = &apiextensionsv1.CustomResourceDefinition{}
-		err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+		err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 		Expect(len(crd.Spec.Versions)).To(BeEquivalentTo(3))
@@ -781,8 +780,7 @@ var _ = Describe("Test", func() {
 	})
 
 	Describe("UninstallCRDs", func() {
-		It("should uninstall the CRDs from the cluster", func() {
-
+		It("should uninstall the CRDs from the cluster", func(ctx SpecContext) {
 			crds, err = InstallCRDs(env.Config, CRDInstallOptions{
 				Paths: []string{validDirectory},
 			})
@@ -791,27 +789,27 @@ var _ = Describe("Test", func() {
 			// Expect to find the CRDs
 
 			crd := &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "foos.bar.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "foos.bar.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Foo"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "bazs.qux.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Baz"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "captains.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "captains.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Captain"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "firstmates.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("FirstMate"))
 
 			crd = &apiextensionsv1.CustomResourceDefinition{}
-			err = c.Get(context.TODO(), types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
+			err = c.Get(ctx, types.NamespacedName{Name: "drivers.crew.example.com"}, crd)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(crd.Spec.Names.Kind).To(Equal("Driver"))
 
@@ -927,7 +925,7 @@ var _ = Describe("Test", func() {
 			placeholder := &apiextensionsv1.CustomResourceDefinition{}
 			Eventually(func() bool {
 				for _, crd := range crds {
-					err = c.Get(context.TODO(), types.NamespacedName{Name: crd}, placeholder)
+					err = c.Get(ctx, types.NamespacedName{Name: crd}, placeholder)
 					notFound := err != nil && apierrors.IsNotFound(err)
 					if !notFound {
 						return false

--- a/pkg/envtest/webhook_test.go
+++ b/pkg/envtest/webhook_test.go
@@ -37,9 +37,8 @@ import (
 )
 
 var _ = Describe("Test", func() {
-
 	Describe("Webhook", func() {
-		It("should reject create request for webhook that rejects all requests", func() {
+		It("should reject create request for webhook that rejects all requests", func(specCtx SpecContext) {
 			m, err := manager.New(env.Config, manager.Options{
 				WebhookServer: webhook.NewServer(webhook.Options{
 					Port:    env.WebhookInstallOptions.LocalServingPort,
@@ -52,7 +51,7 @@ var _ = Describe("Test", func() {
 			server := m.GetWebhookServer()
 			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{}})
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(specCtx)
 			go func() {
 				_ = server.Start(ctx)
 			}()
@@ -88,7 +87,7 @@ var _ = Describe("Test", func() {
 			}
 
 			Eventually(func() bool {
-				err = c.Create(context.TODO(), obj)
+				err = c.Create(ctx, obj)
 				return err != nil && strings.HasSuffix(err.Error(), "Always denied") && apierrors.ReasonForError(err) == metav1.StatusReasonForbidden
 			}, 1*time.Second).Should(BeTrue())
 

--- a/pkg/finalizer/finalizer_test.go
+++ b/pkg/finalizer/finalizer_test.go
@@ -57,14 +57,14 @@ var _ = Describe("TestFinalizer", func() {
 	})
 
 	Describe("Finalize", func() {
-		It("successfully finalizes and returns true for Updated when deletion timestamp is nil and finalizer does not exist", func() {
+		It("successfully finalizes and returns true for Updated when deletion timestamp is nil and finalizer does not exist", func(ctx SpecContext) {
 			err = finalizers.Register("finalizers.sigs.k8s.io/testfinalizer", f)
 			Expect(err).ToNot(HaveOccurred())
 
 			pod.DeletionTimestamp = nil
 			pod.Finalizers = []string{}
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeTrue())
 			// when deletion timestamp is nil and finalizer is not present, the registered finalizer would be added to the obj
@@ -73,7 +73,7 @@ var _ = Describe("TestFinalizer", func() {
 
 		})
 
-		It("successfully finalizes and returns true for Updated when deletion timestamp is not nil and the finalizer exists", func() {
+		It("successfully finalizes and returns true for Updated when deletion timestamp is not nil and the finalizer exists", func(ctx SpecContext) {
 			now := metav1.Now()
 			pod.DeletionTimestamp = &now
 
@@ -82,37 +82,37 @@ var _ = Describe("TestFinalizer", func() {
 
 			pod.Finalizers = []string{"finalizers.sigs.k8s.io/testfinalizer"}
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeTrue())
 			// finalizer will be removed from the obj upon successful finalization
 			Expect(pod.Finalizers).To(BeEmpty())
 		})
 
-		It("should return no error and return false for Updated when deletion timestamp is nil and finalizer doesn't exist", func() {
+		It("should return no error and return false for Updated when deletion timestamp is nil and finalizer doesn't exist", func(ctx SpecContext) {
 			pod.DeletionTimestamp = nil
 			pod.Finalizers = []string{}
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeFalse())
 			Expect(pod.Finalizers).To(BeEmpty())
 
 		})
 
-		It("should return no error and return false for Updated when deletion timestamp is not nil and the finalizer doesn't exist", func() {
+		It("should return no error and return false for Updated when deletion timestamp is not nil and the finalizer doesn't exist", func(ctx SpecContext) {
 			now := metav1.Now()
 			pod.DeletionTimestamp = &now
 			pod.Finalizers = []string{}
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeFalse())
 			Expect(pod.Finalizers).To(BeEmpty())
 
 		})
 
-		It("successfully finalizes multiple finalizers and returns true for Updated when deletion timestamp is not nil and the finalizer exists", func() {
+		It("successfully finalizes multiple finalizers and returns true for Updated when deletion timestamp is not nil and the finalizer exists", func(ctx SpecContext) {
 			now := metav1.Now()
 			pod.DeletionTimestamp = &now
 
@@ -124,14 +124,14 @@ var _ = Describe("TestFinalizer", func() {
 
 			pod.Finalizers = []string{"finalizers.sigs.k8s.io/testfinalizer", "finalizers.sigs.k8s.io/newtestfinalizer"}
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeTrue())
 			Expect(result.StatusUpdated).To(BeFalse())
 			Expect(pod.Finalizers).To(BeEmpty())
 		})
 
-		It("should return result as false and a non-nil error", func() {
+		It("should return result as false and a non-nil error", func(ctx SpecContext) {
 			now := metav1.Now()
 			pod.DeletionTimestamp = &now
 			pod.Finalizers = []string{"finalizers.sigs.k8s.io/testfinalizer"}
@@ -143,7 +143,7 @@ var _ = Describe("TestFinalizer", func() {
 			err = finalizers.Register("finalizers.sigs.k8s.io/testfinalizer", f)
 			Expect(err).ToNot(HaveOccurred())
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("finalizer failed"))
 			Expect(result.Updated).To(BeFalse())
@@ -152,7 +152,7 @@ var _ = Describe("TestFinalizer", func() {
 			Expect(pod.Finalizers[0]).To(Equal("finalizers.sigs.k8s.io/testfinalizer"))
 		})
 
-		It("should return expected result values and error values when registering multiple finalizers", func() {
+		It("should return expected result values and error values when registering multiple finalizers", func(ctx SpecContext) {
 			now := metav1.Now()
 			pod.DeletionTimestamp = &now
 			pod.Finalizers = []string{
@@ -169,7 +169,7 @@ var _ = Describe("TestFinalizer", func() {
 			err = finalizers.Register("finalizers.sigs.k8s.io/testfinalizer1", f)
 			Expect(err).ToNot(HaveOccurred())
 
-			result, err := finalizers.Finalize(context.TODO(), pod)
+			result, err := finalizers.Finalize(ctx, pod)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Updated).To(BeTrue())
 			Expect(result.StatusUpdated).To(BeFalse())
@@ -186,7 +186,7 @@ var _ = Describe("TestFinalizer", func() {
 			err = finalizers.Register("finalizers.sigs.k8s.io/testfinalizer2", f)
 			Expect(err).ToNot(HaveOccurred())
 
-			result, err = finalizers.Finalize(context.TODO(), pod)
+			result, err = finalizers.Finalize(ctx, pod)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("finalizer failed"))
 			Expect(result.Updated).To(BeFalse())
@@ -202,7 +202,7 @@ var _ = Describe("TestFinalizer", func() {
 			err = finalizers.Register("finalizers.sigs.k8s.io/testfinalizer3", f)
 			Expect(err).ToNot(HaveOccurred())
 
-			result, err = finalizers.Finalize(context.TODO(), pod)
+			result, err = finalizers.Finalize(ctx, pod)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("finalizer failed"))
 			Expect(result.Updated).To(BeTrue())

--- a/pkg/handler/eventhandler_test.go
+++ b/pkg/handler/eventhandler_test.go
@@ -41,7 +41,6 @@ import (
 )
 
 var _ = Describe("Eventhandler", func() {
-	var ctx = context.Background()
 	var q workqueue.TypedRateLimitingInterface[reconcile.Request]
 	var instance handler.EnqueueRequestForObject
 	var pod *corev1.Pod
@@ -60,7 +59,7 @@ var _ = Describe("Eventhandler", func() {
 	})
 
 	Describe("EnqueueRequestForObject", func() {
-		It("should enqueue a Request with the Name / Namespace of the object in the CreateEvent.", func() {
+		It("should enqueue a Request with the Name / Namespace of the object in the CreateEvent.", func(ctx SpecContext) {
 			evt := event.CreateEvent{
 				Object: pod,
 			}
@@ -71,7 +70,7 @@ var _ = Describe("Eventhandler", func() {
 			Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
 		})
 
-		It("should enqueue a Request with the Name / Namespace of the object in the DeleteEvent.", func() {
+		It("should enqueue a Request with the Name / Namespace of the object in the DeleteEvent.", func(ctx SpecContext) {
 			evt := event.DeleteEvent{
 				Object: pod,
 			}
@@ -83,7 +82,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		It("should enqueue a Request with the Name / Namespace of one object in the UpdateEvent.",
-			func() {
+			func(ctx SpecContext) {
 				newPod := pod.DeepCopy()
 				newPod.Name = "baz2"
 				newPod.Namespace = "biz2"
@@ -99,7 +98,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz2", Name: "baz2"}))
 			})
 
-		It("should enqueue a Request with the Name / Namespace of the object in the GenericEvent.", func() {
+		It("should enqueue a Request with the Name / Namespace of the object in the GenericEvent.", func(ctx SpecContext) {
 			evt := event.GenericEvent{
 				Object: pod,
 			}
@@ -110,7 +109,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		Context("for a runtime.Object without Object", func() {
-			It("should do nothing if the Object is missing for a CreateEvent.", func() {
+			It("should do nothing if the Object is missing for a CreateEvent.", func(ctx SpecContext) {
 				evt := event.CreateEvent{
 					Object: nil,
 				}
@@ -118,7 +117,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(q.Len()).To(Equal(0))
 			})
 
-			It("should do nothing if the Object is missing for a UpdateEvent.", func() {
+			It("should do nothing if the Object is missing for a UpdateEvent.", func(ctx SpecContext) {
 				newPod := pod.DeepCopy()
 				newPod.Name = "baz2"
 				newPod.Namespace = "biz2"
@@ -140,7 +139,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(req.NamespacedName).To(Equal(types.NamespacedName{Namespace: "biz", Name: "baz"}))
 			})
 
-			It("should do nothing if the Object is missing for a DeleteEvent.", func() {
+			It("should do nothing if the Object is missing for a DeleteEvent.", func(ctx SpecContext) {
 				evt := event.DeleteEvent{
 					Object: nil,
 				}
@@ -148,7 +147,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(q.Len()).To(Equal(0))
 			})
 
-			It("should do nothing if the Object is missing for a GenericEvent.", func() {
+			It("should do nothing if the Object is missing for a GenericEvent.", func(ctx SpecContext) {
 				evt := event.GenericEvent{
 					Object: nil,
 				}
@@ -159,7 +158,7 @@ var _ = Describe("Eventhandler", func() {
 	})
 
 	Describe("EnqueueRequestsFromMapFunc", func() {
-		It("should enqueue a Request with the function applied to the CreateEvent.", func() {
+		It("should enqueue a Request with the function applied to the CreateEvent.", func(ctx SpecContext) {
 			req := []reconcile.Request{}
 			instance := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
@@ -191,7 +190,7 @@ var _ = Describe("Eventhandler", func() {
 			))
 		})
 
-		It("should enqueue a Request with the function applied to the DeleteEvent.", func() {
+		It("should enqueue a Request with the function applied to the DeleteEvent.", func(ctx SpecContext) {
 			req := []reconcile.Request{}
 			instance := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
@@ -224,7 +223,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		It("should enqueue a Request with the function applied to both objects in the UpdateEvent.",
-			func() {
+			func(ctx SpecContext) {
 				newPod := pod.DeepCopy()
 
 				req := []reconcile.Request{}
@@ -256,7 +255,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(i).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Namespace: "biz", Name: "baz-baz"}}))
 			})
 
-		It("should enqueue a Request with the function applied to the GenericEvent.", func() {
+		It("should enqueue a Request with the function applied to the GenericEvent.", func(ctx SpecContext) {
 			req := []reconcile.Request{}
 			instance := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []reconcile.Request {
 				defer GinkgoRecover()
@@ -290,7 +289,7 @@ var _ = Describe("Eventhandler", func() {
 	})
 
 	Describe("EnqueueRequestForOwner", func() {
-		It("should enqueue a Request with the Owner of the object in the CreateEvent.", func() {
+		It("should enqueue a Request with the Owner of the object in the CreateEvent.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 
 			pod.OwnerReferences = []metav1.OwnerReference{
@@ -311,7 +310,7 @@ var _ = Describe("Eventhandler", func() {
 				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
-		It("should enqueue a Request with the Owner of the object in the DeleteEvent.", func() {
+		It("should enqueue a Request with the Owner of the object in the DeleteEvent.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 
 			pod.OwnerReferences = []metav1.OwnerReference{
@@ -332,7 +331,7 @@ var _ = Describe("Eventhandler", func() {
 				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
-		It("should enqueue a Request with the Owners of both objects in the UpdateEvent.", func() {
+		It("should enqueue a Request with the Owners of both objects in the UpdateEvent.", func(ctx SpecContext) {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
@@ -370,7 +369,7 @@ var _ = Describe("Eventhandler", func() {
 			))
 		})
 
-		It("should enqueue a Request with the one duplicate Owner of both objects in the UpdateEvent.", func() {
+		It("should enqueue a Request with the one duplicate Owner of both objects in the UpdateEvent.", func(ctx SpecContext) {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 
@@ -402,7 +401,7 @@ var _ = Describe("Eventhandler", func() {
 				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
-		It("should enqueue a Request with the Owner of the object in the GenericEvent.", func() {
+		It("should enqueue a Request with the Owner of the object in the GenericEvent.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 			pod.OwnerReferences = []metav1.OwnerReference{
 				{
@@ -422,7 +421,7 @@ var _ = Describe("Eventhandler", func() {
 				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
-		It("should not enqueue a Request if there are no owners matching Group and Kind.", func() {
+		It("should not enqueue a Request if there are no owners matching Group and Kind.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{}, handler.OnlyControllerOwner())
 			pod.OwnerReferences = []metav1.OwnerReference{
 				{ // Wrong group
@@ -444,7 +443,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		It("should enqueue a Request if there are owners matching Group "+
-			"and Kind with a different version.", func() {
+			"and Kind with a different version.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &autoscalingv1.HorizontalPodAutoscaler{})
 			pod.OwnerReferences = []metav1.OwnerReference{
 				{
@@ -464,7 +463,7 @@ var _ = Describe("Eventhandler", func() {
 				NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo-parent"}}))
 		})
 
-		It("should enqueue a Request for a owner that is cluster scoped", func() {
+		It("should enqueue a Request for a owner that is cluster scoped", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &corev1.Node{})
 			pod.OwnerReferences = []metav1.OwnerReference{
 				{
@@ -485,7 +484,7 @@ var _ = Describe("Eventhandler", func() {
 
 		})
 
-		It("should not enqueue a Request if there are no owners.", func() {
+		It("should not enqueue a Request if there are no owners.", func(ctx SpecContext) {
 			instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 			evt := event.CreateEvent{
 				Object: pod,
@@ -496,7 +495,7 @@ var _ = Describe("Eventhandler", func() {
 
 		Context("with the Controller field set to true", func() {
 			It("should enqueue reconcile.Requests for only the first the Controller if there are "+
-				"multiple Controller owners.", func() {
+				"multiple Controller owners.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{}, handler.OnlyControllerOwner())
 				pod.OwnerReferences = []metav1.OwnerReference{
 					{
@@ -537,7 +536,7 @@ var _ = Describe("Eventhandler", func() {
 					NamespacedName: types.NamespacedName{Namespace: pod.GetNamespace(), Name: "foo2-parent"}}))
 			})
 
-			It("should not enqueue reconcile.Requests if there are no Controller owners.", func() {
+			It("should not enqueue reconcile.Requests if there are no Controller owners.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{}, handler.OnlyControllerOwner())
 				pod.OwnerReferences = []metav1.OwnerReference{
 					{
@@ -563,7 +562,7 @@ var _ = Describe("Eventhandler", func() {
 				Expect(q.Len()).To(Equal(0))
 			})
 
-			It("should not enqueue reconcile.Requests if there are no owners.", func() {
+			It("should not enqueue reconcile.Requests if there are no owners.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{}, handler.OnlyControllerOwner())
 				evt := event.CreateEvent{
 					Object: pod,
@@ -574,7 +573,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		Context("with the Controller field set to false", func() {
-			It("should enqueue a reconcile.Requests for all owners.", func() {
+			It("should enqueue a reconcile.Requests for all owners.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 				pod.OwnerReferences = []metav1.OwnerReference{
 					{
@@ -614,7 +613,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		Context("with a nil object", func() {
-			It("should do nothing.", func() {
+			It("should do nothing.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 				pod.OwnerReferences = []metav1.OwnerReference{
 					{
@@ -640,7 +639,7 @@ var _ = Describe("Eventhandler", func() {
 		})
 
 		Context("with an invalid APIVersion in the OwnerReference", func() {
-			It("should do nothing.", func() {
+			It("should do nothing.", func(ctx SpecContext) {
 				instance := handler.EnqueueRequestForOwner(scheme.Scheme, mapper, &appsv1.ReplicaSet{})
 				pod.OwnerReferences = []metav1.OwnerReference{
 					{
@@ -678,7 +677,7 @@ var _ = Describe("Eventhandler", func() {
 			},
 		}
 
-		It("should call CreateFunc for a CreateEvent if provided.", func() {
+		It("should call CreateFunc for a CreateEvent if provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			evt := event.CreateEvent{
 				Object: pod,
@@ -691,7 +690,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Create(ctx, evt, q)
 		})
 
-		It("should NOT call CreateFunc for a CreateEvent if NOT provided.", func() {
+		It("should NOT call CreateFunc for a CreateEvent if NOT provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			instance.CreateFunc = nil
 			evt := event.CreateEvent{
@@ -700,7 +699,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Create(ctx, evt, q)
 		})
 
-		It("should call UpdateFunc for an UpdateEvent if provided.", func() {
+		It("should call UpdateFunc for an UpdateEvent if provided.", func(ctx SpecContext) {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
@@ -719,7 +718,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Update(ctx, evt, q)
 		})
 
-		It("should NOT call UpdateFunc for an UpdateEvent if NOT provided.", func() {
+		It("should NOT call UpdateFunc for an UpdateEvent if NOT provided.", func(ctx SpecContext) {
 			newPod := pod.DeepCopy()
 			newPod.Name = pod.Name + "2"
 			newPod.Namespace = pod.Namespace + "2"
@@ -730,7 +729,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Update(ctx, evt, q)
 		})
 
-		It("should call DeleteFunc for a DeleteEvent if provided.", func() {
+		It("should call DeleteFunc for a DeleteEvent if provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			evt := event.DeleteEvent{
 				Object: pod,
@@ -743,7 +742,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Delete(ctx, evt, q)
 		})
 
-		It("should NOT call DeleteFunc for a DeleteEvent if NOT provided.", func() {
+		It("should NOT call DeleteFunc for a DeleteEvent if NOT provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			instance.DeleteFunc = nil
 			evt := event.DeleteEvent{
@@ -752,7 +751,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Delete(ctx, evt, q)
 		})
 
-		It("should call GenericFunc for a GenericEvent if provided.", func() {
+		It("should call GenericFunc for a GenericEvent if provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			evt := event.GenericEvent{
 				Object: pod,
@@ -765,7 +764,7 @@ var _ = Describe("Eventhandler", func() {
 			instance.Generic(ctx, evt, q)
 		})
 
-		It("should NOT call GenericFunc for a GenericEvent if NOT provided.", func() {
+		It("should NOT call GenericFunc for a GenericEvent if NOT provided.", func(ctx SpecContext) {
 			instance := failingFuncs
 			instance.GenericFunc = nil
 			evt := event.GenericEvent{
@@ -841,7 +840,7 @@ var _ = Describe("Eventhandler", func() {
 		}
 		for _, test := range handlerPriorityTests {
 			When("handler is "+test.name, func() {
-				It("should lower the priority of a create request for an object that was part of the initial list", func() {
+				It("should lower the priority of a create request for an object that was part of the initial list", func(ctx SpecContext) {
 					actualOpts := priorityqueue.AddOpts{}
 					var actualRequests []reconcile.Request
 					wq := &fakePriorityQueue{
@@ -867,7 +866,7 @@ var _ = Describe("Eventhandler", func() {
 					Expect(actualRequests).To(Equal([]reconcile.Request{{NamespacedName: types.NamespacedName{Name: "my-pod"}}}))
 				})
 
-				It("should not lower the priority of a create request for an object that was not part of the initial list", func() {
+				It("should not lower the priority of a create request for an object that was not part of the initial list", func(ctx SpecContext) {
 					actualOpts := priorityqueue.AddOpts{}
 					var actualRequests []reconcile.Request
 					wq := &fakePriorityQueue{
@@ -893,7 +892,7 @@ var _ = Describe("Eventhandler", func() {
 					Expect(actualRequests).To(Equal([]reconcile.Request{{NamespacedName: types.NamespacedName{Name: "my-pod"}}}))
 				})
 
-				It("should lower the priority of an update request with unchanged RV", func() {
+				It("should lower the priority of an update request with unchanged RV", func(ctx SpecContext) {
 					actualOpts := priorityqueue.AddOpts{}
 					var actualRequests []reconcile.Request
 					wq := &fakePriorityQueue{
@@ -924,7 +923,7 @@ var _ = Describe("Eventhandler", func() {
 					Expect(actualRequests).To(Equal([]reconcile.Request{{NamespacedName: types.NamespacedName{Name: "my-pod"}}}))
 				})
 
-				It("should not lower the priority of an update request with changed RV", func() {
+				It("should not lower the priority of an update request with changed RV", func(ctx SpecContext) {
 					actualOpts := priorityqueue.AddOpts{}
 					var actualRequests []reconcile.Request
 					wq := &fakePriorityQueue{
@@ -956,7 +955,7 @@ var _ = Describe("Eventhandler", func() {
 					Expect(actualRequests).To(Equal([]reconcile.Request{{NamespacedName: types.NamespacedName{Name: "my-pod"}}}))
 				})
 
-				It("should have no effect on create if the workqueue is not a priorityqueue", func() {
+				It("should have no effect on create if the workqueue is not a priorityqueue", func(ctx SpecContext) {
 					test.handler().Create(ctx, event.CreateEvent{
 						Object: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 							Name: "my-pod",
@@ -972,7 +971,7 @@ var _ = Describe("Eventhandler", func() {
 					Expect(item).To(Equal(reconcile.Request{NamespacedName: types.NamespacedName{Name: "my-pod"}}))
 				})
 
-				It("should have no effect on Update if the workqueue is not a priorityqueue", func() {
+				It("should have no effect on Update if the workqueue is not a priorityqueue", func(ctx SpecContext) {
 					test.handler().Update(ctx, event.UpdateEvent{
 						ObjectOld: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
 							Name: "my-pod",

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -37,7 +37,7 @@ import (
 
 var _ = Describe("recorder", func() {
 	Describe("recorder", func() {
-		It("should publish events", func() {
+		It("should publish events", func(ctx SpecContext) {
 			By("Creating the Manager")
 			cm, err := manager.New(cfg, manager.Options{})
 			Expect(err).NotTo(HaveOccurred())
@@ -60,8 +60,6 @@ var _ = Describe("recorder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Starting the Manager")
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
 			go func() {
 				defer GinkgoRecover()
 				Expect(cm.Start(ctx)).NotTo(HaveOccurred())

--- a/pkg/internal/source/internal_test.go
+++ b/pkg/internal/source/internal_test.go
@@ -38,11 +38,10 @@ import (
 )
 
 var _ = Describe("Internal", func() {
-	var ctx = context.Background()
 	var instance *internal.EventHandler[client.Object, reconcile.Request]
 	var funcs, setfuncs *handler.Funcs
 	var set bool
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		funcs = &handler.Funcs{
 			CreateFunc: func(context.Context, event.CreateEvent, workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 				defer GinkgoRecover()
@@ -92,7 +91,7 @@ var _ = Describe("Internal", func() {
 			newPod.Labels = map[string]string{"foo": "bar"}
 		})
 
-		It("should create a CreateEvent", func() {
+		It("should create a CreateEvent", func(ctx SpecContext) {
 			funcs.CreateFunc = func(ctx context.Context, evt event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 				defer GinkgoRecover()
 				Expect(evt.Object).To(Equal(pod))
@@ -100,7 +99,7 @@ var _ = Describe("Internal", func() {
 			instance.OnAdd(pod, false)
 		})
 
-		It("should used Predicates to filter CreateEvents", func() {
+		It("should used Predicates to filter CreateEvents", func(ctx SpecContext) {
 			instance = internal.NewEventHandler(ctx, &controllertest.Queue{}, setfuncs, []predicate.Predicate{
 				predicate.Funcs{CreateFunc: func(event.CreateEvent) bool { return false }},
 			})
@@ -148,7 +147,7 @@ var _ = Describe("Internal", func() {
 			instance.OnAdd(FooRuntimeObject{}, false)
 		})
 
-		It("should create an UpdateEvent", func() {
+		It("should create an UpdateEvent", func(ctx SpecContext) {
 			funcs.UpdateFunc = func(ctx context.Context, evt event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
 				defer GinkgoRecover()
 				Expect(evt.ObjectOld).To(Equal(pod))
@@ -157,7 +156,7 @@ var _ = Describe("Internal", func() {
 			instance.OnUpdate(pod, newPod)
 		})
 
-		It("should used Predicates to filter UpdateEvents", func() {
+		It("should used Predicates to filter UpdateEvents", func(ctx SpecContext) {
 			set = false
 			instance = internal.NewEventHandler(ctx, &controllertest.Queue{}, setfuncs, []predicate.Predicate{
 				predicate.Funcs{UpdateFunc: func(updateEvent event.UpdateEvent) bool { return false }},
@@ -215,7 +214,7 @@ var _ = Describe("Internal", func() {
 			instance.OnDelete(pod)
 		})
 
-		It("should used Predicates to filter DeleteEvents", func() {
+		It("should used Predicates to filter DeleteEvents", func(ctx SpecContext) {
 			set = false
 			instance = internal.NewEventHandler(ctx, &controllertest.Queue{}, setfuncs, []predicate.Predicate{
 				predicate.Funcs{DeleteFunc: func(event.DeleteEvent) bool { return false }},

--- a/pkg/internal/testing/controlplane/plane_test.go
+++ b/pkg/internal/testing/controlplane/plane_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package controlplane_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kauthn "k8s.io/api/authorization/v1"
@@ -69,7 +67,7 @@ var _ = Describe("Control Plane", func() {
 			Expect(plane.Stop()).To(Succeed())
 		})
 
-		It("should provision a working legacy user and legacy kubectl", func() {
+		It("should provision a working legacy user and legacy kubectl", func(ctx SpecContext) {
 			By("grabbing the legacy kubectl")
 			Expect(plane.KubeCtl()).NotTo(BeNil())
 
@@ -89,7 +87,7 @@ var _ = Describe("Control Plane", func() {
 					},
 				},
 			}
-			Expect(cl.Create(context.Background(), sar)).To(Succeed(), "should be able to make a Self-SAR")
+			Expect(cl.Create(ctx, sar)).To(Succeed(), "should be able to make a Self-SAR")
 			Expect(sar.Status.Allowed).To(BeTrue(), "admin user should be able to do everything")
 		})
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package log
 
 import (
-	"context"
 	"errors"
 
 	"github.com/go-logr/logr"
@@ -297,17 +296,17 @@ var _ = Describe("logging", func() {
 	})
 
 	Describe("logger from context", func() {
-		It("should return default logger when context is empty", func() {
-			gotLog := FromContext(context.Background())
+		It("should return default logger when context is empty", func(ctx SpecContext) {
+			gotLog := FromContext(ctx)
 			Expect(gotLog).To(Not(BeNil()))
 		})
 
-		It("should return existing logger", func() {
+		It("should return existing logger", func(specCtx SpecContext) {
 			root := &fakeLoggerRoot{}
 			baseLog := &fakeLogger{root: root}
 
 			wantLog := logr.New(baseLog).WithName("my-logger")
-			ctx := IntoContext(context.Background(), wantLog)
+			ctx := IntoContext(specCtx, wantLog)
 
 			gotLog := FromContext(ctx)
 			Expect(gotLog).To(Not(BeNil()))
@@ -318,12 +317,12 @@ var _ = Describe("logging", func() {
 			))
 		})
 
-		It("should have added key-values", func() {
+		It("should have added key-values", func(specCtx SpecContext) {
 			root := &fakeLoggerRoot{}
 			baseLog := &fakeLogger{root: root}
 
 			wantLog := logr.New(baseLog).WithName("my-logger")
-			ctx := IntoContext(context.Background(), wantLog)
+			ctx := IntoContext(specCtx, wantLog)
 
 			gotLog := FromContext(ctx, "tag1", "value1")
 			Expect(gotLog).To(Not(BeNil()))

--- a/pkg/manager/server.go
+++ b/pkg/manager/server.go
@@ -70,7 +70,7 @@ func (s *Server) Start(ctx context.Context) error {
 		shutdownCtx := context.Background()
 		if s.ShutdownTimeout != nil {
 			var shutdownCancel context.CancelFunc
-			shutdownCtx, shutdownCancel = context.WithTimeout(context.Background(), *s.ShutdownTimeout)
+			shutdownCtx, shutdownCancel = context.WithTimeout(shutdownCtx, *s.ShutdownTimeout)
 			defer shutdownCancel()
 		}
 

--- a/pkg/metrics/filters/filters_test.go
+++ b/pkg/metrics/filters/filters_test.go
@@ -76,7 +76,7 @@ var _ = Describe("manger.Manager", func() {
 				}}
 			})
 
-			It("should serve metrics in its registry", func() {
+			It("should serve metrics in its registry", func(ctx SpecContext) {
 				one := prometheus.NewCounter(prometheus.CounterOpts{
 					Name: "test_one",
 					Help: "test metric for testing",
@@ -88,8 +88,6 @@ var _ = Describe("manger.Manager", func() {
 				m, err := manager.New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())
@@ -128,7 +126,7 @@ var _ = Describe("manger.Manager", func() {
 				Expect(ok).To(BeTrue())
 			})
 
-			It("should serve extra endpoints", func() {
+			It("should serve extra endpoints", func(ctx SpecContext) {
 				opts.Metrics.ExtraHandlers = map[string]http.Handler{
 					"/debug": http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 						_, _ = w.Write([]byte("Some debug info"))
@@ -137,8 +135,6 @@ var _ = Describe("manger.Manager", func() {
 				m, err := manager.New(cfg, opts)
 				Expect(err).NotTo(HaveOccurred())
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
 				go func() {
 					defer GinkgoRecover()
 					Expect(m.Start(ctx)).NotTo(HaveOccurred())

--- a/pkg/reconcile/reconcile_test.go
+++ b/pkg/reconcile/reconcile_test.go
@@ -63,7 +63,7 @@ var _ = Describe("reconcile", func() {
 	})
 
 	Describe("Func", func() {
-		It("should call the function with the request and return a nil error.", func() {
+		It("should call the function with the request and return a nil error.", func(ctx SpecContext) {
 			request := reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"},
 			}
@@ -77,12 +77,12 @@ var _ = Describe("reconcile", func() {
 
 				return result, nil
 			})
-			actualResult, actualErr := instance.Reconcile(context.Background(), request)
+			actualResult, actualErr := instance.Reconcile(ctx, request)
 			Expect(actualResult).To(Equal(result))
 			Expect(actualErr).NotTo(HaveOccurred())
 		})
 
-		It("should call the function with the request and return an error.", func() {
+		It("should call the function with the request and return an error.", func(ctx SpecContext) {
 			request := reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: "foo", Namespace: "bar"},
 			}
@@ -97,7 +97,7 @@ var _ = Describe("reconcile", func() {
 
 				return result, err
 			})
-			actualResult, actualErr := instance.Reconcile(context.Background(), request)
+			actualResult, actualErr := instance.Reconcile(ctx, request)
 			Expect(actualResult).To(Equal(result))
 			Expect(actualErr).To(Equal(err))
 		})
@@ -136,7 +136,7 @@ var _ = Describe("reconcile", func() {
 		Context("with an existing object", func() {
 			var key client.ObjectKey
 
-			BeforeEach(func() {
+			BeforeEach(func(ctx SpecContext) {
 				cm := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "default",
@@ -145,11 +145,11 @@ var _ = Describe("reconcile", func() {
 				}
 				key = client.ObjectKeyFromObject(cm)
 
-				err := testClient.Create(context.Background(), cm)
+				err := testClient.Create(ctx, cm)
 				Expect(err).NotTo(HaveOccurred())
 			})
 
-			It("should Get the object and call the ObjectReconciler", func() {
+			It("should Get the object and call the ObjectReconciler", func(ctx SpecContext) {
 				var actual *corev1.ConfigMap
 				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
@@ -158,7 +158,7 @@ var _ = Describe("reconcile", func() {
 					},
 				})
 
-				res, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+				res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(BeZero())
 				Expect(actual).NotTo(BeNil())
@@ -168,7 +168,7 @@ var _ = Describe("reconcile", func() {
 		})
 
 		Context("with an object that doesn't exist", func() {
-			It("should not call the ObjectReconciler", func() {
+			It("should not call the ObjectReconciler", func(ctx SpecContext) {
 				called := false
 				reconciler := reconcile.AsReconciler(testClient, &mockObjectReconciler{
 					reconcileFunc: func(ctx context.Context, cm *corev1.ConfigMap) (reconcile.Result, error) {
@@ -178,7 +178,7 @@ var _ = Describe("reconcile", func() {
 				})
 
 				key := types.NamespacedName{Namespace: "default", Name: "fake-obj"}
-				res, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+				res, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: key})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(res).To(BeZero())
 				Expect(called).To(BeFalse())

--- a/pkg/source/source_integration_test.go
+++ b/pkg/source/source_integration_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Source", func() {
 	var ns string
 	count := 0
 
-	BeforeEach(func() {
+	BeforeEach(func(ctx SpecContext) {
 		// Create the namespace for the test
 		ns = fmt.Sprintf("controller-source-kindsource-%v", count)
 		count++
@@ -63,7 +63,7 @@ var _ = Describe("Source", func() {
 		c2 = make(chan interface{})
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx SpecContext) {
 		err := clientset.CoreV1().Namespaces().Delete(ctx, ns, metav1.DeleteOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		close(c1)
@@ -74,7 +74,7 @@ var _ = Describe("Source", func() {
 		Context("for a Deployment resource", func() {
 			obj = &appsv1.Deployment{}
 
-			It("should provide Deployment Events", func() {
+			It("should provide Deployment Events", func(ctx SpecContext) {
 				var created, updated, deleted *appsv1.Deployment
 				var err error
 
@@ -239,7 +239,7 @@ var _ = Describe("Source", func() {
 		})
 
 		Context("for a ReplicaSet resource", func() {
-			It("should provide a ReplicaSet CreateEvent", func() {
+			It("should provide a ReplicaSet CreateEvent", func(ctx SpecContext) {
 				c := make(chan struct{})
 
 				q := workqueue.NewTypedRateLimitingQueueWithConfig(
@@ -282,7 +282,7 @@ var _ = Describe("Source", func() {
 				<-c
 			})
 
-			It("should provide a ReplicaSet UpdateEvent", func() {
+			It("should provide a ReplicaSet UpdateEvent", func(ctx SpecContext) {
 				var err error
 				rs, err = clientset.AppsV1().ReplicaSets("default").Get(ctx, rs.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
@@ -331,7 +331,7 @@ var _ = Describe("Source", func() {
 				<-c
 			})
 
-			It("should provide a ReplicaSet DeletedEvent", func() {
+			It("should provide a ReplicaSet DeletedEvent", func(ctx SpecContext) {
 				c := make(chan struct{})
 
 				q := workqueue.NewTypedRateLimitingQueueWithConfig(

--- a/pkg/source/source_suite_test.go
+++ b/pkg/source/source_suite_test.go
@@ -39,11 +39,12 @@ var testenv *envtest.Environment
 var config *rest.Config
 var clientset *kubernetes.Clientset
 var icache cache.Cache
-var ctx context.Context
 var cancel context.CancelFunc
 
 var _ = BeforeSuite(func() {
-	ctx, cancel = context.WithCancel(context.Background())
+	var ctx context.Context
+	// Has to be derived from context.Background, as it stays valid past the BeforeSuite
+	ctx, cancel = context.WithCancel(context.Background()) //nolint:forbidigo
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	testenv = &envtest.Environment{}

--- a/pkg/webhook/admission/defaulter_custom_test.go
+++ b/pkg/webhook/admission/defaulter_custom_test.go
@@ -30,11 +30,11 @@ import (
 
 var _ = Describe("Defaulter Handler", func() {
 
-	It("should remove unknown fields when DefaulterRemoveUnknownFields is passed", func() {
+	It("should remove unknown fields when DefaulterRemoveUnknownFields is passed", func(ctx SpecContext) {
 		obj := &TestDefaulter{}
 		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{}, DefaulterRemoveUnknownOrOmitableFields)
 
-		resp := handler.Handle(context.TODO(), Request{
+		resp := handler.Handle(ctx, Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
@@ -67,11 +67,11 @@ var _ = Describe("Defaulter Handler", func() {
 		Expect(resp.Result.Code).Should(Equal(int32(http.StatusOK)))
 	})
 
-	It("should preserve unknown fields by default", func() {
+	It("should preserve unknown fields by default", func(ctx SpecContext) {
 		obj := &TestDefaulter{}
 		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{})
 
-		resp := handler.Handle(context.TODO(), Request{
+		resp := handler.Handle(ctx, Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
@@ -100,10 +100,10 @@ var _ = Describe("Defaulter Handler", func() {
 		Expect(resp.Result.Code).Should(Equal(int32(http.StatusOK)))
 	})
 
-	It("should return ok if received delete verb in defaulter handler", func() {
+	It("should return ok if received delete verb in defaulter handler", func(ctx SpecContext) {
 		obj := &TestDefaulter{}
 		handler := WithCustomDefaulter(admissionScheme, obj, &TestCustomDefaulter{})
-		resp := handler.Handle(context.TODO(), Request{
+		resp := handler.Handle(ctx, Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Operation: admissionv1.Delete,
 				OldObject: runtime.RawExtension{

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Admission Webhooks", func() {
 			Expect(respRecorder.Body.String()).To(Equal(expected))
 		})
 
-		It("should present the Context from the HTTP request, if any", func() {
+		It("should present the Context from the HTTP request, if any", func(specCtx SpecContext) {
 			req := &http.Request{
 				Header: http.Header{"Content-Type": []string{"application/json"}},
 				Body:   nopCloser{Reader: bytes.NewBufferString(`{"request":{}}`)},
@@ -176,13 +176,13 @@ var _ = Describe("Admission Webhooks", func() {
 			expected := fmt.Sprintf(`{%s,"response":{"uid":"","allowed":true,"status":{"metadata":{},"message":%q,"code":200}}}
 `, gvkJSONv1, value)
 
-			ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, value))
+			ctx, cancel := context.WithCancel(context.WithValue(specCtx, key, value))
 			cancel()
 			webhook.ServeHTTP(respRecorder, req.WithContext(ctx))
 			Expect(respRecorder.Body.String()).To(Equal(expected))
 		})
 
-		It("should mutate the Context from the HTTP request, if func supplied", func() {
+		It("should mutate the Context from the HTTP request, if func supplied", func(specCtx SpecContext) {
 			req := &http.Request{
 				Header: http.Header{"Content-Type": []string{"application/json"}},
 				Body:   nopCloser{Reader: bytes.NewBufferString(`{"request":{}}`)},
@@ -203,7 +203,7 @@ var _ = Describe("Admission Webhooks", func() {
 			expected := fmt.Sprintf(`{%s,"response":{"uid":"","allowed":true,"status":{"metadata":{},"message":%q,"code":200}}}
 `, gvkJSONv1, "application/json")
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(specCtx)
 			cancel()
 			webhook.ServeHTTP(respRecorder, req.WithContext(ctx))
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/admission/multi_test.go
+++ b/pkg/webhook/admission/multi_test.go
@@ -58,32 +58,32 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 	}
 
 	Context("with validating handlers", func() {
-		It("should deny the request if any handler denies the request", func() {
+		It("should deny the request if any handler denies the request", func(ctx SpecContext) {
 			By("setting up a handler with accept and deny")
 			handler := MultiValidatingHandler(alwaysAllow, alwaysDeny)
 
 			By("checking that the handler denies the request")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Warnings).To(BeEmpty())
 		})
 
-		It("should allow the request if all handlers allow the request", func() {
+		It("should allow the request if all handlers allow the request", func(ctx SpecContext) {
 			By("setting up a handler with only accept")
 			handler := MultiValidatingHandler(alwaysAllow, alwaysAllow)
 
 			By("checking that the handler allows the request")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Warnings).To(BeEmpty())
 		})
 
-		It("should show the warnings if all handlers allow the request", func() {
+		It("should show the warnings if all handlers allow the request", func(ctx SpecContext) {
 			By("setting up a handler with only accept")
 			handler := MultiValidatingHandler(alwaysAllow, withWarnings)
 
 			By("checking that the handler allows the request")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Warnings).To(HaveLen(1))
 		})
@@ -149,34 +149,34 @@ var _ = Describe("Multi-Handler Admission Webhooks", func() {
 			},
 		}
 
-		It("should not return any patches if the request is denied", func() {
+		It("should not return any patches if the request is denied", func(ctx SpecContext) {
 			By("setting up a webhook with some patches and a deny")
 			handler := MultiMutatingHandler(patcher1, patcher2, alwaysDeny)
 
 			By("checking that the handler denies the request and produces no patches")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Patches).To(BeEmpty())
 		})
 
-		It("should produce all patches if the requests are all allowed", func() {
+		It("should produce all patches if the requests are all allowed", func(ctx SpecContext) {
 			By("setting up a webhook with some patches")
 			handler := MultiMutatingHandler(patcher1, patcher2, alwaysAllow)
 
 			By("checking that the handler accepts the request and returns all patches")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Patch).To(Equal([]byte(
 				`[{"op":"add","path":"/metadata/annotation/new-key","value":"new-value"},` +
 					`{"op":"replace","path":"/spec/replicas","value":"2"},{"op":"add","path":"/metadata/annotation/hello","value":"world"}]`)))
 		})
 
-		It("should produce all patches if the requests are all allowed and show warnings", func() {
+		It("should produce all patches if the requests are all allowed and show warnings", func(ctx SpecContext) {
 			By("setting up a webhook with some patches")
 			handler := MultiMutatingHandler(patcher1, patcher2, alwaysAllow, patcher3)
 
 			By("checking that the handler accepts the request and returns all patches")
-			resp := handler.Handle(context.Background(), Request{})
+			resp := handler.Handle(ctx, Request{})
 			Expect(resp.Allowed).To(BeTrue())
 			Expect(resp.Patch).To(Equal([]byte(
 				`[{"op":"add","path":"/metadata/annotation/new-key","value":"new-value"},` +

--- a/pkg/webhook/admission/validator_custom_test.go
+++ b/pkg/webhook/admission/validator_custom_test.go
@@ -37,9 +37,9 @@ var _ = Describe("customValidatingHandler", func() {
 		f := &fakeValidator{}
 		handler := WithCustomValidator(admissionScheme, f, val)
 
-		It("should return 200 in response when create succeeds", func() {
+		It("should return 200 in response when create succeeds", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
@@ -53,9 +53,9 @@ var _ = Describe("customValidatingHandler", func() {
 			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
 		})
 
-		It("should return 200 in response when update succeeds", func() {
+		It("should return 200 in response when update succeeds", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
@@ -72,9 +72,9 @@ var _ = Describe("customValidatingHandler", func() {
 			Expect(response.Result.Code).Should(Equal(int32(http.StatusOK)))
 		})
 
-		It("should return 200 in response when delete succeeds", func() {
+		It("should return 200 in response when delete succeeds", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
@@ -97,8 +97,8 @@ var _ = Describe("customValidatingHandler", func() {
 			anotherWarningMessage,
 		}}
 		handler := WithCustomValidator(admissionScheme, f, val)
-		It("should return 200 in response when create succeeds, with warning messages", func() {
-			response := handler.Handle(context.TODO(), Request{
+		It("should return 200 in response when create succeeds, with warning messages", func(ctx SpecContext) {
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
@@ -114,9 +114,9 @@ var _ = Describe("customValidatingHandler", func() {
 			Expect(response.AdmissionResponse.Warnings).Should(ContainElement(anotherWarningMessage))
 		})
 
-		It("should return 200 in response when update succeeds, with warning messages", func() {
+		It("should return 200 in response when update succeeds, with warning messages", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
@@ -135,9 +135,9 @@ var _ = Describe("customValidatingHandler", func() {
 			Expect(response.AdmissionResponse.Warnings).Should(ContainElement(anotherWarningMessage))
 		})
 
-		It("should return 200 in response when delete succeeds, with warning messages", func() {
+		It("should return 200 in response when delete succeeds, with warning messages", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
@@ -166,9 +166,9 @@ var _ = Describe("customValidatingHandler", func() {
 		val := &fakeCustomValidator{ErrorToReturn: expectedError, GVKToReturn: fakeValidatorVK, WarningsToReturn: []string{warningMessage, anotherWarningMessage}}
 		handler := WithCustomValidator(admissionScheme, f, val)
 
-		It("should propagate the Status from ValidateCreate's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateCreate's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
@@ -186,9 +186,9 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should propagate the Status from ValidateUpdate's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateUpdate's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
@@ -211,9 +211,9 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should propagate the Status from ValidateDelete's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateDelete's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 
@@ -246,9 +246,9 @@ var _ = Describe("customValidatingHandler", func() {
 		val := &fakeCustomValidator{ErrorToReturn: expectedError, GVKToReturn: fakeValidatorVK, WarningsToReturn: nil}
 		handler := WithCustomValidator(admissionScheme, f, val)
 
-		It("should propagate the Status from ValidateCreate's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateCreate's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
@@ -265,9 +265,9 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should propagate the Status from ValidateUpdate's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateUpdate's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
@@ -287,9 +287,9 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should propagate the Status from ValidateDelete's return value to the HTTP response", func() {
+		It("should propagate the Status from ValidateDelete's return value to the HTTP response", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
@@ -315,9 +315,9 @@ var _ = Describe("customValidatingHandler", func() {
 		val := &fakeCustomValidator{ErrorToReturn: expectedError, GVKToReturn: fakeValidatorVK}
 		handler := WithCustomValidator(admissionScheme, f, val)
 
-		It("should return 403 response when ValidateCreate with error message embedded", func() {
+		It("should return 403 response when ValidateCreate with error message embedded", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Create,
@@ -334,9 +334,9 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func() {
+		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
@@ -357,8 +357,8 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should return 403 response when ValidateDelete returns non-APIStatus error", func() {
-			response := handler.Handle(context.TODO(), Request{
+		It("should return 403 response when ValidateDelete returns non-APIStatus error", func(ctx SpecContext) {
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{
@@ -381,9 +381,9 @@ var _ = Describe("customValidatingHandler", func() {
 		val := &fakeCustomValidator{ErrorToReturn: expectedError, GVKToReturn: fakeValidatorVK, WarningsToReturn: []string{warningMessage, anotherWarningMessage}}
 		handler := WithCustomValidator(admissionScheme, f, val)
 
-		It("should return 403 response when ValidateCreate with error message embedded", func() {
+		It("should return 403 response when ValidateCreate with error message embedded", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 
 					Operation: admissionv1.Create,
@@ -402,9 +402,9 @@ var _ = Describe("customValidatingHandler", func() {
 			Expect(response.AdmissionResponse.Warnings).Should(ContainElement(anotherWarningMessage))
 		})
 
-		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func() {
+		It("should return 403 response when ValidateUpdate returns non-APIStatus error", func(ctx SpecContext) {
 
-			response := handler.Handle(context.TODO(), Request{
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Update,
 					Object: runtime.RawExtension{
@@ -428,8 +428,8 @@ var _ = Describe("customValidatingHandler", func() {
 
 		})
 
-		It("should return 403 response when ValidateDelete returns non-APIStatus error", func() {
-			response := handler.Handle(context.TODO(), Request{
+		It("should return 403 response when ValidateDelete returns non-APIStatus error", func(ctx SpecContext) {
+			response := handler.Handle(ctx, Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					Operation: admissionv1.Delete,
 					OldObject: runtime.RawExtension{

--- a/pkg/webhook/authentication/http_test.go
+++ b/pkg/webhook/authentication/http_test.go
@@ -154,7 +154,7 @@ var _ = Describe("Authentication Webhooks", func() {
 			Expect(respRecorder.Body.String()).To(Equal(expected))
 		})
 
-		It("should present the Context from the HTTP request, if any", func() {
+		It("should present the Context from the HTTP request, if any", func(specContext SpecContext) {
 			req := &http.Request{
 				Header: http.Header{"Content-Type": []string{"application/json"}},
 				Method: http.MethodPost,
@@ -175,13 +175,13 @@ var _ = Describe("Authentication Webhooks", func() {
 			expected := fmt.Sprintf(`{%s,"metadata":{},"spec":{},"status":{"authenticated":true,"user":{},"error":%q}}
 `, gvkJSONv1, value)
 
-			ctx, cancel := context.WithCancel(context.WithValue(context.Background(), key, value))
+			ctx, cancel := context.WithCancel(context.WithValue(specContext, key, value))
 			cancel()
 			webhook.ServeHTTP(respRecorder, req.WithContext(ctx))
 			Expect(respRecorder.Body.String()).To(Equal(expected))
 		})
 
-		It("should mutate the Context from the HTTP request, if func supplied", func() {
+		It("should mutate the Context from the HTTP request, if func supplied", func(specContext SpecContext) {
 			req := &http.Request{
 				Header: http.Header{"Content-Type": []string{"application/json"}},
 				Method: http.MethodPost,
@@ -203,7 +203,7 @@ var _ = Describe("Authentication Webhooks", func() {
 			expected := fmt.Sprintf(`{%s,"metadata":{},"spec":{},"status":{"authenticated":true,"user":{},"error":%q}}
 `, gvkJSONv1, "application/json")
 
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(specContext)
 			cancel()
 			webhook.ServeHTTP(respRecorder, req.WithContext(ctx))
 			Expect(respRecorder.Body.String()).To(Equal(expected))

--- a/pkg/webhook/authentication/webhook_test.go
+++ b/pkg/webhook/authentication/webhook_test.go
@@ -47,40 +47,40 @@ var _ = Describe("Authentication Webhooks", func() {
 		return webhook
 	}
 
-	It("should invoke the handler to get a response", func() {
+	It("should invoke the handler to get a response", func(ctx SpecContext) {
 		By("setting up a webhook with an allow handler")
 		webhook := allowHandler()
 
 		By("invoking the webhook")
-		resp := webhook.Handle(context.Background(), Request{})
+		resp := webhook.Handle(ctx, Request{})
 
 		By("checking that it allowed the request")
 		Expect(resp.Status.Authenticated).To(BeTrue())
 	})
 
-	It("should ensure that the response's UID is set to the request's UID", func() {
+	It("should ensure that the response's UID is set to the request's UID", func(ctx SpecContext) {
 		By("setting up a webhook")
 		webhook := allowHandler()
 
 		By("invoking the webhook")
-		resp := webhook.Handle(context.Background(), Request{TokenReview: authenticationv1.TokenReview{ObjectMeta: metav1.ObjectMeta{UID: "foobar"}}})
+		resp := webhook.Handle(ctx, Request{TokenReview: authenticationv1.TokenReview{ObjectMeta: metav1.ObjectMeta{UID: "foobar"}}})
 
 		By("checking that the response share's the request's UID")
 		Expect(resp.UID).To(Equal(machinerytypes.UID("foobar")))
 	})
 
-	It("should populate the status on a response if one is not provided", func() {
+	It("should populate the status on a response if one is not provided", func(ctx SpecContext) {
 		By("setting up a webhook")
 		webhook := allowHandler()
 
 		By("invoking the webhook")
-		resp := webhook.Handle(context.Background(), Request{})
+		resp := webhook.Handle(ctx, Request{})
 
 		By("checking that the response share's the request's UID")
 		Expect(resp.Status).To(Equal(authenticationv1.TokenReviewStatus{Authenticated: true}))
 	})
 
-	It("shouldn't overwrite the status on a response", func() {
+	It("shouldn't overwrite the status on a response", func(ctx SpecContext) {
 		By("setting up a webhook that sets a status")
 		webhook := &Webhook{
 			Handler: HandlerFunc(func(ctx context.Context, req Request) Response {
@@ -96,7 +96,7 @@ var _ = Describe("Authentication Webhooks", func() {
 		}
 
 		By("invoking the webhook")
-		resp := webhook.Handle(context.Background(), Request{})
+		resp := webhook.Handle(ctx, Request{})
 
 		By("checking that the message is intact")
 		Expect(resp.Status).NotTo(BeNil())

--- a/pkg/webhook/webhook_integration_test.go
+++ b/pkg/webhook/webhook_integration_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Webhook", func() {
 		}
 	})
 	Context("when running a webhook server with a manager", func() {
-		It("should reject create request for webhook that rejects all requests", func() {
+		It("should reject create request for webhook that rejects all requests", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{
 				WebhookServer: webhook.NewServer(webhook.Options{
 					Port:    testenv.WebhookInstallOptions.LocalServingPort,
@@ -86,20 +86,17 @@ var _ = Describe("Webhook", func() {
 			server := m.GetWebhookServer()
 			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{d: admission.NewDecoder(testenv.Scheme)}})
 
-			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				err := server.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
 			Eventually(func() bool {
-				err := c.Create(context.TODO(), obj)
+				err := c.Create(ctx, obj)
 				return err != nil && strings.HasSuffix(err.Error(), "Always denied") && apierrors.ReasonForError(err) == metav1.StatusReasonForbidden
 			}, 1*time.Second).Should(BeTrue())
-
-			cancel()
 		})
-		It("should reject create request for multi-webhook that rejects all requests", func() {
+		It("should reject create request for multi-webhook that rejects all requests", func(ctx SpecContext) {
 			m, err := manager.New(cfg, manager.Options{
 				Metrics: metricsserver.Options{BindAddress: "0"},
 				WebhookServer: webhook.NewServer(webhook.Options{
@@ -113,22 +110,19 @@ var _ = Describe("Webhook", func() {
 			server := m.GetWebhookServer()
 			server.Register("/failing", &webhook.Admission{Handler: admission.MultiValidatingHandler(&rejectingValidator{d: admission.NewDecoder(testenv.Scheme)})})
 
-			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				err = server.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
 			Eventually(func() bool {
-				err = c.Create(context.TODO(), obj)
+				err = c.Create(ctx, obj)
 				return err != nil && strings.HasSuffix(err.Error(), "Always denied") && apierrors.ReasonForError(err) == metav1.StatusReasonForbidden
 			}, 1*time.Second).Should(BeTrue())
-
-			cancel()
 		})
 	})
 	Context("when running a webhook server without a manager", func() {
-		It("should reject create request for webhook that rejects all requests", func() {
+		It("should reject create request for webhook that rejects all requests", func(ctx SpecContext) {
 			server := webhook.NewServer(webhook.Options{
 				Port:    testenv.WebhookInstallOptions.LocalServingPort,
 				Host:    testenv.WebhookInstallOptions.LocalServingHost,
@@ -136,18 +130,15 @@ var _ = Describe("Webhook", func() {
 			})
 			server.Register("/failing", &webhook.Admission{Handler: &rejectingValidator{d: admission.NewDecoder(testenv.Scheme)}})
 
-			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
 				err := server.Start(ctx)
 				Expect(err).NotTo(HaveOccurred())
 			}()
 
 			Eventually(func() bool {
-				err := c.Create(context.TODO(), obj)
+				err := c.Create(ctx, obj)
 				return err != nil && strings.HasSuffix(err.Error(), "Always denied") && apierrors.ReasonForError(err) == metav1.StatusReasonForbidden
 			}, 1*time.Second).Should(BeTrue())
-
-			cancel()
 		})
 	})
 })

--- a/tools/setup-envtest/store/store_suite_test.go
+++ b/tools/setup-envtest/store/store_suite_test.go
@@ -40,8 +40,8 @@ func zapLogger() logr.Logger {
 	return zapr.NewLogger(zapLog)
 }
 
-func logCtx() context.Context {
-	return logr.NewContext(context.Background(), testLog)
+func logCtx(ctx context.Context) context.Context {
+	return logr.NewContext(ctx, testLog)
 }
 
 func TestStore(t *testing.T) {


### PR DESCRIPTION
This change replaces the usage of `context.Background()` and `context.TODO()` in tests with ginkgos `SpecContext` or golangs `t.Context()` in order to ensure contexts are scoped to the test they are for and only valid for the duration of the test.

While this change is massive in terms of LOC, it should be easy to review as it is essentially just the same three changes over and over again.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
