### PR TITLE
:sparkles: Improve logging for dynamic type kind source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # editor and IDE paraphernalia
 .idea
+*.iml
 *.swp
 *.swo
 *~

--- a/pkg/internal/source/internal_test.go
+++ b/pkg/internal/source/internal_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -292,6 +293,28 @@ var _ = Describe("Internal", func() {
 				Type: &corev1.Pod{},
 			}
 			Expect(kind.String()).Should(Equal("kind source: *v1.Pod"))
+		})
+		It("should return kind source underlying type for Unstructured", func() {
+			kind := internal.Kind[*unstructured.Unstructured, reconcile.Request]{
+				Type: &unstructured.Unstructured{
+					Object: map[string]any{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+					},
+				},
+			}
+			Expect(kind.String()).Should(Equal("kind source: *unstructured.Unstructured[apps/v1 Deployment]"))
+		})
+		It("should return kind source underlying type for PartialObjectMetadata", func() {
+			kind := internal.Kind[*metav1.PartialObjectMetadata, reconcile.Request]{
+				Type: &metav1.PartialObjectMetadata{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+					},
+				},
+			}
+			Expect(kind.String()).Should(Equal("kind source: *v1.PartialObjectMetadata[apps/v1 Deployment]"))
 		})
 	})
 })

--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -116,10 +118,18 @@ func (ks *Kind[object, request]) Start(ctx context.Context, queue workqueue.Type
 }
 
 func (ks *Kind[object, request]) String() string {
-	if !isNil(ks.Type) {
+	if isNil(ks.Type) {
+		return "kind source: unknown type"
+	}
+
+	switch v := any(ks.Type).(type) {
+	case *unstructured.Unstructured, *metav1.PartialObjectMetadata:
+		gvk := v.(client.Object).GetObjectKind().GroupVersionKind()
+		gv, kind := gvk.ToAPIVersionAndKind()
+		return fmt.Sprintf("kind source: %T[%s %s]", v, gv, kind)
+	default:
 		return fmt.Sprintf("kind source: %T", ks.Type)
 	}
-	return "kind source: unknown type"
 }
 
 // WaitForSync implements SyncingSource to allow controllers to wait with starting
@@ -133,7 +143,7 @@ func (ks *Kind[object, request]) WaitForSync(ctx context.Context) error {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			return nil
 		}
-		return fmt.Errorf("timed out waiting for cache to be synced for Kind %T", ks.Type)
+		return fmt.Errorf("timed out waiting for cache to be synced for %s", ks.String())
 	}
 }
 


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

This PR improves the logging when using a dynamic type (Unstructured and PartialObjectMetadata) with a kind source. Including information about the underlying type (kind) should make it easier to reason about what's going on. Implementation as suggested in https://github.com/kubernetes-sigs/controller-runtime/issues/3493#issuecomment-4187977496.

Was a bit in doubt about only logging the kind or the full GVK. I landed on the just the kind, but please let me know if you want me to change this.

Fixes https://github.com/kubernetes-sigs/controller-runtime/issues/3493