### PR TITLE
:seedling: Clean up owners

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -17,8 +17,7 @@ aliases:
   - vincepri
 
   # non-admin folks who can approve any PRs in the repo
-  controller-runtime-approvers:
-  - fillzpp
+  controller-runtime-approvers: []
 
   # folks who can review and LGTM any PRs in the repo (doesn't
   # include approvers & admins -- those count too via the OWNERS


### PR DESCRIPTION
This change removes fillzpp from maintainters, as there was no activity since September 2024: https://github.com/kubernetes-sigs/controller-runtime/issues?q=commenter%3Afillzpp

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
