### PR TITLE
✨ envtest: search the assets index for latest of a release series

### DIFF
--- a/examples/scratch-env/go.mod
+++ b/examples/scratch-env/go.mod
@@ -10,7 +10,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.12.2 // indirect

--- a/examples/scratch-env/go.sum
+++ b/examples/scratch-env/go.sum
@@ -1,7 +1,5 @@
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
-github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module sigs.k8s.io/controller-runtime
 go 1.24.0
 
 require (
-	github.com/blang/semver/v4 v4.0.0
 	github.com/evanphx/json-patch/v5 v5.9.11
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/go-logr/logr v1.4.2
@@ -37,6 +36,7 @@ require (
 	cel.dev/expr v0.24.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/pkg/envtest/binaries.go
+++ b/pkg/envtest/binaries.go
@@ -32,7 +32,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/version"
@@ -111,6 +110,25 @@ type archive struct {
 	SelfLink string `json:"selfLink"`
 }
 
+// parseKubernetesVersion returns:
+//  1. the SemVer form of s when it refers to a specific Kubernetes release, or
+//  2. the major and minor portions of s when it refers to a release series, or
+//  3. an error
+func parseKubernetesVersion(s string) (exact string, major, minor uint, err error) {
+	if v, err := version.ParseSemantic(s); err == nil {
+		return v.String(), 0, 0, nil
+	}
+
+	// See two parseable components and nothing else.
+	if v, err := version.ParseGeneric(s); err == nil && len(v.Components()) == 2 {
+		if v.String() == strings.TrimPrefix(s, "v") {
+			return "", v.Major(), v.Minor(), nil
+		}
+	}
+
+	return "", 0, 0, fmt.Errorf("could not parse %q as version", s)
+}
+
 func downloadBinaryAssets(ctx context.Context, binaryAssetsDirectory, binaryAssetsVersion, binaryAssetsIndexURL string) (string, string, string, error) {
 	if binaryAssetsIndexURL == "" {
 		binaryAssetsIndexURL = DefaultBinaryAssetsIndexURL
@@ -125,14 +143,23 @@ func downloadBinaryAssets(ctx context.Context, binaryAssetsDirectory, binaryAsse
 	}
 
 	var binaryAssetsIndex *index
-	if binaryAssetsVersion == "" {
-		var err error
+	switch exact, major, minor, err := parseKubernetesVersion(binaryAssetsVersion); {
+	case binaryAssetsVersion != "" && err != nil:
+		return "", "", "", err
+
+	case binaryAssetsVersion != "" && exact != "":
+		// Look for these specific binaries locally before downloading them from the release index.
+		// Use the canonical form of the version from here on.
+		binaryAssetsVersion = "v" + exact
+
+	case binaryAssetsVersion == "" || major != 0 || minor != 0:
+		// Select a stable version from the release index before continuing.
 		binaryAssetsIndex, err = getIndex(ctx, binaryAssetsIndexURL)
 		if err != nil {
 			return "", "", "", err
 		}
 
-		binaryAssetsVersion, err = latestStableVersionFromIndex(binaryAssetsIndex)
+		binaryAssetsVersion, err = latestStableVersionFromIndex(binaryAssetsIndex, major, minor)
 		if err != nil {
 			return "", "", "", err
 		}
@@ -252,12 +279,19 @@ func downloadBinaryAssetsArchive(ctx context.Context, index *index, version stri
 	return readBody(resp, out, archiveName, archive.Hash)
 }
 
-func latestStableVersionFromIndex(index *index) (string, error) {
+// latestStableVersionFromIndex returns the version with highest [precedence] in index that is not a prerelease.
+// When either major or minor are not zero, the returned version will have those major and minor versions.
+// Note that the version cannot be limited to 0.0.x this way.
+//
+// It is an error when there is no appropriate version in index.
+//
+// [precedence]: https://semver.org/spec/v2.0.0.html#spec-item-11
+func latestStableVersionFromIndex(index *index, major, minor uint) (string, error) {
 	if len(index.Releases) == 0 {
 		return "", fmt.Errorf("failed to find latest stable version from index: index is empty")
 	}
 
-	parsedVersions := []*version.Version{}
+	var found *version.Version
 	for releaseVersion := range index.Releases {
 		v, err := version.ParseSemantic(releaseVersion)
 		if err != nil {
@@ -269,17 +303,26 @@ func latestStableVersionFromIndex(index *index) (string, error) {
 			continue
 		}
 
-		parsedVersions = append(parsedVersions, v)
+		// Filter on release series, if any.
+		if (major != 0 || minor != 0) && (v.Major() != major || v.Minor() != minor) {
+			continue
+		}
+
+		if found == nil || v.GreaterThan(found) {
+			found = v
+		}
 	}
 
-	if len(parsedVersions) == 0 {
-		return "", fmt.Errorf("failed to find latest stable version from index: index does not have stable versions")
+	if found == nil {
+		search := "any"
+		if major != 0 || minor != 0 {
+			search = fmt.Sprint(major, ".", minor)
+		}
+
+		return "", fmt.Errorf("failed to find latest stable version from index: index does not have %s stable versions", search)
 	}
 
-	sort.Slice(parsedVersions, func(i, j int) bool {
-		return parsedVersions[i].GreaterThan(parsedVersions[j])
-	})
-	return "v" + parsedVersions[0].String(), nil
+	return "v" + found.String(), nil
 }
 
 func getIndex(ctx context.Context, indexURL string) (*index, error) {

--- a/pkg/envtest/binaries.go
+++ b/pkg/envtest/binaries.go
@@ -35,7 +35,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/blang/semver/v4"
+	"k8s.io/apimachinery/pkg/util/version"
 	"sigs.k8s.io/yaml"
 )
 
@@ -257,15 +257,15 @@ func latestStableVersionFromIndex(index *index) (string, error) {
 		return "", fmt.Errorf("failed to find latest stable version from index: index is empty")
 	}
 
-	parsedVersions := []semver.Version{}
+	parsedVersions := []*version.Version{}
 	for releaseVersion := range index.Releases {
-		v, err := semver.ParseTolerant(releaseVersion)
+		v, err := version.ParseSemantic(releaseVersion)
 		if err != nil {
 			return "", fmt.Errorf("failed to parse version %q: %w", releaseVersion, err)
 		}
 
 		// Filter out pre-releases.
-		if len(v.Pre) > 0 {
+		if len(v.PreRelease()) > 0 {
 			continue
 		}
 
@@ -277,7 +277,7 @@ func latestStableVersionFromIndex(index *index) (string, error) {
 	}
 
 	sort.Slice(parsedVersions, func(i, j int) bool {
-		return parsedVersions[i].GT(parsedVersions[j])
+		return parsedVersions[i].GreaterThan(parsedVersions[j])
 	})
 	return "v" + parsedVersions[0].String(), nil
 }


### PR DESCRIPTION
This allows configuring the `DownloadBinaryAssetsVersion` field of `envtest.Environment` with only the Major.Minor portions of a Kubernetes API version. In that case, the framework searches the asset index for the latest stable version in that release series.

This matches the behavior of `setup-envtest use {major}.{minor}` without the full complexity of version selectors. The leading `v` is now optional, too. For example:
- `"v1.29"` resolves to [v1.29.4](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L24)
- `"1.27"` resolves to [v1.27.1](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L134)
- `"1.24"` resolves to [v1.24.2](https://github.com/kubernetes-sigs/controller-tools/blob/50b4feecf68291368219a53ef3645dc0de9a4819/envtest-releases.yaml#L222)

Setting the field to Major.Minor.Patch or Major.Minor.Patch-PreRelease behaves the same as before:
- Existing binaries are used without going to the network.
- Prereleases can only be selected by spelling them out, precisely as they are in the asset index.

This is an alternative implementation of #3260. It uses the [k8s.io/apimachinery/pkg/util/version](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/version) package and basic comparisons, rather than an external package with range/constraint matchers.