### PR TITLE
:seedling: Certwatcher: Don't require leaderelection

### DIFF
--- a/pkg/certwatcher/certwatcher.go
+++ b/pkg/certwatcher/certwatcher.go
@@ -240,3 +240,9 @@ func (cw *CertWatcher) handleEvent(event fsnotify.Event) {
 		log.Error(err, "error re-reading certificate")
 	}
 }
+
+// NeedLeaderElection indicates that the cert-manager
+// does not need leader election.
+func (cw *CertWatcher) NeedLeaderElection() bool {
+	return false
+}

--- a/pkg/certwatcher/certwatcher_test.go
+++ b/pkg/certwatcher/certwatcher_test.go
@@ -37,6 +37,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 var _ = Describe("CertWatcher", func() {
@@ -90,6 +91,12 @@ var _ = Describe("CertWatcher", func() {
 				}).Should(Succeed())
 				return doneCh
 			}
+		})
+
+		It("should not require LeaderElection", func() {
+			leaderElectionRunnable, isLeaderElectionRunnable := any(watcher).(manager.LeaderElectionRunnable)
+			Expect(isLeaderElectionRunnable).To(BeTrue())
+			Expect(leaderElectionRunnable.NeedLeaderElection()).To(BeFalse())
 		})
 
 		It("should read the initial cert/key", func() {


### PR DESCRIPTION
Controller-Runtime starts the certwatcher in the webhook server, which means it always runs regardless of the current replica being leader or not.

It turns out that kubebuilder adds it to the manager and as a result, it only runs on leader replicas. Make it a `LeaderElectionRunnable` and don't require leader election so that it will work correctly even if other projects use it in ways that were not originally anticipated.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
