### PR TITLE
:bug: Fakeclient: Fix status apply if existing object has managedFields set

### DIFF
--- a/pkg/client/fake/versioned_tracker.go
+++ b/pkg/client/fake/versioned_tracker.go
@@ -231,15 +231,17 @@ func (t versionedTracker) updateObject(
 	}
 
 	if t.withStatusSubresource.Has(gvk) {
-		if isStatus { // copy everything but status and metadata.ResourceVersion from original object
+		if isStatus { // copy everything but status, managedFields and metadata.ResourceVersion from original object
 			if err := copyStatusFrom(obj, oldObject); err != nil {
 				return nil, false, fmt.Errorf("failed to copy non-status field for object with status subresouce: %w", err)
 			}
 			passedRV := accessor.GetResourceVersion()
+			passedManagedFields := accessor.GetManagedFields()
 			if err := copyFrom(oldObject, obj); err != nil {
 				return nil, false, fmt.Errorf("failed to restore non-status fields: %w", err)
 			}
 			accessor.SetResourceVersion(passedRV)
+			accessor.SetManagedFields(passedManagedFields)
 		} else { // copy status from original object
 			if err := copyStatusFrom(oldObject, obj); err != nil {
 				return nil, false, fmt.Errorf("failed to copy the status for object with status subresource: %w", err)


### PR DESCRIPTION
The tracker we use in the fakeclient doesn't support status operations, so we implemented them by copying everything but status and ResourceVersion from the existing object.

This meant that we copied the existing objects managedFields and that in turn made the `managedFieldsObjectTracker` error out on Apply with an `metadata.managedFields must be nil`.

Stop copying the managedFields in status updates.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3423

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
