### PR TITLE
🌱 Auto-create git tags for the `tools/setup-envtest` submodule

### DIFF
--- a/.github/workflows/tag-setup-envtest.yaml
+++ b/.github/workflows/tag-setup-envtest.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
+        with:
+          fetch-tags: true
 
       - name: Validate and Create Tag
         id: copy-tag

--- a/.github/workflows/tag-setup-envtest.yaml
+++ b/.github/workflows/tag-setup-envtest.yaml
@@ -13,7 +13,7 @@ jobs:
       
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # tag=v6.0.2
 
       - name: Validate and Create Tag
         id: copy-tag

--- a/.github/workflows/tag-setup-envtest.yaml
+++ b/.github/workflows/tag-setup-envtest.yaml
@@ -1,0 +1,26 @@
+name: Tag setup-envtest
+
+on:
+  push:
+    tags:
+      - '*' # Triggers on all tags, but the action skips non-semver ones.
+
+jobs:
+  create-mangled-tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to create a new tag via API
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create mapped tag
+        id: map-tag
+        uses: stackrox/clone-tag@v1 
+        with:
+          prefix: 'tools/setup-envtest/'
+          
+      - name: Report result
+        if: steps.map-tag.outputs.skipped == 'false'
+        run: echo "Successfully generated tag ${{ steps.map-tag.outputs.new-tag }}"

--- a/.github/workflows/tag-setup-envtest.yaml
+++ b/.github/workflows/tag-setup-envtest.yaml
@@ -3,7 +3,7 @@ name: Tag setup-envtest
 on:
   push:
     tags:
-      - '*' # Triggers on all tags, but the action skips non-semver ones.
+      - 'v*' # Code below does further filtering.
 
 jobs:
   create-mangled-tag:
@@ -15,12 +15,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Create mapped tag
-        id: map-tag
-        uses: stackrox/clone-tag@v1 
-        with:
-          prefix: 'tools/setup-envtest/'
+      - name: Validate and Create Tag
+        id: copy-tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          PREFIX="tools/setup-envtest/"
+    
+          if [[ "${{ github.ref_type }}" != "tag" ]]; then
+            echo "Current ref is not a tag. Skipping."
+            exit 0
+          fi
           
-      - name: Report result
-        if: steps.map-tag.outputs.skipped == 'false'
-        run: echo "Successfully generated tag ${{ steps.map-tag.outputs.new-tag }}"
+          ORIGINAL_TAG="${GITHUB_REF#refs/tags/}"
+          REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+          
+          if [[ ! "$ORIGINAL_TAG" =~ $REGEX ]]; then
+            echo "Original tag '$ORIGINAL_TAG' does not match expression '$REGEX', skipping."
+            exit 0
+          fi
+    
+          echo "skipped=false" >> $GITHUB_OUTPUT
+          NEW_TAG="${PREFIX}${ORIGINAL_TAG}"
+    
+          echo "Original tag '$ORIGINAL_TAG' matches expression '$REGEX'."
+          echo "Creating new tag: '$NEW_TAG' at SHA: ${{ github.sha }}"
+        
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            '/repos/${{ github.repository }}/git/refs' \
+            -f ref="refs/tags/$NEW_TAG" \
+            -f sha="${{ github.sha }}"
+          echo
+          echo "Successfully created $NEW_TAG"

--- a/.github/workflows/tag-setup-envtest.yaml
+++ b/.github/workflows/tag-setup-envtest.yaml
@@ -3,7 +3,7 @@ name: Tag setup-envtest
 on:
   push:
     tags:
-      - 'v*' # Code below does further filtering.
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   create-mangled-tag:
@@ -20,36 +20,4 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          PREFIX="tools/setup-envtest/"
-    
-          if [[ "${{ github.ref_type }}" != "tag" ]]; then
-            echo "Current ref is not a tag. Skipping."
-            exit 0
-          fi
-          
-          ORIGINAL_TAG="${GITHUB_REF#refs/tags/}"
-          REGEX="^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
-          
-          if [[ ! "$ORIGINAL_TAG" =~ $REGEX ]]; then
-            echo "Original tag '$ORIGINAL_TAG' does not match expression '$REGEX', skipping."
-            exit 0
-          fi
-    
-          echo "skipped=false" >> $GITHUB_OUTPUT
-          NEW_TAG="${PREFIX}${ORIGINAL_TAG}"
-    
-          echo "Original tag '$ORIGINAL_TAG' matches expression '$REGEX'."
-          echo "Creating new tag: '$NEW_TAG' at SHA: ${{ github.sha }}"
-        
-          gh api \
-            --method POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            '/repos/${{ github.repository }}/git/refs' \
-            -f ref="refs/tags/$NEW_TAG" \
-            -f sha="${{ github.sha }}"
-          echo
-          echo "Successfully created $NEW_TAG"
+        run: ./hack/tag-setup-envtest.sh

--- a/hack/tag-setup-envtest.sh
+++ b/hack/tag-setup-envtest.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+#  Copyright 2026 The Kubernetes Authors.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -euo pipefail
+
+readonly PREFIX="${1:-tools/setup-envtest/}"
+readonly REF="${2:-${GITHUB_REF}}"
+readonly SHA="${3:-${GITHUB_SHA}}"
+readonly REPO="${4:-${GITHUB_REPOSITORY}}"
+
+ORIGINAL_TAG="${REF#refs/tags/}"
+NEW_TAG="${PREFIX}${ORIGINAL_TAG}"
+if git show-ref --verify --quiet "refs/tags/${NEW_TAG}"; then
+  echo "Tag ${NEW_TAG} already exists, nothing to do."
+  exit 0
+fi
+
+echo "Creating new tag: '${NEW_TAG}' at SHA: ${SHA}"
+
+gh api \
+  --method POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/repos/${REPO}/git/refs" \
+  -f ref="refs/tags/${NEW_TAG}" \
+  -f sha="${SHA}"
+echo
+echo "Successfully created ${NEW_TAG}"


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
See [slack discussion](https://kubernetes.slack.com/archives/C02MRBMN00Z/p1770788038710919).

Using the GitHub CLI (gh api) built into GitHub's runners to create the tag, rather than using standard `git tag` and `git push` commands because it:
- does not require configuring a dummy git user/email, and
- works flawlessly in a shallow checkout.

Tested a [copy of this workflow](https://github.com/porridge/controller-runtime/blob/master/.github/workflows/tag-setup-envtest.yaml) in [this run](https://github.com/porridge/controller-runtime/actions/runs/22895347503/job/66427918078) in a clone repo.