### PR TITLE
🐛 Unlock mutex after controller.Start() fails if already started

### DIFF
--- a/pkg/internal/controller/controller.go
+++ b/pkg/internal/controller/controller.go
@@ -277,6 +277,7 @@ func (c *Controller[request]) Start(ctx context.Context) error {
 	// but lock outside to get proper handling of the queue shutdown
 	c.mu.Lock()
 	if c.Started {
+		c.mu.Unlock()
 		return errors.New("controller was started more than once. This is likely to be caused by being added to a manager multiple times")
 	}
 

--- a/pkg/internal/controller/controller_test.go
+++ b/pkg/internal/controller/controller_test.go
@@ -566,6 +566,11 @@ var _ = Describe("controller", func() {
 			err := ctrl.Start(ctx)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("controller was started more than once. This is likely to be caused by being added to a manager multiple times"))
+
+			// test again to check if locks were properly released
+			err = ctrl.Start(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal("controller was started more than once. This is likely to be caused by being added to a manager multiple times"))
 		})
 
 		It("should check for correct TypedSyncingSource if custom types are used", func(specCtx SpecContext) {


### PR DESCRIPTION
When calling Start() multiple times, the mutex is not released, potentially leading to deadlocks
