### PR TITLE
:seedling: Clarify our versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ The full documentation can be found at [VERSIONING.md](VERSIONING.md), but TL;DR
 
 Users:
 
-- We follow [Semantic Versioning (semver)](https://semver.org)
-- Use releases with your dependency management to ensure that you get compatible code
-- The main branch contains all the latest code, some of which may break compatibility (so "normal" `go get` is not recommended)
+- We stick to a zero major version
+- We publish a minor version for each Kubernetes minor release and allow breaking changes between minor versions
+- We publish patch versions as needed and we don't allow breaking changes in them
 
 Contributors:
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -7,6 +7,16 @@ For the purposes of the aforementioned guidelines, controller-runtime
 counts as a "library project", but otherwise follows the guidelines
 exactly.
 
+We stick to a major version of zero and create a minor version for
+each Kubernetes minor version and we allow breaking changes in our
+minor versions. We create patch releases as needed and don't allow
+breaking changes in them.
+
+Publishing a non-zero major version is pointless for us, as the k8s.io/*
+libraries we heavily depend on do breaking changes but use the same
+versioning scheme as described above. Consequently, a project can only
+ever depend on one controller-runtime version.
+
 [guidelines]: https://sigs.k8s.io/kubebuilder-release-tools/VERSIONING.md
 
 ## Compatibility and Release Support


### PR DESCRIPTION
While its technically true that we do semver because semver allow to do anything for as long as a major version zero is used, referring to it doesn't really explain our versioning scheme. Clarify that in the readme and also mention why we won't publish a major version > 0.

Closes https://github.com/kubernetes-sigs/controller-runtime/issues/601

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
