### PR TITLE
🐛 Don't block on Get when queue is shutdown (2nd try)

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -296,6 +296,32 @@ var _ = Describe("Controllerworkqueue", func() {
 		Expect(isShutDown).To(BeTrue())
 	})
 
+	It("Get from priority queue should get unblocked when the priority queue is shut down", func() {
+		q, _ := newQueue()
+
+		getUnblocked := make(chan struct{})
+
+		go func() {
+			defer GinkgoRecover()
+			defer close(getUnblocked)
+
+			item, priority, isShutDown := q.GetWithPriority()
+			Expect(item).To(Equal(""))
+			Expect(priority).To(Equal(0))
+			Expect(isShutDown).To(BeTrue())
+		}()
+
+		// Verify the go routine above is now waiting for an item.
+		Eventually(q.waiters.Load).Should(Equal(int64(1)))
+		Consistently(getUnblocked).ShouldNot(BeClosed())
+
+		// shut down
+		q.ShutDown()
+
+		// Verify the shutdown unblocked the go routine.
+		Eventually(getUnblocked).Should(BeClosed())
+	})
+
 	It("items are included in Len() and the queueDepth metric once they are ready", func() {
 		q, metrics := newQueue()
 		defer q.ShutDown()


### PR DESCRIPTION
Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Part of https://github.com/kubernetes-sigs/controller-runtime/issues/2374
