### PR TITLE
:bug: confusing ManagerOptions#CertDir default

### DIFF
--- a/pkg/metrics/server/defaults_test.go
+++ b/pkg/metrics/server/defaults_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"testing"
+)
+
+func TestOptionsSetDefaults(t *testing.T) {
+	o := &Options{}
+	o.setDefaults()
+
+	if o.CertDir != "" {
+		t.Errorf("expected CertDir to be empty by default, got %q", o.CertDir)
+	}
+
+	if o.CertName != "tls.crt" {
+		t.Errorf("expected CertName to be tls.crt, got %q", o.CertName)
+	}
+
+	if o.KeyName != "tls.key" {
+		t.Errorf("expected KeyName to be tls.key, got %q", o.KeyName)
+	}
+
+	if o.BindAddress != DefaultBindAddress {
+		t.Errorf("expected BindAddress to be %q, got %q", DefaultBindAddress, o.BindAddress)
+	}
+}

--- a/pkg/webhook/defaults_test.go
+++ b/pkg/webhook/defaults_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+)
+
+func TestOptionsSetDefaults(t *testing.T) {
+	o := &Options{}
+	o.setDefaults()
+
+	if o.CertDir != "" {
+		t.Errorf("expected CertDir to be empty by default, got %q", o.CertDir)
+	}
+
+	if o.CertName != "tls.crt" {
+		t.Errorf("expected CertName to be tls.crt, got %q", o.CertName)
+	}
+
+	if o.KeyName != "tls.key" {
+		t.Errorf("expected KeyName to be tls.key, got %q", o.KeyName)
+	}
+
+	if o.Port != DefaultPort {
+		t.Errorf("expected Port to be %d, got %d", DefaultPort, o.Port)
+	}
+}


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Solves #900 
