### PR TITLE
✨ envtest: respect pre-configured binary paths in ControlPlane

### DIFF
--- a/pkg/envtest/server.go
+++ b/pkg/envtest/server.go
@@ -109,7 +109,11 @@ var (
 // Environment creates a Kubernetes test environment that will start / stop the Kubernetes control plane and
 // install extension APIs.
 type Environment struct {
-	// ControlPlane is the ControlPlane including the apiserver and etcd
+	// ControlPlane is the ControlPlane including the apiserver and etcd.
+	// Binary paths (APIServer.Path, Etcd.Path, KubectlPath) can be pre-configured in ControlPlane.
+	// If DownloadBinaryAssets is true, the downloaded paths will always be used.
+	// If DownloadBinaryAssets is false and paths are not pre-configured (default is empty), they will be
+	// automatically resolved using BinaryAssetsDirectory.
 	ControlPlane controlplane.ControlPlane
 
 	// Scheme is used to determine if conversion webhooks should be enabled
@@ -211,6 +215,40 @@ func (te *Environment) Stop() error {
 	return te.ControlPlane.Stop()
 }
 
+// configureBinaryPaths configures the binary paths for the API server, etcd, and kubectl.
+// If DownloadBinaryAssets is true, it downloads and uses those paths.
+// If DownloadBinaryAssets is false, it only sets paths that are not already configured (empty).
+func (te *Environment) configureBinaryPaths() error {
+	apiServer := te.ControlPlane.GetAPIServer()
+
+	if te.ControlPlane.Etcd == nil {
+		te.ControlPlane.Etcd = &controlplane.Etcd{}
+	}
+
+	if te.DownloadBinaryAssets {
+		apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(context.TODO(),
+			te.BinaryAssetsDirectory, te.DownloadBinaryAssetsVersion, te.DownloadBinaryAssetsIndexURL)
+		if err != nil {
+			return err
+		}
+
+		apiServer.Path = apiServerPath
+		te.ControlPlane.Etcd.Path = etcdPath
+		te.ControlPlane.KubectlPath = kubectlPath
+	} else {
+		if apiServer.Path == "" {
+			apiServer.Path = process.BinPathFinder("kube-apiserver", te.BinaryAssetsDirectory)
+		}
+		if te.ControlPlane.Etcd.Path == "" {
+			te.ControlPlane.Etcd.Path = process.BinPathFinder("etcd", te.BinaryAssetsDirectory)
+		}
+		if te.ControlPlane.KubectlPath == "" {
+			te.ControlPlane.KubectlPath = process.BinPathFinder("kubectl", te.BinaryAssetsDirectory)
+		}
+	}
+	return nil
+}
+
 // Start starts a local Kubernetes server and updates te.ApiserverPort with the port it is listening on.
 func (te *Environment) Start() (*rest.Config, error) {
 	if te.useExistingCluster() {
@@ -229,10 +267,6 @@ func (te *Environment) Start() (*rest.Config, error) {
 	} else {
 		apiServer := te.ControlPlane.GetAPIServer()
 
-		if te.ControlPlane.Etcd == nil {
-			te.ControlPlane.Etcd = &controlplane.Etcd{}
-		}
-
 		if os.Getenv(envAttachOutput) == "true" {
 			te.AttachControlPlaneOutput = true
 		}
@@ -243,6 +277,9 @@ func (te *Environment) Start() (*rest.Config, error) {
 			if apiServer.Err == nil {
 				apiServer.Err = os.Stderr
 			}
+			if te.ControlPlane.Etcd == nil {
+				te.ControlPlane.Etcd = &controlplane.Etcd{}
+			}
 			if te.ControlPlane.Etcd.Out == nil {
 				te.ControlPlane.Etcd.Out = os.Stdout
 			}
@@ -251,20 +288,8 @@ func (te *Environment) Start() (*rest.Config, error) {
 			}
 		}
 
-		if te.DownloadBinaryAssets {
-			apiServerPath, etcdPath, kubectlPath, err := downloadBinaryAssets(context.TODO(),
-				te.BinaryAssetsDirectory, te.DownloadBinaryAssetsVersion, te.DownloadBinaryAssetsIndexURL)
-			if err != nil {
-				return nil, err
-			}
-
-			apiServer.Path = apiServerPath
-			te.ControlPlane.Etcd.Path = etcdPath
-			te.ControlPlane.KubectlPath = kubectlPath
-		} else {
-			apiServer.Path = process.BinPathFinder("kube-apiserver", te.BinaryAssetsDirectory)
-			te.ControlPlane.Etcd.Path = process.BinPathFinder("etcd", te.BinaryAssetsDirectory)
-			te.ControlPlane.KubectlPath = process.BinPathFinder("kubectl", te.BinaryAssetsDirectory)
+		if err := te.configureBinaryPaths(); err != nil {
+			return nil, fmt.Errorf("failed to configure binary paths: %w", err)
 		}
 
 		if err := te.defaultTimeouts(); err != nil {


### PR DESCRIPTION
This commit fixes an issue where Environment.Start() would ignore pre-configured binary paths (APIServer.Path, Etcd.Path, KubectlPath) set in ControlPlane when DownloadBinaryAssets is false.

Changes:
- Extract path configuration logic into configureBinaryPaths() method for better testability and separation of concerns
- Only auto-configure binary paths when they are empty (not pre-set)
- When DownloadBinaryAssets is true, downloaded paths are still used (preserving existing behavior)
- Update ControlPlane field documentation to clarify path behavior
- Add tests in envtest_test.go to verify path handling logic

This fixed  issue #3373 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
