### PR TITLE
✨ Use a buffer to optimize priority queue AddWithOpts performance

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -371,12 +371,20 @@ func BenchmarkAddOnly(b *testing.B) {
 func BenchmarkAddLockContended(b *testing.B) {
 	q := New[int]("")
 	defer q.ShutDown()
-	go func() {
-		for range 1000 {
-			item, _ := q.Get()
-			q.Done(item)
-		}
-	}()
+
+	for i := range 1000000 {
+		q.Add(i)
+	}
+
+	for range 1000 {
+		go func() {
+			for {
+				item, _ := q.Get()
+				time.Sleep(1 * time.Millisecond)
+				q.Done(item)
+			}
+		}()
+	}
 
 	for b.Loop() {
 		for i := range 1000 {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

before #3416, In the implementation of the priority queue, when there are a large number of items and many workers blocked in `GetWithPriority()`, calls to `spin()` can take a significant amount of time. This method shares the same lock with `AddWithOpts()`, **which causes `AddWithOpts()` to spend 10 ms or more contending for the lock during writes.**

Although `AddWithOpts()` supports enqueuing multiple items in a single call, the event handler as the caller passes only one item at a time. As a result, when the enqueue volume is high, **a large number of items end up being blocked in the `processorListener`’s ring buffer.**

After merging #3416, the time consumption of `handleReadyItems()` (i.e., `spin()`) has been significantly reduced, but due to the still existing lock contention issue, there is still room for optimization in the time consumption of `AddWithOpts()`.

benchmark function:

```go
func BenchmarkAddLockContended(b *testing.B) {
	q := New[int]("")
	defer q.ShutDown()

	for i := range 1000000 {
		q.Add(i)
	}

	for range 1000 {
		go func() {
			for {
				item, _ := q.Get()
				time.Sleep(1 * time.Millisecond)
				q.Done(item)
			}
		}()
	}

	for b.Loop() {
		for i := range 1000 {
			q.Add(i)
		}
	}
}
```


upstream(5de4c4f5) with 1,000,000 preloaded items, 1,000 workers, 1ms reconcile cost:

```
$ go test sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue -bench=BenchmarkAddLockContended -run=^$ -v -benchtime=10s -count=10

goos: linux
goarch: amd64
pkg: sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
BenchmarkAddLockContended
BenchmarkAddLockContended-8   	   13590	    860324 ns/op
BenchmarkAddLockContended-8   	   12276	    962917 ns/op
BenchmarkAddLockContended-8   	   13140	    884829 ns/op
BenchmarkAddLockContended-8   	   10000	   1099948 ns/op
BenchmarkAddLockContended-8   	   12951	    957041 ns/op
BenchmarkAddLockContended-8   	   10384	   1097541 ns/op
BenchmarkAddLockContended-8   	   13532	    859918 ns/op
BenchmarkAddLockContended-8   	   12502	    933303 ns/op
BenchmarkAddLockContended-8   	   13098	    893137 ns/op
BenchmarkAddLockContended-8   	   13420	    898457 ns/op
PASS
ok  	sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue	119.886s
```

optimized:

```
$ go test sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue -bench=BenchmarkAddLockContended -run=^$ -v -benchtime=10s -count=10

goos: linux
goarch: amd64
pkg: sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue
cpu: 12th Gen Intel(R) Core(TM) i9-12900K
BenchmarkAddLockContended
BenchmarkAddLockContended-8   	  110494	     93792 ns/op
BenchmarkAddLockContended-8   	  118648	     84992 ns/op
BenchmarkAddLockContended-8   	  136893	     87722 ns/op
BenchmarkAddLockContended-8   	  139353	     92412 ns/op
BenchmarkAddLockContended-8   	  149298	     77878 ns/op
BenchmarkAddLockContended-8   	  170970	     81339 ns/op
BenchmarkAddLockContended-8   	  185634	     61435 ns/op
BenchmarkAddLockContended-8   	  163879	     80373 ns/op
BenchmarkAddLockContended-8   	  194013	     83871 ns/op
BenchmarkAddLockContended-8   	  222698	     76021 ns/op
PASS
ok  	sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue	136.549s
```

With the same benchmark setup, the optimized version brings `BenchmarkAddLockContended()` down from ~1 ms/op to ~80 µs/op, showing a 10–15× improvement under high contention.