### PR TITLE
🌱 Add depguard golangci-linter for forbid sort pkg

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - bidichk
     - bodyclose
     - copyloopvar
+    - depguard
     - dogsled
     - dupl
     - errcheck
@@ -42,6 +43,12 @@ linters:
     - unused
     - whitespace
   settings:
+    depguard:
+      rules:
+        forbid-pkg-errors:
+          deny:
+            - pkg: sort
+              desc: Should be replaced with slices package
     forbidigo:
         forbid:
           - pattern: context.Background


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR is a follow-up improvement to #3370  by  https://github.com/kubernetes-sigs/controller-tools/pull/1299#issuecomment-3472365838