### PR TITLE
:bug: adding missing exponential buckets on webhook native histogram

### DIFF
--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -33,6 +33,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:                            "controller_runtime_webhook_latency_seconds",
 			Help:                            "Histogram of the latency of processing admission requests",
+			Buckets:                         prometheus.ExponentialBuckets(10e-9, 10, 12),
 			NativeHistogramBucketFactor:     1.1,
 			NativeHistogramMaxBucketNumber:  100,
 			NativeHistogramMinResetDuration: 1 * time.Hour,


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
When adopting the native histograms, we need different buckets for the webhook. See issue https://github.com/kubernetes-sigs/controller-runtime/issues/3410
