### PR TITLE
✨ Fix unused priorityqueue test: TestWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -889,7 +889,7 @@ func TestMetricsAreUpdatedForItemWhoseRequeueAfterExpiredThatGetsAddedAgainWitho
 	})
 }
 
-func TesWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *testing.T) {
+func TestWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {
 		g := NewWithT(t)
@@ -927,7 +927,7 @@ func TesWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *testi
 
 		forwardQueueTimeBy(5 * time.Millisecond)
 		synctest.Wait()
-		g.Expect(retrievedItem).NotTo(BeClosed())
+		g.Expect(retrievedItem).To(BeClosed())
 		g.Expect(retrievedSecondItem).NotTo(BeClosed())
 
 		forwardQueueTimeBy(635 * time.Millisecond)


### PR DESCRIPTION


<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR fixes the unused test `TestWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther` in priorityqueue_test.go and enables it.