### PR TITLE
:sparkles: only log stacktraces >= DPanic when using the Zap adapter

### DIFF
--- a/pkg/log/zap/zap.go
+++ b/pkg/log/zap/zap.go
@@ -155,8 +155,7 @@ type Options struct {
 	// See https://pkg.go.dev/github.com/go-logr/zapr for how zap level relates to logr verbosity.
 	Level zapcore.LevelEnabler
 	// StacktraceLevel is the level at and above which stacktraces will
-	// be recorded for all messages. Defaults to Warn when Development
-	// is true and Error otherwise.
+	// be recorded for all messages. Defaults to DPanic.
 	// See Level for the relationship of zap log level to logr verbosity.
 	StacktraceLevel zapcore.LevelEnabler
 	// ZapOpts allows passing arbitrary zap.Options to configure on the
@@ -173,6 +172,11 @@ func (o *Options) addDefaults() {
 		o.DestWriter = os.Stderr
 	}
 
+	if o.StacktraceLevel == nil {
+		lvl := zap.NewAtomicLevelAt(zap.DPanicLevel)
+		o.StacktraceLevel = &lvl
+	}
+
 	if o.Development {
 		if o.NewEncoder == nil {
 			o.NewEncoder = newConsoleEncoder
@@ -180,10 +184,6 @@ func (o *Options) addDefaults() {
 		if o.Level == nil {
 			lvl := zap.NewAtomicLevelAt(zap.DebugLevel)
 			o.Level = &lvl
-		}
-		if o.StacktraceLevel == nil {
-			lvl := zap.NewAtomicLevelAt(zap.WarnLevel)
-			o.StacktraceLevel = &lvl
 		}
 		o.ZapOpts = append(o.ZapOpts, zap.Development())
 	} else {
@@ -193,10 +193,6 @@ func (o *Options) addDefaults() {
 		if o.Level == nil {
 			lvl := zap.NewAtomicLevelAt(zap.InfoLevel)
 			o.Level = &lvl
-		}
-		if o.StacktraceLevel == nil {
-			lvl := zap.NewAtomicLevelAt(zap.ErrorLevel)
-			o.StacktraceLevel = &lvl
 		}
 		// Disable sampling for increased Debug levels. Otherwise, this will
 		// cause index out of bounds errors in the sampling code.


### PR DESCRIPTION
Ever since at least #86, the default was to create stacktraces even for _error_ messages.

To me this makes absolutely no sense. Errors can arise from many situations, like a NotFound error when reconciling, or invalid objects that cannot be processed. None of these situations in my opinion warrant a stacktrace being printed, since none of them indicate a bug in the software.

On the other hand, scrolling through an app's logs and seeing stacktraces makes my spider sense tingle a bit, only to then realize "oh, yeah, it's just a NotFound error, false alarm everyone!".

I suggest the default for printing stacktraces should be much higher, hence this PR to raise the default. Personally I also do not really see a value in differentiating between development and production modes. I cannot imagine any real usecases where a developer would expect and want to see a stacktrace when they print a warning message.