### PR TITLE
:bug: Fix testing kube-apiserver serving certificate using wrong SANs

### DIFF
--- a/pkg/internal/testing/controlplane/apiserver.go
+++ b/pkg/internal/testing/controlplane/apiserver.go
@@ -374,9 +374,9 @@ func (s *APIServer) populateAPIServerCerts() error {
 		return err
 	}
 
-	servingAddresses := []string{"localhost", s.SecureServing.ListenAddr.Address}
-	if s.InsecureServing != nil {
-		servingAddresses = append(servingAddresses, s.InsecureServing.Address)
+	servingAddresses := []string{"localhost"}
+	if s.SecureServing.ListenAddr.Address != "" {
+		servingAddresses = append(servingAddresses, s.SecureServing.ListenAddr.Address)
 	}
 
 	servingCerts, err := ca.NewServingCert(servingAddresses...)

--- a/pkg/internal/testing/controlplane/apiserver_test.go
+++ b/pkg/internal/testing/controlplane/apiserver_test.go
@@ -218,6 +218,20 @@ var _ = Describe("APIServer", func() {
 			return cert
 		}
 
+		Context("when SecureServing are not set", func() {
+			It("should have localhost/127.0.0.1 in the certificate altnames", func() {
+				cert := getCertificate()
+
+				Expect(cert.Subject.CommonName).To(Equal("localhost"))
+				Expect(cert.DNSNames).To(ConsistOf("localhost"))
+				expectedIPAddresses := []net.IP{
+					net.ParseIP("127.0.0.1").To4(),
+					net.ParseIP(server.SecureServing.ListenAddr.Address).To4(),
+				}
+				Expect(cert.IPAddresses).To(ContainElements(expectedIPAddresses))
+			})
+		})
+
 		Context("when SecureServing host & port are set", func() {
 			BeforeEach(func() {
 				server.SecureServing = SecureServing{
@@ -236,55 +250,6 @@ var _ = Describe("APIServer", func() {
 				expectedIPAddresses := []net.IP{
 					net.ParseIP("127.0.0.1").To4(),
 					net.ParseIP(server.SecureServing.ListenAddr.Address).To4(),
-				}
-				Expect(cert.IPAddresses).To(ContainElements(expectedIPAddresses))
-			})
-		})
-
-		Context("when InsecureServing host & port are set", func() {
-			BeforeEach(func() {
-				server.InsecureServing = &process.ListenAddr{
-					Address: "1.2.3.4",
-					Port:    "5678",
-				}
-			})
-
-			It("should have the host in the certificate altnames", func() {
-				cert := getCertificate()
-
-				Expect(cert.Subject.CommonName).To(Equal("localhost"))
-				Expect(cert.DNSNames).To(ConsistOf("localhost"))
-				expectedIPAddresses := []net.IP{
-					net.ParseIP("127.0.0.1").To4(),
-					net.ParseIP(server.InsecureServing.Address).To4(),
-				}
-				Expect(cert.IPAddresses).To(ContainElements(expectedIPAddresses))
-			})
-		})
-
-		Context("when SecureServing and InsecureServing host & port are set", func() {
-			BeforeEach(func() {
-				server.SecureServing = SecureServing{
-					ListenAddr: process.ListenAddr{
-						Address: "1.2.3.4",
-						Port:    "5678",
-					},
-				}
-				server.InsecureServing = &process.ListenAddr{
-					Address: "5.6.7.8",
-					Port:    "1234",
-				}
-			})
-
-			It("should have the host in the certificate altnames", func() {
-				cert := getCertificate()
-
-				Expect(cert.Subject.CommonName).To(Equal("localhost"))
-				Expect(cert.DNSNames).To(ConsistOf("localhost"))
-				expectedIPAddresses := []net.IP{
-					net.ParseIP("127.0.0.1").To4(),
-					net.ParseIP(server.SecureServing.ListenAddr.Address).To4(),
-					net.ParseIP(server.InsecureServing.Address).To4(),
 				}
 				Expect(cert.IPAddresses).To(ContainElements(expectedIPAddresses))
 			})


### PR DESCRIPTION
When configuring the kube-apiserver for a test by setting a serving address, the certificate generated for the API server does not include the serving value. In other words, if a test environment is configured like this:

```go
testEnv = &envtest.Environment{
	ControlPlane: envtest.ControlPlane{
		APIServer: &envtest.APIServer{
			SecureServing: envtest.SecureServing{
				ListenAddr: envtest.ListenAddr{
					Address: myTestAddress,
					Port:    strconv.Itoa(6443),
				},
			},
		},
	},
}
```

Then when `testEnv.Start()` is called, the healthcheck will fail because the produced `apiserver.crt` serving certificate is only valid for localhost, and addresses that localhost resolves to.

This fixes the issue by providing the SecureServing and InsecureServing listening address to the cert generator function.
