### PR TITLE
:seedling: Priorityqueue tests: Use synctest

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -771,13 +771,7 @@ func TesWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *testi
 		q.rateLimiter = workqueue.NewTypedItemExponentialFailureRateLimiter[string](5*time.Millisecond, 1000*time.Second)
 		originalTick := q.tick
 		q.tick = func(d time.Duration) <-chan time.Time {
-			done := make(chan struct{})
-			go func() {
-				defer close(done)
-
-				g.Expect(d).To(Or(Equal(5*time.Millisecond), Equal(635*time.Millisecond)))
-			}()
-			<-done
+			g.Expect(d).To(Or(Equal(5*time.Millisecond), Equal(635*time.Millisecond)))
 			return originalTick(d)
 		}
 


### PR DESCRIPTION
This change moves all tests in the priorityqueue where it makes sense to use [synctest](https://go.dev/blog/synctest). Synctest provides a `Wait` func we can use to wait until all goroutines in the test are durably blocked. This allows us to block after an `Add` call until the priorityqueue has finished processing. Because we didn't have that, we previously used `time.Sleep` and `Eventually` if we wanted something to happen and `Consistently` if we wanted to assert that something does not happen. With this change, we don't need any of those three anymore.

Because [ginkgo doesn't support synctest](https://github.com/onsi/ginkgo/issues/1601), this change entails that we have to stop using it. To simplify reviewing, I've moved the tests from ginkgo to go test in the first commit and updated them to use synctest in the second commit.