### PR TITLE
:bug: controller/metrics: drop MetricsAll from the default GoCollector

### DIFF
--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -103,7 +103,17 @@ func init() {
 		ReconcileTimeouts,
 		// expose process metrics like CPU, Memory, file descriptor usage etc.
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
-		// expose all Go runtime metrics like GC stats, memory stats etc.
-		collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll)),
+		// expose the default Go runtime metrics (GC stats, memory
+		// stats, etc.). The collectors.MetricsAll variant this
+		// previously used balloons cardinality roughly 5x: a v0.19
+		// -> v0.23 bump took an unchanged daemonset controller
+		// from ~31 go_* series per pod to ~142, enough to blow past
+		// per-project metric quotas. The opt-out was reverted on the
+		// 0.19 / 0.20 release branches via #3147 / #3148 but the
+		// revert was never forward-ported to 0.21+. Restore the
+		// conservative default; operators who want the extra
+		// metrics can register their own GoCollector with MetricsAll
+		// on the Registry themselves (#3505).
+		collectors.NewGoCollector(),
 	)
 }


### PR DESCRIPTION
## Summary

Fixes #3505.

#3070 switched the default `GoCollector` to

```go
collectors.NewGoCollector(collectors.WithGoCollectorRuntimeMetrics(collectors.MetricsAll))
```

which exposes every `runtime/metrics` path. This ballooned Prometheus cardinality ~5x: unchanged daemonset controllers bumping v0.19.7 → v0.23.1 went from ~31 `go_*` series per pod to ~142, enough to trip per-project metric quotas. The opt-out was reverted on `release-0.19` via #3147 and on `release-0.20` via #3148 after users hit the wall, but the revert never got forward-ported to `release-0.21+`. Every release from v0.21 onward still carries the regression.

Newly exposed families (per pod, all DaemonSet-amplified): `go_godebug_non_default_behavior_*` (~40 series), `go_gc_heap_allocs_by_size_bytes_bucket`, `go_gc_heap_frees_by_size_bytes_bucket`, `go_sched_latencies_seconds_bucket`, `go_gc_pauses_seconds_bucket + 3 other pause histograms`, `go_cpu_classes_*`, `go_memory_classes_*`, `go_gc_cycles_*`.

## Fix

Drop the `WithGoCollectorRuntimeMetrics(MetricsAll)` option so the default `GoCollector` reverts to the conservative runtime set. Operators who want the extra runtime metrics can still register their own `GoCollector` with `MetricsAll` on `ctrlmetrics.Registry` themselves — the Registry is already exported.

## Test plan

- [x] `go build ./pkg/internal/controller/metrics/...` clean
- [x] `go vet ./pkg/internal/controller/metrics/...` clean
- [ ] Manual: scrape `:8443/metrics` on a bare controller built against this revision and confirm `go_*` series are back to ~30/pod (vs ~140 on v0.21+ today). `go_godebug_non_default_behavior_*`, `go_gc_heap_*_by_size_bytes_bucket`, `go_sched_latencies_seconds_bucket`, and the extra pause histograms should all be absent.

The envtest integration suite in `pkg/manager/internal/integration/` requires `$KUBEBUILDER_ASSETS` / `/usr/local/kubebuilder/bin/etcd` which is not present in a bare clone, so that suite errors on both master and this branch — unrelated to the change.
