### PR TITLE
✨ Reduce memory usage of default webhooks

### DIFF
--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -129,11 +129,7 @@ func (h *defaulterForType[T]) Handle(ctx context.Context, req Request) Response 
 		return Errored(http.StatusBadRequest, err)
 	}
 
-	// Keep a copy of the object if needed
-	var originalObj T
-	if !h.removeUnknownOrOmitableFields {
-		originalObj = obj.DeepCopyObject().(T)
-	}
+	originalObj := obj.DeepCopyObject().(T)
 
 	// Default the object
 	if err := h.defaulter.Default(ctx, obj); err != nil {
@@ -142,6 +138,19 @@ func (h *defaulterForType[T]) Handle(ctx context.Context, req Request) Response 
 			return validationResponseFromStatus(false, apiStatus.Status())
 		}
 		return Denied(err.Error())
+	}
+
+	// If the object is not changed, there's no reason to go through the expensive patch calculation below.
+	// Note: While jsonpatch.CreatePatch short-circuits if both byte arrays are equal this is likely never the case.
+	// * json.Marshal that we use below sorts fields alphabetically
+	// * for builtin types the apiserver also sorts alphabetically (but it seems like it adds an empty line at the end)
+	// * for CRDs the apiserver uses the field order in the OpenAPI schema which very likely is not alphabetically sorted
+	if reflect.DeepEqual(originalObj, obj) {
+		return Response{
+			AdmissionResponse: admissionv1.AdmissionResponse{
+				Allowed: true,
+			},
+		}
 	}
 
 	// Create the patch

--- a/pkg/webhook/admission/defaulter_custom_test.go
+++ b/pkg/webhook/admission/defaulter_custom_test.go
@@ -15,17 +15,24 @@ limitations under the License.
 package admission
 
 import (
+	"bytes"
 	"context"
 	"maps"
 	"net/http"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
-
 	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Defaulter Handler", func() {
@@ -166,4 +173,175 @@ func (d *TestCustomDefaulter) Default(ctx context.Context, obj runtime.Object) e
 	}
 	o.TotalReplicas = 0
 	return nil
+}
+
+func BenchmarkDefaulter(b *testing.B) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	b.Run("noop", func(b *testing.B) {
+		req := createTestRequest("test-hostname")
+		handler := WithDefaulter(scheme, &PodDefaulter{
+			defaultHostname: "test-hostname", // defaulting will be no-op as hostname is already "test-hostname"
+		})
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = handler.Handle(b.Context(), req)
+		}
+	})
+
+	b.Run("with changes", func(b *testing.B) {
+		req := createTestRequest("")
+		handler := WithDefaulter(scheme, &PodDefaulter{
+			defaultHostname: "test-hostname", // will be used to default hostname
+		})
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = handler.Handle(b.Context(), req)
+		}
+	})
+}
+
+type PodDefaulter struct {
+	defaultHostname string
+}
+
+func (p PodDefaulter) Default(_ context.Context, pod *corev1.Pod) error {
+	if pod.Spec.Hostname == "" && p.defaultHostname != "" {
+		pod.Spec.Hostname = p.defaultHostname
+	}
+	return nil
+}
+
+func createTestRequest(hostname string) Request {
+	return Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			UID: "12345",
+			Kind: metav1.GroupVersionKind{
+				Group:   "",
+				Version: "v1",
+				Kind:    "Pod",
+			},
+			Object:    runtime.RawExtension{Raw: mustEncodeLikeAPIServer(createSuperPod(hostname))},
+			Operation: admissionv1.Create,
+		},
+	}
+}
+
+func createSuperPod(hostname string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "monolith-service-7f8d9b",
+			Namespace: "prod",
+			Labels: map[string]string{
+				"app": "processor", "env": "prod", "version": "1.4.2",
+				"pci-compliant": "true", "team": "data-eng",
+			},
+			Annotations: map[string]string{
+				"agent-inject":    "true",
+				"checksum/config": "e3b0c23238fc1c149afbf4c8996fb92427ae",
+			},
+			Finalizers: []string{"cleanup.finalizer.my.io"},
+		},
+		Spec: corev1.PodSpec{
+			Hostname: hostname,
+			InitContainers: []corev1.Container{
+				{
+					Name: "vault-init", Image: "vault:1.13.1",
+					SecurityContext: &corev1.SecurityContext{RunAsUser: ptr.To[int64](1000)},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "main-app",
+					Image: "my-priv-reg.io/analytics:v1.4.2",
+					Env: []corev1.EnvVar{
+						{Name: "DB_URL", Value: "postgres://db:5432"},
+						{
+							Name: "POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+							},
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+						Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+					},
+					LivenessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{Path: "/health", Port: intstr.FromInt(8080)},
+						},
+						InitialDelaySeconds: 30,
+					},
+				},
+				{
+					Name:  "log-shipper",
+					Image: "fluentbit:2.1.4",
+					Args:  []string{"--config", "/etc/fluent-bit/fluent-bit.conf"},
+				},
+			},
+			Affinity: &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{Key: "topology.kubernetes.io/zone", Operator: corev1.NodeSelectorOpIn, Values: []string{"us-east-1a", "us-east-1b"}},
+								},
+							},
+						},
+					},
+				},
+			},
+			TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+				{
+					MaxSkew:           1,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "processor"}},
+				},
+			},
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot:   ptr.To(true),
+				SeccompProfile: &corev1.SeccompProfile{Type: corev1.SeccompProfileTypeRuntimeDefault},
+			},
+			TerminationGracePeriodSeconds: ptr.To[int64](60),
+			ReadinessGates: []corev1.PodReadinessGate{
+				{ConditionType: "target-health.lbv3.k8s.cloud/my-tg"},
+			},
+			Volumes: []corev1.Volume{
+				{
+					Name: "config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: "app-config"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func mustEncodeLikeAPIServer(obj runtime.Object) []byte {
+	// 1. Create a NewSerializer
+	// Options: false (not pretty printed), false (not YAML)
+	s := json.NewSerializerWithOptions(
+		json.DefaultMetaFactory,
+		nil,
+		nil,
+		json.SerializerOptions{Yaml: false, Pretty: false, Strict: false},
+	)
+
+	// 2. Use a Buffer for efficiency
+	buf := new(bytes.Buffer)
+	err := s.Encode(obj, buf)
+	if err != nil {
+		panic(err)
+	}
+
+	return buf.Bytes()
 }


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

Before this PR we were always going through the JSON patch calculation which is pretty expensive.
This PR optimizes this by short-circuting if the objects are equal.

```
goos: darwin
goarch: arm64
pkg: sigs.k8s.io/controller-runtime/pkg/webhook/admission/bench
cpu: Apple M2 Pro
                          │   old.txt   │              new.txt               │
                          │   sec/op    │   sec/op     vs base               │
Defaulter/noop-12           95.52µ ± 7%   43.50µ ± 2%  -54.46% (p=0.002 n=6)
Defaulter/with_changes-12   89.98µ ± 2%   96.58µ ± 6%   +7.33% (p=0.002 n=6)
geomean                     92.71µ        64.82µ       -30.09%

                          │   old.txt    │               new.txt               │
                          │     B/op     │     B/op      vs base               │
Defaulter/noop-12           52.66Ki ± 0%   22.19Ki ± 0%  -57.86% (p=0.002 n=6)
Defaulter/with_changes-12   52.26Ki ± 0%   55.00Ki ± 0%   +5.25% (p=0.002 n=6)
geomean                     52.46Ki        34.94Ki       -33.40%

                          │  old.txt   │              new.txt              │
                          │ allocs/op  │ allocs/op   vs base               │
Defaulter/noop-12           950.0 ± 0%   217.0 ± 0%  -77.16% (p=0.002 n=6)
Defaulter/with_changes-12   950.0 ± 0%   982.0 ± 0%   +3.37% (p=0.002 n=6)
geomean                     950.0        461.6       -51.41%
```