### PR TITLE
🐛Panic when trying to build more than one instance of fake.ClientBuilder

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -141,6 +141,7 @@ type ClientBuilder struct {
 	interceptorFuncs      *interceptor.Funcs
 	typeConverters        []managedfields.TypeConverter
 	returnManagedFields   bool
+	isBuilt               bool
 
 	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
 	// The inner map maps from index name to IndexerFunc.
@@ -267,6 +268,9 @@ func (f *ClientBuilder) WithReturnManagedFields() *ClientBuilder {
 
 // Build builds and returns a new fake client.
 func (f *ClientBuilder) Build() client.WithWatch {
+	if f.isBuilt {
+		panic("build must not be called multiple times when creating a ClientBuilder")
+	}
 	if f.scheme == nil {
 		f.scheme = scheme.Scheme
 	}
@@ -344,6 +348,7 @@ func (f *ClientBuilder) Build() client.WithWatch {
 		result = interceptor.NewClient(result, *f.interceptorFuncs)
 	}
 
+	f.isBuilt = true
 	return result
 }
 

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -3182,4 +3182,13 @@ var _ = Describe("Fake client builder", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(called).To(BeTrue())
 	})
+
+	It("should panic when calling build more than once", func() {
+		cb := NewClientBuilder()
+		anotherCb := cb
+		cb.Build()
+		Expect(func() {
+			anotherCb.Build()
+		}).To(Panic())
+	})
 })


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
When using `fake.NewClientBuilder`, you recieve a `client.WithWatch`.  However, having many instances of the `fake.ClientBuilder` can cause issues when trying to call `Build()` where the behavior is inconsistent in testing.  

This will now panic when trying to use two instances of the clientBuilder and using build in both of those instances.

Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3313
<!-- What does this do, and why do we need it? -->
