### PR TITLE
[release-0.22] :bug: priority queue: properly sync the waiter manipulation 

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -378,7 +378,12 @@ var _ = Describe("Controllerworkqueue", func() {
 		}()
 
 		// Verify the go routine above is now waiting for an item.
-		Eventually(q.(*priorityqueue[string]).waiters.Load).Should(Equal(int64(1)))
+		Eventually(func() int64 {
+			q.(*priorityqueue[string]).lock.Lock()
+			defer q.(*priorityqueue[string]).lock.Unlock()
+
+			return q.(*priorityqueue[string]).waiters
+		}).Should(Equal(int64(1)))
 		Consistently(getUnblocked).ShouldNot(BeClosed())
 
 		// shut down


### PR DESCRIPTION
As described in https://github.com/kubernetes-sigs/controller-runtime/issues/3363,
there are some circumstances under which `GetWithPriority`
is not returning the correct/expected element.

This can happen when a `GetWithPriority` is executed
and the `Ascend` of the queue is not completed yet,
causing not all the items of the BTree to evaluate
the same w.waiters.Load() value.

Adding a lock to manipulate the waiters will solve the issue.
Since the lock is required, there is no need to use an
atomic.Int64 anymore.

Cherry-pick of https://github.com/kubernetes-sigs/controller-runtime/pull/3368

This cherry-pick does not include the corresponding test, because it uses synctest which is only available in go 1.25 and we use go 1.24 here. Given that all changes have to pass CI and be merged into `main` first, I think this is acceptable.

/assign @sbueringer 