### PR TITLE
:bug: Wire up base context into http servers

### DIFF
--- a/pkg/internal/httpserver/server.go
+++ b/pkg/internal/httpserver/server.go
@@ -1,13 +1,16 @@
 package httpserver
 
 import (
+	"context"
+	"net"
 	"net/http"
 	"time"
 )
 
 // New returns a new server with sane defaults.
-func New(handler http.Handler) *http.Server {
+func New(ctx context.Context, handler http.Handler) *http.Server {
 	return &http.Server{
+		BaseContext:       func(_ net.Listener) context.Context { return ctx },
 		Handler:           handler,
 		MaxHeaderBytes:    1 << 20,
 		IdleTimeout:       90 * time.Second, // matches http.DefaultTransport keep-alive timeout

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -302,7 +302,7 @@ func (cm *controllerManager) GetControllerOptions() config.Controller {
 
 func (cm *controllerManager) addHealthProbeServer() error {
 	mux := http.NewServeMux()
-	srv := httpserver.New(mux)
+	srv := httpserver.New(cm.internalCtx, mux)
 
 	if cm.readyzHandler != nil {
 		mux.Handle(cm.readinessEndpointName, http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
@@ -324,7 +324,7 @@ func (cm *controllerManager) addHealthProbeServer() error {
 
 func (cm *controllerManager) addPprofServer() error {
 	mux := http.NewServeMux()
-	srv := httpserver.New(mux)
+	srv := httpserver.New(cm.internalCtx, mux)
 
 	mux.HandleFunc("/debug/pprof/", pprof.Index)
 	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -246,7 +246,7 @@ func (s *defaultServer) Start(ctx context.Context) error {
 
 	log.Info("Serving metrics server", "bindAddress", s.options.BindAddress, "secure", s.options.SecureServing)
 
-	srv := httpserver.New(mux)
+	srv := httpserver.New(ctx, mux)
 
 	idleConnsClosed := make(chan struct{})
 	go func() {

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -241,7 +241,7 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 	log.Info("Serving webhook server", "host", s.Options.Host, "port", s.Options.Port)
 
-	srv := httpserver.New(s.webhookMux)
+	srv := httpserver.New(ctx, s.webhookMux)
 
 	idleConnsClosed := make(chan struct{})
 	go func() {


### PR DESCRIPTION
The manager already has a configurable base context, but it doesn't pass that on onto http servers. As a result, configuring it does nothing for example webhooks.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
