### PR TITLE
:bug: Ensure cleanup validates etcd proces state first

### DIFF
--- a/pkg/internal/testing/controlplane/etcd.go
+++ b/pkg/internal/testing/controlplane/etcd.go
@@ -159,6 +159,10 @@ func (e *Etcd) setProcessState() error {
 // Stop stops this process gracefully, waits for its termination, and cleans up
 // the DataDir if necessary.
 func (e *Etcd) Stop() error {
+	if e.processState == nil {
+		return nil
+	}
+
 	if e.processState.DirNeedsCleaning {
 		e.DataDir = "" // reset the directory if it was randomly allocated, so that we can safely restart
 	}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
This PR addresses a potential nil pointer dereference in the Stop method of the ETCD cleanup. The change adds a check to ensure `processState` is not nil before proceeding with the stop logic, preventing a panic if Stop is called on an uninitialized etcd instance, in a deferred cleanup after setup failure.

Fixes #3271 