### PR TITLE
[release-0.22] :bug: Don't block on Get when queue is shutdown (2nd try)

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -337,7 +337,7 @@ var _ = Describe("Controllerworkqueue", func() {
 		}()
 
 		// Verify the go routine above is now waiting for an item.
-		Eventually(q.waiters.Load).Should(Equal(int64(1)))
+		Eventually(q.(*priorityqueue[string]).waiters.Load).Should(Equal(int64(1)))
 		Consistently(getUnblocked).ShouldNot(BeClosed())
 
 		// shut down


### PR DESCRIPTION
Cherrypick of https://github.com/kubernetes-sigs/controller-runtime/pull/3337
Supersedes https://github.com/kubernetes-sigs/controller-runtime/pull/3338
/assign @sbueringer 