### PR TITLE
🐛 fix(testing/addr): prevent possible leak by avoiding defer in loop

### DIFF
--- a/pkg/internal/testing/addr/manager.go
+++ b/pkg/internal/testing/addr/manager.go
@@ -124,14 +124,16 @@ func suggest(listenHost string) (*net.TCPListener, int, string, error) {
 // Suggest suggests an address a process can listen on. It returns
 // a tuple consisting of a free port and the hostname resolved to its IP.
 // It makes sure that new port allocated does not conflict with old ports
-// allocated within 1 minute.
+// allocated within 2 minute.
 func Suggest(listenHost string) (int, string, error) {
 	for i := 0; i < portConflictRetry; i++ {
 		listener, port, resolvedHost, err := suggest(listenHost)
 		if err != nil {
 			return -1, "", err
 		}
-		defer listener.Close()
+		if err := listener.Close(); err != nil {
+			return -1, "", err
+		}
 		if ok, err := cache.add(port); ok {
 			return port, resolvedHost, nil
 		} else if err != nil {


### PR DESCRIPTION
1. prevent possible leak by removing defer in loop
2. update description as `portReserveTime` constant
