### PR TITLE
🐛 Update List in namespaced client to list objects that are cluster scoped

### DIFF
--- a/pkg/client/namespaced_client.go
+++ b/pkg/client/namespaced_client.go
@@ -221,7 +221,12 @@ func (n *namespacedClient) Get(ctx context.Context, key ObjectKey, obj Object, o
 
 // List implements client.Client.
 func (n *namespacedClient) List(ctx context.Context, obj ObjectList, opts ...ListOption) error {
-	if n.namespace != "" {
+	isNamespaceScoped, err := n.IsObjectNamespaced(obj)
+	if err != nil {
+		return fmt.Errorf("error finding the scope of the object: %w", err)
+	}
+
+	if isNamespaceScoped && n.namespace != "" {
 		opts = append(opts, InNamespace(n.namespace))
 	}
 	return n.client.List(ctx, obj, opts...)

--- a/pkg/client/namespaced_client_test.go
+++ b/pkg/client/namespaced_client_test.go
@@ -54,6 +54,8 @@ var _ = Describe("NamespacedClient", func() {
 
 		err := rbacv1.AddToScheme(sch)
 		Expect(err).ToNot(HaveOccurred())
+		err = corev1.AddToScheme(sch)
+		Expect(err).ToNot(HaveOccurred())
 		err = appsv1.AddToScheme(sch)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -145,6 +147,13 @@ var _ = Describe("NamespacedClient", func() {
 			Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
 			Expect(len(result.Items)).To(BeEquivalentTo(1))
 			Expect(result.Items[0]).To(BeEquivalentTo(*dep))
+		})
+
+		It("should successfully List objects when object is not namespaced scoped", func(ctx SpecContext) {
+			result := &corev1.NodeList{}
+			opts := &client.ListOptions{}
+			Expect(getClient().List(ctx, result, opts)).NotTo(HaveOccurred())
+			Expect(result.Items).NotTo(BeEmpty())
 		})
 
 		It("should List objects from the namespace specified in the client", func(ctx SpecContext) {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3347
<!-- What does this do, and why do we need it? -->
