### PR TITLE
⚠ webhook: remove deprecated custom path function

### DIFF
--- a/pkg/builder/webhook.go
+++ b/pkg/builder/webhook.go
@@ -44,7 +44,6 @@ type WebhookBuilder[T runtime.Object] struct {
 	customDefaulterOpts       []admission.DefaulterOption
 	customValidator           admission.CustomValidator //nolint:staticcheck
 	validator                 admission.Validator[T]
-	customPath                string
 	customValidatorCustomPath string
 	customDefaulterCustomPath string
 	converterConstructor      func(*runtime.Scheme) (conversion.Converter, error)
@@ -119,15 +118,6 @@ func (blder *WebhookBuilder[T]) RecoverPanic(recoverPanic bool) *WebhookBuilder[
 	return blder
 }
 
-// WithCustomPath overrides the webhook's default path by the customPath
-//
-// Deprecated: WithCustomPath should not be used anymore.
-// Please use WithValidatorCustomPath or WithDefaulterCustomPath instead.
-func (blder *WebhookBuilder[T]) WithCustomPath(customPath string) *WebhookBuilder[T] {
-	blder.customPath = customPath
-	return blder
-}
-
 // WithValidatorCustomPath overrides the path of the Validator.
 func (blder *WebhookBuilder[T]) WithValidatorCustomPath(customPath string) *WebhookBuilder[T] {
 	blder.customValidatorCustomPath = customPath
@@ -178,10 +168,6 @@ func (blder *WebhookBuilder[T]) setLogConstructor() {
 	}
 }
 
-func (blder *WebhookBuilder[T]) isThereCustomPathConflict() bool {
-	return (blder.customPath != "" && blder.customDefaulter != nil && blder.customValidator != nil) || (blder.customPath != "" && blder.customDefaulterCustomPath != "") || (blder.customPath != "" && blder.customValidatorCustomPath != "")
-}
-
 func (blder *WebhookBuilder[T]) registerWebhooks() error {
 	typ, err := blder.getType()
 	if err != nil {
@@ -191,17 +177,6 @@ func (blder *WebhookBuilder[T]) registerWebhooks() error {
 	blder.gvk, err = apiutil.GVKForObject(typ, blder.mgr.GetScheme())
 	if err != nil {
 		return err
-	}
-
-	if blder.isThereCustomPathConflict() {
-		return errors.New("only one of CustomDefaulter or CustomValidator should be set when using WithCustomPath. Otherwise, WithDefaulterCustomPath() and WithValidatorCustomPath() should be used")
-	}
-	if blder.customPath != "" {
-		// isThereCustomPathConflict() already checks for potential conflicts.
-		// Since we are sure that only one of customDefaulter or customValidator will be used,
-		// we can set both customDefaulterCustomPath and validatingCustomPath.
-		blder.customDefaulterCustomPath = blder.customPath
-		blder.customValidatorCustomPath = blder.customPath
 	}
 
 	// Register webhook(s) for type

--- a/pkg/builder/webhook_test.go
+++ b/pkg/builder/webhook_test.go
@@ -48,8 +48,6 @@ const (
 
 	svcBaseAddr = "http://svc-name.svc-ns.svc"
 
-	customPath = "/custom-path"
-
 	userAgentHeader             = "User-Agent"
 	userAgentCtxKey agentCtxKey = "UserAgent"
 	userAgentValue              = "test"
@@ -931,90 +929,6 @@ func runTests(admissionReviewVersion string) {
 		Entry("Defaulter + Validator", func(b *WebhookBuilder[*TestDefaultValidator]) {
 			b.WithDefaulter(&testValidatorDefaulter{})
 			b.WithValidator(&testDefaultValidatorValidator{})
-		}),
-	)
-
-	It("should not scaffold a custom defaulting and a custom validating webhook with the same custom path", func() {
-		By("creating a controller manager")
-		m, err := manager.New(cfg, manager.Options{})
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-		By("registering the type in the Scheme")
-		builder := scheme.Builder{GroupVersion: testValidatorGVK.GroupVersion()}
-		builder.Register(&TestDefaultValidator{}, &TestDefaultValidatorList{})
-		err = builder.AddToScheme(m.GetScheme())
-		ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-		err = WebhookManagedBy(m, &TestDefaultValidator{}).
-			WithCustomDefaulter(&TestCustomDefaultValidator{}).
-			WithCustomValidator(&TestCustomDefaultValidator{}).
-			WithLogConstructor(func(base logr.Logger, req *admission.Request) logr.Logger {
-				return admission.DefaultLogConstructor(testingLogger, req)
-			}).
-			WithCustomPath(customPath).
-			Complete()
-		ExpectWithOffset(1, err).To(HaveOccurred())
-	})
-
-	DescribeTable("should not scaffold a custom defaulting when setting a custom path and a defaulting custom path",
-		func(build func(*WebhookBuilder[*TestDefaulterObject])) {
-			By("creating a controller manager")
-			m, err := manager.New(cfg, manager.Options{})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("registering the type in the Scheme")
-			builder := scheme.Builder{GroupVersion: testDefaulterGVK.GroupVersion()}
-			builder.Register(&TestDefaulterObject{}, &TestDefaulterList{})
-			err = builder.AddToScheme(m.GetScheme())
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			webhookBuilder := WebhookManagedBy(m, &TestDefaulterObject{})
-			build(webhookBuilder)
-			err = webhookBuilder.
-				WithLogConstructor(func(base logr.Logger, req *admission.Request) logr.Logger {
-					return admission.DefaultLogConstructor(testingLogger, req)
-				}).
-				WithDefaulterCustomPath(customPath).
-				WithCustomPath(customPath).
-				Complete()
-			ExpectWithOffset(1, err).To(HaveOccurred())
-		},
-		Entry("CustomDefaulter", func(b *WebhookBuilder[*TestDefaulterObject]) {
-			b.WithCustomDefaulter(&TestCustomDefaulter{})
-		}),
-		Entry("Defaulter", func(b *WebhookBuilder[*TestDefaulterObject]) {
-			b.WithDefaulter(&testDefaulter{})
-		}),
-	)
-
-	DescribeTable("should not scaffold a custom validating when setting a custom path and a validating custom path",
-		func(build func(*WebhookBuilder[*TestValidatorObject])) {
-			By("creating a controller manager")
-			m, err := manager.New(cfg, manager.Options{})
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			By("registering the type in the Scheme")
-			builder := scheme.Builder{GroupVersion: testValidatorGVK.GroupVersion()}
-			builder.Register(&TestValidatorObject{}, &TestValidatorList{})
-			err = builder.AddToScheme(m.GetScheme())
-			ExpectWithOffset(1, err).NotTo(HaveOccurred())
-
-			webhookBuilder := WebhookManagedBy(m, &TestValidatorObject{})
-			build(webhookBuilder)
-			err = webhookBuilder.
-				WithLogConstructor(func(base logr.Logger, req *admission.Request) logr.Logger {
-					return admission.DefaultLogConstructor(testingLogger, req)
-				}).
-				WithValidatorCustomPath(customPath).
-				WithCustomPath(customPath).
-				Complete()
-			ExpectWithOffset(1, err).To(HaveOccurred())
-		},
-		Entry("CustomValidator", func(b *WebhookBuilder[*TestValidatorObject]) {
-			b.WithCustomValidator(&TestCustomValidator{})
-		}),
-		Entry("Validator", func(b *WebhookBuilder[*TestValidatorObject]) {
-			b.WithValidator(&testValidator{})
 		}),
 	)
 


### PR DESCRIPTION
Remove the `WithCustomPath()` deprecated function. It has been replaced by `WithValidatorCustomPath()` and `WithDefaulterCustomPath()` about a year ago.