### PR TITLE
⚠️ Add subresource apply support

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -545,7 +545,7 @@ func (po *SubResourcePatchOptions) ApplyToSubResourcePatch(o *SubResourcePatchOp
 }
 
 // SubResourceApplyOptions are the options for a subresource
-// apply rquest.
+// apply request.
 type SubResourceApplyOptions struct {
 	ApplyOptions
 	SubResourceBody runtime.ApplyConfiguration

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -544,6 +544,30 @@ func (po *SubResourcePatchOptions) ApplyToSubResourcePatch(o *SubResourcePatchOp
 	}
 }
 
+// SubResourceApplyOptions are the options for a subresource
+// apply rquest.
+type SubResourceApplyOptions struct {
+	ApplyOptions
+	SubResourceBody runtime.ApplyConfiguration
+}
+
+// ApplyOpts applies the given options.
+func (ao *SubResourceApplyOptions) ApplyOpts(opts []SubResourceApplyOption) *SubResourceApplyOptions {
+	for _, o := range opts {
+		o.ApplyToSubResourceApply(ao)
+	}
+
+	return ao
+}
+
+// ApplyToSubResourceApply applies the configuration on the given patch options.
+func (ao *SubResourceApplyOptions) ApplyToSubResourceApply(o *SubResourceApplyOptions) {
+	ao.ApplyOptions.ApplyToApply(&o.ApplyOptions)
+	if ao.SubResourceBody != nil {
+		o.SubResourceBody = ao.SubResourceBody
+	}
+}
+
 func (sc *subResourceClient) Get(ctx context.Context, obj Object, subResource Object, opts ...SubResourceGetOption) error {
 	switch obj.(type) {
 	case runtime.Unstructured:
@@ -593,5 +617,15 @@ func (sc *subResourceClient) Patch(ctx context.Context, obj Object, patch Patch,
 		return sc.client.metadataClient.PatchSubResource(ctx, obj, sc.subResource, patch, opts...)
 	default:
 		return sc.client.typedClient.PatchSubResource(ctx, obj, sc.subResource, patch, opts...)
+	}
+}
+
+func (sc *subResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error {
+	switch obj := obj.(type) {
+	case *unstructuredApplyConfiguration:
+		defer sc.client.resetGroupVersionKind(obj, obj.GetObjectKind().GroupVersionKind())
+		return sc.client.unstructuredClient.ApplySubResource(ctx, obj, sc.subResource, opts...)
+	default:
+		return sc.client.typedClient.ApplySubResource(ctx, obj, sc.subResource, opts...)
 	}
 }

--- a/pkg/client/dryrun.go
+++ b/pkg/client/dryrun.go
@@ -132,3 +132,7 @@ func (sw *dryRunSubResourceClient) Update(ctx context.Context, obj Object, opts 
 func (sw *dryRunSubResourceClient) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	return sw.client.Patch(ctx, obj, patch, append(opts, DryRunAll)...)
 }
+
+func (sw *dryRunSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error {
+	return sw.client.Apply(ctx, obj, append(opts, DryRunAll)...)
+}

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1357,8 +1357,12 @@ func (sw *fakeSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyCon
 	patchOpts.Raw = applyOpts.AsPatchOptions()
 
 	if applyOpts.SubResourceBody != nil {
+		subResourceBodySerialized, err := json.Marshal(applyOpts.SubResourceBody)
+		if err != nil {
+			return fmt.Errorf("failed to serialize subresource body: %w", err)
+		}
 		subResourceBody := &unstructured.Unstructured{}
-		if err := json.Unmarshal(data, subResourceBody); err != nil {
+		if err := json.Unmarshal(subResourceBodySerialized, subResourceBody); err != nil {
 			return fmt.Errorf("failed to unmarshal subresource body: %w", err)
 		}
 		patchOpts.SubResourceBody = subResourceBody

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -2719,7 +2719,7 @@ var _ = Describe("Fake client", func() {
 		obj.SetName("foo")
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
@@ -2727,7 +2727,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cm.Data).To(Equal(map[string]string{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "data")).To(Succeed())
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"other": "data"}))
@@ -2743,13 +2743,13 @@ var _ = Describe("Fake client", func() {
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "spec")).To(Succeed())
 
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "spec")).To(Succeed())
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		Expect(cl.Get(ctx, client.ObjectKeyFromObject(result), result)).To(Succeed())
 		Expect(result.Object["spec"]).To(Equal(map[string]any{"other": "data"}))
@@ -2763,9 +2763,9 @@ var _ = Describe("Fake client", func() {
 		obj.SetName("foo")
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
-		err := cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))
+		err := cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo")) //nolint:staticcheck // will be removed once client.Apply is removed
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("metadata.managedFields must be nil"))
 	})
@@ -2781,7 +2781,7 @@ var _ = Describe("Fake client", func() {
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"some": "data"}, "data")).To(Succeed())
 
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
@@ -2789,7 +2789,7 @@ var _ = Describe("Fake client", func() {
 		Expect(cm.Data).To(Equal(map[string]string{"some": "data"}))
 
 		Expect(unstructured.SetNestedField(obj.Object, map[string]any{"other": "data"}, "data")).To(Succeed())
-		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed())
+		Expect(cl.Patch(ctx, obj, client.Apply, client.FieldOwner("foo"))).To(Succeed()) //nolint:staticcheck // will be removed once client.Apply is removed
 
 		Expect(cl.Get(ctx, client.ObjectKeyFromObject(cm), cm)).To(Succeed())
 		Expect(cm.Data).To(Equal(map[string]string{"other": "data"}))
@@ -2835,7 +2835,7 @@ var _ = Describe("Fake client", func() {
 				"ssa": "value",
 			},
 		}}
-		Expect(cl.Patch(ctx, u, client.Apply, client.FieldOwner("foo"))).NotTo(HaveOccurred())
+		Expect(cl.Patch(ctx, u, client.Apply, client.FieldOwner("foo"))).NotTo(HaveOccurred()) //nolint:staticcheck // will be removed once client.Apply is removed
 		_, exists, err := unstructured.NestedFieldNoCopy(u.Object, "metadata", "managedFields")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(exists).To(BeTrue())

--- a/pkg/client/fieldowner.go
+++ b/pkg/client/fieldowner.go
@@ -108,3 +108,7 @@ func (f *subresourceClientWithFieldOwner) Update(ctx context.Context, obj Object
 func (f *subresourceClientWithFieldOwner) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	return f.subresourceWriter.Patch(ctx, obj, patch, append([]SubResourcePatchOption{FieldOwner(f.owner)}, opts...)...)
 }
+
+func (f *subresourceClientWithFieldOwner) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error {
+	return f.subresourceWriter.Apply(ctx, obj, append([]SubResourceApplyOption{FieldOwner(f.owner)}, opts...)...)
+}

--- a/pkg/client/fieldvalidation.go
+++ b/pkg/client/fieldvalidation.go
@@ -27,6 +27,9 @@ import (
 // WithFieldValidation wraps a Client and configures field validation, by
 // default, for all write requests from this client. Users can override field
 // validation for individual write requests.
+//
+// This wrapper has no effect on apply requests, as they do not support a
+// custom fieldValidation setting, it is always strict.
 func WithFieldValidation(c Client, validation FieldValidation) Client {
 	return &clientWithFieldValidation{
 		validation: validation,
@@ -107,4 +110,8 @@ func (c *subresourceClientWithFieldValidation) Update(ctx context.Context, obj O
 
 func (c *subresourceClientWithFieldValidation) Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error {
 	return c.subresourceWriter.Patch(ctx, obj, patch, append([]SubResourcePatchOption{c.validation}, opts...)...)
+}
+
+func (c *subresourceClientWithFieldValidation) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error {
+	return c.subresourceWriter.Apply(ctx, obj, opts...)
 }

--- a/pkg/client/fieldvalidation_test.go
+++ b/pkg/client/fieldvalidation_test.go
@@ -119,11 +119,13 @@ func TestWithStrictFieldValidation(t *testing.T) {
 	_ = wrappedClient.Status().Create(ctx, dummyObj, dummyObj)
 	_ = wrappedClient.Status().Update(ctx, dummyObj)
 	_ = wrappedClient.Status().Patch(ctx, dummyObj, nil)
+	_ = wrappedClient.Status().Apply(ctx, corev1applyconfigurations.Namespace(""), nil)
 	_ = wrappedClient.SubResource("some-subresource").Create(ctx, dummyObj, dummyObj)
 	_ = wrappedClient.SubResource("some-subresource").Update(ctx, dummyObj)
 	_ = wrappedClient.SubResource("some-subresource").Patch(ctx, dummyObj, nil)
+	_ = wrappedClient.SubResource("some-subresource").Apply(ctx, corev1applyconfigurations.Namespace(""), nil)
 
-	if expectedCalls := 10; calls != expectedCalls {
+	if expectedCalls := 12; calls != expectedCalls {
 		t.Fatalf("wrong number of calls to assertions: expected=%d; got=%d", expectedCalls, calls)
 	}
 }

--- a/pkg/client/interceptor/intercept.go
+++ b/pkg/client/interceptor/intercept.go
@@ -26,6 +26,7 @@ type Funcs struct {
 	SubResourceCreate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error
 	SubResourceUpdate func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error
 	SubResourcePatch  func(ctx context.Context, client client.Client, subResourceName string, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error
+	SubResourceApply  func(ctx context.Context, client client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error
 }
 
 // NewClient returns a new interceptor client that calls the functions in funcs instead of the underlying client's methods, if they are not nil.
@@ -172,4 +173,11 @@ func (s subResourceInterceptor) Patch(ctx context.Context, obj client.Object, pa
 		return s.funcs.SubResourcePatch(ctx, s.client, s.subResourceName, obj, patch, opts...)
 	}
 	return s.client.SubResource(s.subResourceName).Patch(ctx, obj, patch, opts...)
+}
+
+func (s subResourceInterceptor) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+	if s.funcs.SubResourceApply != nil {
+		return s.funcs.SubResourceApply(ctx, s.client, s.subResourceName, obj, opts...)
+	}
+	return s.client.SubResource(s.subResourceName).Apply(ctx, obj, opts...)
 }

--- a/pkg/client/interceptor/intercept_test.go
+++ b/pkg/client/interceptor/intercept_test.go
@@ -351,6 +351,31 @@ var _ = Describe("NewSubResourceClient", func() {
 		_ = client2.SubResource("foo").Create(ctx, nil, nil)
 		Expect(called).To(BeTrue())
 	})
+	It("should call the provided Apply function", func(ctx SpecContext) {
+		var called bool
+		client := NewClient(c, Funcs{
+			SubResourceApply: func(_ context.Context, client client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				called = true
+				Expect(subResourceName).To(BeEquivalentTo("foo"))
+				return nil
+			},
+		})
+		_ = client.SubResource("foo").Apply(ctx, nil)
+		Expect(called).To(BeTrue())
+	})
+	It("should call the underlying client if the provided Apply function is nil", func(ctx SpecContext) {
+		var called bool
+		client1 := NewClient(c, Funcs{
+			SubResourceApply: func(_ context.Context, client client.Client, subResourceName string, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
+				called = true
+				Expect(subResourceName).To(BeEquivalentTo("foo"))
+				return nil
+			},
+		})
+		client2 := NewClient(client1, Funcs{})
+		_ = client2.SubResource("foo").Apply(ctx, nil)
+		Expect(called).To(BeTrue())
+	})
 })
 
 type dummyClient struct{}

--- a/pkg/client/interfaces.go
+++ b/pkg/client/interfaces.go
@@ -155,6 +155,9 @@ type SubResourceWriter interface {
 	// pointer so that obj can be updated with the content returned by the
 	// Server.
 	Patch(ctx context.Context, obj Object, patch Patch, opts ...SubResourcePatchOption) error
+
+	// Apply applies the given apply configurations subresource.
+	Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error
 }
 
 // SubResourceClient knows how to perform CRU operations on Kubernetes objects.

--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -150,7 +150,7 @@ func (n *namespacedClient) Patch(ctx context.Context, obj Object, patch Patch, o
 	return n.client.Patch(ctx, obj, patch, opts...)
 }
 
-func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+func (n *namespacedClient) setNamespaceForApplyConfigIfNamespaceScoped(obj runtime.ApplyConfiguration) error {
 	var gvk schema.GroupVersionKind
 	switch o := obj.(type) {
 	case applyConfiguration:
@@ -193,6 +193,14 @@ func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfigura
 		}
 	}
 
+	return nil
+}
+
+func (n *namespacedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...ApplyOption) error {
+	if err := n.setNamespaceForApplyConfigIfNamespaceScoped(obj); err != nil {
+		return err
+	}
+
 	return n.client.Apply(ctx, obj, opts...)
 }
 
@@ -226,7 +234,10 @@ func (n *namespacedClient) Status() SubResourceWriter {
 
 // SubResource implements client.SubResourceClient.
 func (n *namespacedClient) SubResource(subResource string) SubResourceClient {
-	return &namespacedClientSubResourceClient{client: n.client.SubResource(subResource), namespace: n.namespace, namespacedclient: n}
+	return &namespacedClientSubResourceClient{
+		client:           n.client.SubResource(subResource),
+		namespacedclient: n,
+	}
 }
 
 // ensure namespacedClientSubResourceClient implements client.SubResourceClient.
@@ -234,8 +245,7 @@ var _ SubResourceClient = &namespacedClientSubResourceClient{}
 
 type namespacedClientSubResourceClient struct {
 	client           SubResourceClient
-	namespace        string
-	namespacedclient Client
+	namespacedclient *namespacedClient
 }
 
 func (nsw *namespacedClientSubResourceClient) Get(ctx context.Context, obj, subResource Object, opts ...SubResourceGetOption) error {
@@ -245,12 +255,12 @@ func (nsw *namespacedClientSubResourceClient) Get(ctx context.Context, obj, subR
 	}
 
 	objectNamespace := obj.GetNamespace()
-	if objectNamespace != nsw.namespace && objectNamespace != "" {
-		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	if objectNamespace != nsw.namespacedclient.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespacedclient.namespace)
 	}
 
 	if isNamespaceScoped && objectNamespace == "" {
-		obj.SetNamespace(nsw.namespace)
+		obj.SetNamespace(nsw.namespacedclient.namespace)
 	}
 
 	return nsw.client.Get(ctx, obj, subResource, opts...)
@@ -263,12 +273,12 @@ func (nsw *namespacedClientSubResourceClient) Create(ctx context.Context, obj, s
 	}
 
 	objectNamespace := obj.GetNamespace()
-	if objectNamespace != nsw.namespace && objectNamespace != "" {
-		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	if objectNamespace != nsw.namespacedclient.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespacedclient.namespace)
 	}
 
 	if isNamespaceScoped && objectNamespace == "" {
-		obj.SetNamespace(nsw.namespace)
+		obj.SetNamespace(nsw.namespacedclient.namespace)
 	}
 
 	return nsw.client.Create(ctx, obj, subResource, opts...)
@@ -282,12 +292,12 @@ func (nsw *namespacedClientSubResourceClient) Update(ctx context.Context, obj Ob
 	}
 
 	objectNamespace := obj.GetNamespace()
-	if objectNamespace != nsw.namespace && objectNamespace != "" {
-		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	if objectNamespace != nsw.namespacedclient.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespacedclient.namespace)
 	}
 
 	if isNamespaceScoped && objectNamespace == "" {
-		obj.SetNamespace(nsw.namespace)
+		obj.SetNamespace(nsw.namespacedclient.namespace)
 	}
 	return nsw.client.Update(ctx, obj, opts...)
 }
@@ -300,12 +310,19 @@ func (nsw *namespacedClientSubResourceClient) Patch(ctx context.Context, obj Obj
 	}
 
 	objectNamespace := obj.GetNamespace()
-	if objectNamespace != nsw.namespace && objectNamespace != "" {
-		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespace)
+	if objectNamespace != nsw.namespacedclient.namespace && objectNamespace != "" {
+		return fmt.Errorf("namespace %s of the object %s does not match the namespace %s on the client", objectNamespace, obj.GetName(), nsw.namespacedclient.namespace)
 	}
 
 	if isNamespaceScoped && objectNamespace == "" {
-		obj.SetNamespace(nsw.namespace)
+		obj.SetNamespace(nsw.namespacedclient.namespace)
 	}
 	return nsw.client.Patch(ctx, obj, patch, opts...)
+}
+
+func (nsw *namespacedClientSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...SubResourceApplyOption) error {
+	if err := nsw.namespacedclient.setNamespaceForApplyConfigIfNamespaceScoped(obj); err != nil {
+		return err
+	}
+	return nsw.client.Apply(ctx, obj, opts...)
 }

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -97,7 +97,7 @@ type SubResourcePatchOption interface {
 	ApplyToSubResourcePatch(*SubResourcePatchOptions)
 }
 
-// SubResourceApplyOption configures a subresoruce apply request.
+// SubResourceApplyOption configures a subresource apply request.
 type SubResourceApplyOption interface {
 	// ApplyToSubResourceApply applies the configuration on the given patch options.
 	ApplyToSubResourceApply(*SubResourceApplyOptions)

--- a/pkg/client/options.go
+++ b/pkg/client/options.go
@@ -97,6 +97,12 @@ type SubResourcePatchOption interface {
 	ApplyToSubResourcePatch(*SubResourcePatchOptions)
 }
 
+// SubResourceApplyOption configures a subresoruce apply request.
+type SubResourceApplyOption interface {
+	// ApplyToSubResourceApply applies the configuration on the given patch options.
+	ApplyToSubResourceApply(*SubResourceApplyOptions)
+}
+
 // }}}
 
 // {{{ Multi-Type Options
@@ -148,6 +154,10 @@ func (dryRunAll) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
 	opts.DryRun = []string{metav1.DryRunAll}
 }
 
+func (dryRunAll) ApplyToSubResourceApply(opts *SubResourceApplyOptions) {
+	opts.DryRun = []string{metav1.DryRunAll}
+}
+
 // FieldOwner set the field manager name for the given server-side apply patch.
 type FieldOwner string
 
@@ -183,6 +193,11 @@ func (f FieldOwner) ApplyToSubResourceCreate(opts *SubResourceCreateOptions) {
 
 // ApplyToSubResourceUpdate applies this configuration to the given update options.
 func (f FieldOwner) ApplyToSubResourceUpdate(opts *SubResourceUpdateOptions) {
+	opts.FieldManager = string(f)
+}
+
+// ApplyToSubResourceApply applies this configuration to the given apply options.
+func (f FieldOwner) ApplyToSubResourceApply(opts *SubResourceApplyOptions) {
 	opts.FieldManager = string(f)
 }
 
@@ -946,6 +961,10 @@ func (forceOwnership) ApplyToSubResourcePatch(opts *SubResourcePatchOptions) {
 }
 
 func (forceOwnership) ApplyToApply(opts *ApplyOptions) {
+	opts.Force = ptr.To(true)
+}
+
+func (forceOwnership) ApplyToSubResourceApply(opts *SubResourceApplyOptions) {
 	opts.Force = ptr.To(true)
 }
 

--- a/pkg/client/options_test.go
+++ b/pkg/client/options_test.go
@@ -374,6 +374,12 @@ var _ = Describe("DryRunAll", func() {
 		t.ApplyToSubResourceUpdate(o)
 		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
 	})
+	It("Should apply to SubResourceApplyOptions", func() {
+		o := &client.SubResourceApplyOptions{ApplyOptions: client.ApplyOptions{DryRun: []string{"server"}}}
+		t := client.DryRunAll
+		t.ApplyToSubResourceApply(o)
+		Expect(o.DryRun).To(Equal([]string{metav1.DryRunAll}))
+	})
 })
 
 var _ = Describe("FieldOwner", func() {
@@ -419,6 +425,12 @@ var _ = Describe("FieldOwner", func() {
 		t.ApplyToSubResourceUpdate(o)
 		Expect(o.FieldManager).To(Equal("foo"))
 	})
+	It("Should apply to SubResourceApplyOptions", func() {
+		o := &client.SubResourceApplyOptions{ApplyOptions: client.ApplyOptions{FieldManager: "bar"}}
+		t := client.FieldOwner("foo")
+		t.ApplyToSubResourceApply(o)
+		Expect(o.FieldManager).To(Equal("foo"))
+	})
 })
 
 var _ = Describe("ForceOwnership", func() {
@@ -438,6 +450,12 @@ var _ = Describe("ForceOwnership", func() {
 		o := &client.ApplyOptions{}
 		t := client.ForceOwnership
 		t.ApplyToApply(o)
+		Expect(*o.Force).To(BeTrue())
+	})
+	It("Should apply to SubResourceApplyOptions", func() {
+		o := &client.SubResourceApplyOptions{}
+		t := client.ForceOwnership
+		t.ApplyToSubResourceApply(o)
 		Expect(*o.Force).To(BeTrue())
 	})
 })

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -28,10 +28,7 @@ import (
 var (
 	// Apply uses server-side apply to patch the given object.
 	//
-	// This should now only be used to patch sub resources, e.g. with client.Client.Status().Patch().
-	// Use client.Client.Apply() instead of client.Client.Patch(..., client.Apply, ...)
-	// This will be deprecated once the Apply method has been added for sub resources.
-	// See the following issue for more details: https://github.com/kubernetes-sigs/controller-runtime/issues/3183
+	// Deprecated: Use client.Client.Apply() instead.
 	Apply Patch = applyPatch{}
 
 	// Merge uses the raw object as a merge patch, without modifications.

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -28,7 +28,7 @@ import (
 var (
 	// Apply uses server-side apply to patch the given object.
 	//
-	// Deprecated: Use client.Client.Apply() instead.
+	// Deprecated: Use client.Client.Apply() and client.Client.SubResource("subrsource").Apply() instead.
 	Apply Patch = applyPatch{}
 
 	// Merge uses the raw object as a merge patch, without modifications.


### PR DESCRIPTION
This change adds subresource apply support to the client. It is breaking, as that entails extending the interface.

The fake client currently only supports the `status` subresource for apply and will error out if it is used for any other subresource.

Ref https://github.com/kubernetes-sigs/controller-runtime/issues/3183

/hold


<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
