### PR TITLE
📖Remove latest from setupenvtest docs

### DIFF
--- a/tools/setup-envtest/README.md
+++ b/tools/setup-envtest/README.md
@@ -4,11 +4,14 @@ This is a small tool that manages binaries for envtest. It can be used to
 download new binaries, list currently installed and available ones, and
 clean up versions.
 
-To use it, just go-install it with Golang 1.24+ (it's a separate, self-contained
-module):
+To use it, download the binary from the [release page.](https://github.com/kubernetes-sigs/controller-runtime/releases)
+
+If you want to install this with Golang, you can install a release by using a release branch instead.
+
+NOTE: Each release branch may prefer a different version of Golang when installing.
 
 ```shell
-go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
 ```
 
 If you are using Golang 1.23, use the `release-0.20` branch instead:


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
Instead of saying use `latest` which can have a different go version in the go.mod at the time of reading the doc, we can just use the last release.  

If people want to install at latest, they will do so at their own will.
<!-- What does this do, and why do we need it? -->
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3358

/assign @sbueringer 
/assign @alvaroaleman 

_Not sure if this is sufficient but it does document this a little better than before._