### PR TITLE
 🐛 Cache reader: Wait for cache sync when ReaderFailOnMissingInformer is true

### DIFF
--- a/pkg/cache/informer_cache.go
+++ b/pkg/cache/informer_cache.go
@@ -51,16 +51,7 @@ var _ error = (*ErrCacheNotStarted)(nil)
 // ErrResourceNotCached indicates that the resource type
 // the client asked the cache for is not cached, i.e. the
 // corresponding informer does not exist yet.
-type ErrResourceNotCached struct {
-	GVK schema.GroupVersionKind
-}
-
-// Error returns the error
-func (r ErrResourceNotCached) Error() string {
-	return fmt.Sprintf("%s is not cached", r.GVK.String())
-}
-
-var _ error = (*ErrResourceNotCached)(nil)
+type ErrResourceNotCached = internal.ErrResourceNotCached
 
 // informerCache is a Kubernetes Object cache populated from internal.Informers.
 // informerCache wraps internal.Informers.
@@ -157,7 +148,7 @@ func (ic *informerCache) GetInformerForKind(ctx context.Context, gvk schema.Grou
 		return nil, err
 	}
 
-	_, i, err := ic.Informers.Get(ctx, gvk, obj, applyGetOptions(opts...))
+	_, i, err := ic.Informers.Get(ctx, gvk, obj, false, applyGetOptions(opts...))
 	if err != nil {
 		return nil, err
 	}
@@ -171,7 +162,7 @@ func (ic *informerCache) GetInformer(ctx context.Context, obj client.Object, opt
 		return nil, err
 	}
 
-	_, i, err := ic.Informers.Get(ctx, gvk, obj, applyGetOptions(opts...))
+	_, i, err := ic.Informers.Get(ctx, gvk, obj, false, applyGetOptions(opts...))
 	if err != nil {
 		return nil, err
 	}
@@ -179,15 +170,11 @@ func (ic *informerCache) GetInformer(ctx context.Context, obj client.Object, opt
 }
 
 func (ic *informerCache) getInformerForKind(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object) (bool, *internal.Cache, error) {
-	if ic.readerFailOnMissingInformer {
-		cache, started, ok := ic.Informers.Peek(gvk, obj)
-		if !ok {
-			return false, nil, &ErrResourceNotCached{GVK: gvk}
-		}
-		return started, cache, nil
+	started, cache, err := ic.Informers.Get(ctx, gvk, obj, ic.readerFailOnMissingInformer, &internal.GetOptions{})
+	if err != nil {
+		return false, nil, err
 	}
-
-	return ic.Informers.Get(ctx, gvk, obj, &internal.GetOptions{})
+	return started, cache, nil
 }
 
 // RemoveInformer deactivates and removes the informer from the cache.

--- a/pkg/cache/internal/informers.go
+++ b/pkg/cache/internal/informers.go
@@ -45,6 +45,20 @@ import (
 
 var log = logf.RuntimeLog.WithName("cache")
 
+// ErrResourceNotCached indicates that the resource type
+// the client asked the cache for is not cached, i.e. the
+// corresponding informer does not exist yet.
+type ErrResourceNotCached struct {
+	GVK schema.GroupVersionKind
+}
+
+// Error returns the error
+func (r ErrResourceNotCached) Error() string {
+	return fmt.Sprintf("%s is not cached", r.GVK.String())
+}
+
+var _ error = (*ErrResourceNotCached)(nil)
+
 // InformersOpts configures an InformerMap.
 type InformersOpts struct {
 	HTTPClient            *http.Client
@@ -294,10 +308,13 @@ func (ip *Informers) Peek(gvk schema.GroupVersionKind, obj runtime.Object) (res 
 
 // Get will create a new Informer and add it to the map of specificInformersMap if none exists. Returns
 // the Informer from the map.
-func (ip *Informers) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, opts *GetOptions) (bool, *Cache, error) {
+func (ip *Informers) Get(ctx context.Context, gvk schema.GroupVersionKind, obj runtime.Object, readerFailOnMissingInformer bool, opts *GetOptions) (bool, *Cache, error) {
 	// Return the informer if it is found
 	i, started, ok := ip.Peek(gvk, obj)
 	if !ok {
+		if readerFailOnMissingInformer {
+			return false, nil, &ErrResourceNotCached{GVK: gvk}
+		}
 		var err error
 		if i, started, err = ip.addInformerToMap(gvk, obj); err != nil {
 			return started, nil, err


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
Resolves https://github.com/kubernetes-sigs/controller-runtime/issues/3424

/assign @alvaroaleman 