### PR TITLE
:sparkles: Add a ReconciliationTimeout option

### DIFF
--- a/pkg/config/controller.go
+++ b/pkg/config/controller.go
@@ -81,4 +81,8 @@ type Controller struct {
 
 	// Logger is the logger controllers should use.
 	Logger logr.Logger
+
+	// ReconciliationTimeout is used as the timeout passed to the context of each Reconcile call.
+	// By default, there is no timeout.
+	ReconciliationTimeout time.Duration
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,6 +106,10 @@ type TypedOptions[request comparable] struct {
 	// leader election do not wait on leader election to start their sources.
 	// Defaults to false.
 	EnableWarmup *bool
+
+	// ReconciliationTimeout is used as the timeout passed to the context of each Reconcile call.
+	// By default, there is no timeout.
+	ReconciliationTimeout time.Duration
 }
 
 // DefaultFromConfig defaults the config from a config.Controller
@@ -140,6 +144,10 @@ func (options *TypedOptions[request]) DefaultFromConfig(config config.Controller
 
 	if options.EnableWarmup == nil {
 		options.EnableWarmup = config.EnableWarmup
+	}
+
+	if options.ReconciliationTimeout == 0 {
+		options.ReconciliationTimeout = config.ReconciliationTimeout
 	}
 }
 
@@ -271,6 +279,7 @@ func NewTypedUnmanaged[request comparable](name string, options TypedOptions[req
 		RecoverPanic:            options.RecoverPanic,
 		LeaderElected:           options.NeedLeaderElection,
 		EnableWarmup:            options.EnableWarmup,
+		ReconciliationTimeout:   options.ReconciliationTimeout,
 	}), nil
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -540,5 +540,40 @@ var _ = Describe("controller.Controller", func() {
 			Expect(ok).To(BeTrue())
 			Expect(internalCtrlOverridingWarmup.EnableWarmup).To(HaveValue(BeFalse()))
 		})
+
+		It("should default ReconciliationTimeout from manager if unset", func() {
+			m, err := manager.New(cfg, manager.Options{
+				Controller: config.Controller{ReconciliationTimeout: 30 * time.Second},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("mgr-reconciliation-timeout", m, controller.Options{
+				Reconciler: rec,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller[reconcile.Request])
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.ReconciliationTimeout).To(Equal(30 * time.Second))
+		})
+
+		It("should not override an existing ReconciliationTimeout", func() {
+			m, err := manager.New(cfg, manager.Options{
+				Controller: config.Controller{ReconciliationTimeout: 30 * time.Second},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			c, err := controller.New("ctrl-reconciliation-timeout", m, controller.Options{
+				Reconciler:            rec,
+				ReconciliationTimeout: time.Minute,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			ctrl, ok := c.(*internalcontroller.Controller[reconcile.Request])
+			Expect(ok).To(BeTrue())
+
+			Expect(ctrl.ReconciliationTimeout).To(Equal(time.Minute))
+		})
 	})
 })


### PR DESCRIPTION
This change add a ReconciliatiomTimeout option to the controller options. It defaults to zero, so is backwards-compatible.

While it is easy to do the same through a Reconciler wrapper, this setting is something that pretty much any controller should have set, so add a knob for it to make that a bit simpler.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
