### PR TITLE
⚠️  Default selectors to Nothing if it is nil for `MatchingLabelsSelector` and `MatchingFieldsSelector`

### DIFF
--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -645,7 +645,7 @@ type MatchingLabelsSelector struct {
 // ApplyToList applies this configuration to the given list options.
 func (m MatchingLabelsSelector) ApplyToList(opts *ListOptions) {
 	if m.Selector == nil {
-		m.Selector = labels.Everything()
+		m.Selector = labels.Nothing()
 	}
 	opts.LabelSelector = m
 }
@@ -681,7 +681,7 @@ type MatchingFieldsSelector struct {
 // ApplyToList applies this configuration to the given list options.
 func (m MatchingFieldsSelector) ApplyToList(opts *ListOptions) {
 	if m.Selector == nil {
-		m.Selector = fields.Everything()
+		m.Selector = fields.Nothing()
 	}
 	opts.FieldSelector = m
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -644,6 +644,9 @@ type MatchingLabelsSelector struct {
 
 // ApplyToList applies this configuration to the given list options.
 func (m MatchingLabelsSelector) ApplyToList(opts *ListOptions) {
+	if m.Selector == nil {
+		m.Selector = labels.Everything()
+	}
 	opts.LabelSelector = m
 }
 
@@ -677,6 +680,9 @@ type MatchingFieldsSelector struct {
 
 // ApplyToList applies this configuration to the given list options.
 func (m MatchingFieldsSelector) ApplyToList(opts *ListOptions) {
+	if m.Selector == nil {
+		m.Selector = fields.Everything()
+	}
 	opts.FieldSelector = m
 }
 

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -36,11 +36,37 @@ var _ = Describe("ListOptions", func() {
 		o.ApplyToList(newListOpts)
 		Expect(newListOpts).To(Equal(o))
 	})
+	It("Should set LabelSelector with MatchingLabelsSelector", func() {
+		labelSelector, err := labels.Parse("a=b")
+		Expect(err).NotTo(HaveOccurred())
+		newListOpts := &client.ListOptions{}
+		newListOpts.ApplyOptions([]client.ListOption{client.MatchingLabelsSelector{Selector: labelSelector}})
+		expectedListOpts := &client.ListOptions{LabelSelector: client.MatchingLabelsSelector{Selector: labelSelector}}
+		Expect(newListOpts).To(Equal(expectedListOpts))
+	})
+	It("Should set LabelSelector to everything with empty MatchingLabelsSelector", func() {
+		newListOpts := &client.ListOptions{}
+		newListOpts.ApplyOptions([]client.ListOption{client.MatchingLabelsSelector{}})
+		expectedListOpts := &client.ListOptions{LabelSelector: client.MatchingLabelsSelector{Selector: labels.Everything()}}
+		Expect(newListOpts).To(Equal(expectedListOpts))
+	})
 	It("Should set FieldSelector", func() {
 		o := &client.ListOptions{FieldSelector: fields.Nothing()}
 		newListOpts := &client.ListOptions{}
 		o.ApplyToList(newListOpts)
 		Expect(newListOpts).To(Equal(o))
+	})
+	It("Should set FieldSelector with MatchingFieldsSelector", func() {
+		newListOpts := &client.ListOptions{}
+		newListOpts.ApplyOptions([]client.ListOption{client.MatchingFieldsSelector{Selector: fields.Nothing()}})
+		expectedListOpts := &client.ListOptions{FieldSelector: client.MatchingFieldsSelector{Selector: fields.Nothing()}}
+		Expect(newListOpts).To(Equal(expectedListOpts))
+	})
+	It("Should set FieldSelector to everything with empty MatchingFieldsSelector", func() {
+		newListOpts := &client.ListOptions{}
+		newListOpts.ApplyOptions([]client.ListOption{client.MatchingFieldsSelector{}})
+		expectedListOpts := &client.ListOptions{FieldSelector: client.MatchingFieldsSelector{Selector: fields.Everything()}}
+		Expect(newListOpts).To(Equal(expectedListOpts))
 	})
 	It("Should set Namespace", func() {
 		o := &client.ListOptions{Namespace: "my-ns"}

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -44,10 +44,10 @@ var _ = Describe("ListOptions", func() {
 		expectedListOpts := &client.ListOptions{LabelSelector: client.MatchingLabelsSelector{Selector: labelSelector}}
 		Expect(newListOpts).To(Equal(expectedListOpts))
 	})
-	It("Should set LabelSelector to everything with empty MatchingLabelsSelector", func() {
+	It("Should set LabelSelector to nothing with empty MatchingLabelsSelector", func() {
 		newListOpts := &client.ListOptions{}
 		newListOpts.ApplyOptions([]client.ListOption{client.MatchingLabelsSelector{}})
-		expectedListOpts := &client.ListOptions{LabelSelector: client.MatchingLabelsSelector{Selector: labels.Everything()}}
+		expectedListOpts := &client.ListOptions{LabelSelector: client.MatchingLabelsSelector{Selector: labels.Nothing()}}
 		Expect(newListOpts).To(Equal(expectedListOpts))
 	})
 	It("Should set FieldSelector", func() {
@@ -62,10 +62,10 @@ var _ = Describe("ListOptions", func() {
 		expectedListOpts := &client.ListOptions{FieldSelector: client.MatchingFieldsSelector{Selector: fields.Nothing()}}
 		Expect(newListOpts).To(Equal(expectedListOpts))
 	})
-	It("Should set FieldSelector to everything with empty MatchingFieldsSelector", func() {
+	It("Should set FieldSelector to nothing with empty MatchingFieldsSelector", func() {
 		newListOpts := &client.ListOptions{}
 		newListOpts.ApplyOptions([]client.ListOption{client.MatchingFieldsSelector{}})
-		expectedListOpts := &client.ListOptions{FieldSelector: client.MatchingFieldsSelector{Selector: fields.Everything()}}
+		expectedListOpts := &client.ListOptions{FieldSelector: client.MatchingFieldsSelector{Selector: fields.Nothing()}}
 		Expect(newListOpts).To(Equal(expectedListOpts))
 	})
 	It("Should set Namespace", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
If the selector is not set for `MatchingLabelsSelector` and `MatchingFieldsSelector`, then the list call panics.
This PR updates `MatchingLabelsSelector` and `MatchingFieldsSelector` to default their Selector fields to labels.Nothing() and fields.Nothing() respectively if unset in ApplyToList.
