### PR TITLE
📖 pkg/client/config: remove outdated doc comments

### DIFF
--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -64,9 +64,6 @@ func RegisterFlags(fs *flag.FlagSet) {
 // The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
 // fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 //
-// It also applies saner defaults for QPS and burst based on the Kubernetes
-// controller manager defaults (20 QPS, 30 burst)
-//
 // Config precedence:
 //
 // * --kubeconfig flag pointing at a file
@@ -86,9 +83,6 @@ func GetConfig() (*rest.Config, error) {
 //
 // The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
 // fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
-//
-// It also applies saner defaults for QPS and burst based on the Kubernetes
-// controller manager defaults (20 QPS, 30 burst)
 //
 // Config precedence:
 //


### PR DESCRIPTION
Remove the outdated doc comments about the default config of the client-side ratelimiter.