### PR TITLE
🐛 Priorityqueue: Do FIFO ordering within priorities and not across

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -320,6 +320,26 @@ var _ = Describe("Controllerworkqueue", func() {
 			Expect(depth).To(Equal(0))
 		}
 	})
+
+	It("follows FIFO order in the new priority queue when item priority changes", func() {
+		q, _ := newQueue()
+		defer q.ShutDown()
+
+		q.AddWithOpts(AddOpts{Priority: ptr.To(0)}, "foo")
+		q.AddWithOpts(AddOpts{Priority: ptr.To(1)}, "bar")
+		q.AddWithOpts(AddOpts{Priority: ptr.To(1)}, "foo")
+		Expect(q.Len()).To(Equal(2))
+
+		item, priority, _ := q.GetWithPriority()
+		Expect(item).To(Equal("bar"))
+		Expect(priority).To(Equal(1))
+		Expect(q.Len()).To(Equal(1))
+
+		item, priority, _ = q.GetWithPriority()
+		Expect(item).To(Equal("foo"))
+		Expect(priority).To(Equal(1))
+		Expect(q.Len()).To(Equal(0))
+	})
 })
 
 func BenchmarkAddGetDone(b *testing.B) {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR fixes an ordering issue in the priority queue: items should be ordered by priority first, and by enqueue time (FIFO) within the same priority. When an item’s priority changes, the queue previously didn’t consistently preserve this rule. The PR corrects the behavior and adds corresponding test case.

Note: @alvaroaleman may want to review the semantic change to `addedCounter`.
