### PR TITLE
🐛 Fix fake client Apply with Unstructured ApplyConfiguration and resourceVersion unset

### DIFF
--- a/pkg/client/fake/versioned_tracker.go
+++ b/pkg/client/fake/versioned_tracker.go
@@ -265,10 +265,13 @@ func (t versionedTracker) updateObject(
 			// apiserver accepts such a patch, but it does so we just copy that behavior.
 			// Kubernetes apiserver behavior can be checked like this:
 			// `kubectl patch configmap foo --patch '{"metadata":{"annotations":{"foo":"bar"},"resourceVersion":null}}' -v=9`
-		case bytes.
-			Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Patch")):
+		case bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Patch")):
 			// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
 			// that reaction, we use the callstack to figure out if this originated from the "fakeClient.Patch" func.
+			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
+		case bytes.Contains(debug.Stack(), []byte("sigs.k8s.io/controller-runtime/pkg/client/fake.(*fakeClient).Apply")):
+			// We apply patches using a client-go reaction that ends up calling the trackers Update. As we can't change
+			// that reaction, we use the callstack to figure out if this originated from the "fakeClient.Apply" func.
 			accessor.SetResourceVersion(oldAccessor.GetResourceVersion())
 		}
 	}


### PR DESCRIPTION
The fake client has a bug that if Apply is used with Unstructured and without setting resourceVersion it returns the following conflict error:
```
failed to generate CanUpdateMachine request: server side apply dry-run failed for desired Machine: failed to apply Machine: Operation cannot be fulfilled on machines.cluster.x-k8s.io "machine-to-in-place-update": object was modified
```

This PR fixes it by treating Apply the same way as Patch


Signed-off-by: Stefan Büringer buringerst@vmware.com

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
