### PR TITLE
:bug: add not equal as a supported operator for field selectors

### DIFF
--- a/pkg/internal/field/selector/utils.go
+++ b/pkg/internal/field/selector/utils.go
@@ -29,7 +29,7 @@ func RequiresExactMatch(sel fields.Selector) bool {
 	}
 
 	for _, req := range reqs {
-		if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals && req.Operator != selection.NotEquals {
 			return false
 		}
 	}

--- a/pkg/internal/field/selector/utils_test.go
+++ b/pkg/internal/field/selector/utils_test.go
@@ -38,7 +38,7 @@ var _ = Describe("RequiresExactMatch function", func() {
 
 	It("Returns false when the selector has the form key!=val", func() {
 		requiresExactMatch := RequiresExactMatch(fields.ParseSelectorOrDie("key!=val"))
-		Expect(requiresExactMatch).To(BeFalse())
+		Expect(requiresExactMatch).To(BeTrue())
 	})
 
 	It("Returns true when the selector has the form key1==val1,key2==val2", func() {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Currently, field selectors support the "not equal" operator. This affects the fake client and also the `CacheReader`. 
Here is the reference from Kubernetes documentation: https://kubernetes.io/docs/concepts/overview/working-with-objects/field-selectors/#supported-operators

> You can use the =, ==, and != operators with field selectors (= and == mean the same thing).
