### PR TITLE
🌱 Add logger into context for structured logging

### DIFF
--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // EventBroadcasterProducer makes an event broadcaster, returning
@@ -117,6 +118,7 @@ func (p *Provider) getBroadcaster() (record.EventBroadcaster, events.EventBroadc
 
 		// init new broadcaster
 		ctx, cancel := context.WithCancel(context.Background())
+		ctx = log.IntoContext(ctx, p.logger)
 		p.cancelSinkRecordingFunc = cancel
 		if err := p.broadcaster.StartRecordingToSinkWithContext(ctx); err != nil {
 			p.logger.Error(err, "error starting recording for broadcaster")


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
Follow up to https://github.com/kubernetes-sigs/controller-runtime/pull/3451
<!-- What does this do, and why do we need it? -->
Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3407

/assign @sbueringer  

Not sure if this is the intended fix but this was discussed in the initial issue. 