### PR TITLE
🐛 Allow SSA after normal resource creation

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -151,8 +151,7 @@ func newClient(config *rest.Config, options Options) (*client, error) {
 		mapper:     options.Mapper,
 		codecs:     serializer.NewCodecFactory(options.Scheme),
 
-		structuredResourceByType:   make(map[cacheKey]*resourceMeta),
-		unstructuredResourceByType: make(map[cacheKey]*resourceMeta),
+		resourceByType: make(map[cacheKey]*resourceMeta),
 	}
 
 	rawMetaClient, err := metadata.NewForConfigAndClient(metadata.ConfigFor(config), options.HTTPClient)

--- a/pkg/client/client_rest_resources.go
+++ b/pkg/client/client_rest_resources.go
@@ -48,11 +48,8 @@ type clientRestResources struct {
 	// codecs are used to create a REST client for a gvk
 	codecs serializer.CodecFactory
 
-	// structuredResourceByType stores structured type metadata
-	structuredResourceByType map[cacheKey]*resourceMeta
-
-	// unstructuredResourceByType stores unstructured type metadata
-	unstructuredResourceByType map[cacheKey]*resourceMeta
+	// resourceByType stores type metadata
+	resourceByType map[cacheKey]*resourceMeta
 
 	mu sync.RWMutex
 }
@@ -127,12 +124,7 @@ func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
 
 	cacheKey := cacheKey{gvk: gvk, forceDisableProtoBuf: forceDisableProtoBuf}
 
-	resourceByType := c.structuredResourceByType
-	if isUnstructured {
-		resourceByType = c.unstructuredResourceByType
-	}
-
-	r, known := resourceByType[cacheKey]
+	r, known := c.resourceByType[cacheKey]
 
 	c.mu.RUnlock()
 
@@ -152,7 +144,7 @@ func (c *clientRestResources) getResource(obj any) (*resourceMeta, error) {
 	if err != nil {
 		return nil, err
 	}
-	resourceByType[cacheKey] = r
+	c.resourceByType[cacheKey] = r
 	return r, err
 }
 

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -962,10 +962,6 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 					"some-key": []byte("some-value"),
 				}
 				secretObject := &corev1.Secret{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "Secret",
-						APIVersion: "v1",
-					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "secret-one",
 						Namespace: "default",
@@ -975,8 +971,6 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 
 				secretApplyConfiguration := corev1applyconfigurations.
 					Secret("secret-two", "default").
-					WithAPIVersion("v1").
-					WithKind("Secret").
 					WithData(data)
 
 				err = cl.Create(ctx, secretObject)
@@ -985,11 +979,11 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				err = cl.Apply(ctx, secretApplyConfiguration, &client.ApplyOptions{FieldManager: "test-manager"})
 				Expect(err).NotTo(HaveOccurred())
 
-				cm, err := clientset.CoreV1().Secrets(ptr.Deref(secretApplyConfiguration.GetNamespace(), "")).Get(ctx, ptr.Deref(secretApplyConfiguration.GetName(), ""), metav1.GetOptions{})
+				secret, err := clientset.CoreV1().Secrets(ptr.Deref(secretApplyConfiguration.GetNamespace(), "")).Get(ctx, ptr.Deref(secretApplyConfiguration.GetName(), ""), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(cm.Data).To(BeComparableTo(data))
-				Expect(cm.Data).To(BeComparableTo(secretApplyConfiguration.Data))
+				Expect(secret.Data).To(BeComparableTo(data))
+				Expect(secret.Data).To(BeComparableTo(secretApplyConfiguration.Data))
 
 				data = map[string][]byte{
 					"some-key": []byte("some-new-value"),
@@ -999,11 +993,11 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				err = cl.Apply(ctx, secretApplyConfiguration, &client.ApplyOptions{FieldManager: "test-manager"})
 				Expect(err).NotTo(HaveOccurred())
 
-				cm, err = clientset.CoreV1().Secrets(ptr.Deref(secretApplyConfiguration.GetNamespace(), "")).Get(ctx, ptr.Deref(secretApplyConfiguration.GetName(), ""), metav1.GetOptions{})
+				secret, err = clientset.CoreV1().Secrets(ptr.Deref(secretApplyConfiguration.GetNamespace(), "")).Get(ctx, ptr.Deref(secretApplyConfiguration.GetName(), ""), metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(cm.Data).To(BeComparableTo(data))
-				Expect(cm.Data).To(BeComparableTo(secretApplyConfiguration.Data))
+				Expect(secret.Data).To(BeComparableTo(data))
+				Expect(secret.Data).To(BeComparableTo(secretApplyConfiguration.Data))
 			})
 		})
 	})


### PR DESCRIPTION
Addressing issue #3344 

Issue:
- When using Server-Side Apply (SSA) users could encounter the following error: `object %v does not implement the protobuf marshalling interface and cannot be encoded to a *client.applyconfigurationRuntimeObject protobuf message.  `

Root Cause:
- By default, the content-type is set to "protobuf" when creating in-tree resources. If resources were previously created without using Server-Side Apply (SSA), attempting an SSA operation later caused the GroupVersionKind (GVK) to be identified, halting execution before a new client with the forceDisableProtoBuf option could be created. This resulted in unintended generation of Protobuf requests, which SSA does not support, causing the previous error.

Changes Made:
- The implementation now includes a cache key that combines both the actual GVK (GroupVersionKind) and the forceDisableProtoBuf flag. This ensures that we now support up to two distinct clients for each GVK: one with forceDisableProtoBuf enabled and another without it.


