### PR TITLE
:book: Improve help text for retries counter in workqueue

### DIFF
--- a/pkg/internal/metrics/workqueue.go
+++ b/pkg/internal/metrics/workqueue.go
@@ -95,7 +95,7 @@ var (
 	retries = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: WorkQueueSubsystem,
 		Name:      RetriesKey,
-		Help:      "Total number of retries handled by workqueue",
+		Help:      "Total number of items added to the workqueue with a non-zero delay (rate-limited requeues, explicit RequeueAfter or AddAfter calls)",
 	}, []string{"name", "controller"})
 )
 


### PR DESCRIPTION
Updated help text for the retries counter to provide more clarity on its current scope.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
related slack thread in #sig-api-machinery https://kubernetes.slack.com/archives/C0EG7JC6T/p1772834493390239

this retry metric is getting incremented for cases where its not a true retry but queue additions with some delay. since changing metric name is a breaking change. thus improved the `Help` to inform future reader about the scope of this metric.

ex usage 
- https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/daemon/daemon_controller.go#L669
