### PR TITLE
:warning: Add AnnotatedEventRecorderProvider interface

### DIFF
--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -156,6 +156,12 @@ var _ = Describe("cluster.Cluster", func() {
 		Expect(c.GetFieldIndexer()).To(Equal(cluster.cache))
 	})
 
+	It("should provide a function to get the AnnotatedEventRecorder", func() {
+		c, err := New(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(c.GetAnnotatedEventRecorder("test")).NotTo(BeNil())
+	})
+
 	It("should provide a function to get the EventRecorder", func() {
 		c, err := New(cfg)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/cluster/cluster_test.go
+++ b/pkg/cluster/cluster_test.go
@@ -31,6 +31,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
@@ -156,16 +157,14 @@ var _ = Describe("cluster.Cluster", func() {
 		Expect(c.GetFieldIndexer()).To(Equal(cluster.cache))
 	})
 
-	It("should provide a function to get the AnnotatedEventRecorder", func() {
-		c, err := New(cfg)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(c.GetAnnotatedEventRecorder("test")).NotTo(BeNil())
-	})
-
 	It("should provide a function to get the EventRecorder", func() {
 		c, err := New(cfg)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(c.GetEventRecorder("test")).NotTo(BeNil())
+		recorder := c.GetEventRecorder("test")
+		Expect(recorder).NotTo(BeNil())
+		// The returned recorder should support both Eventf and AnnotatedEventf
+		var _ events.EventRecorder = recorder
+		var _ events.AnnotatedEventRecorder = recorder
 	})
 
 	It("should provide a function to get the deprecated EventRecorder", func() {

--- a/pkg/cluster/internal.go
+++ b/pkg/cluster/internal.go
@@ -92,6 +92,10 @@ func (c *cluster) GetEventRecorder(name string) events.EventRecorder {
 	return c.recorderProvider.GetEventRecorder(name)
 }
 
+func (c *cluster) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
+	return c.recorderProvider.GetAnnotatedEventRecorder(name)
+}
+
 func (c *cluster) GetRESTMapper() meta.RESTMapper {
 	return c.mapper
 }

--- a/pkg/cluster/internal.go
+++ b/pkg/cluster/internal.go
@@ -24,12 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
 )
 
 type cluster struct {
@@ -88,12 +88,8 @@ func (c *cluster) GetEventRecorderFor(name string) record.EventRecorder {
 	return c.recorderProvider.GetEventRecorderFor(name)
 }
 
-func (c *cluster) GetEventRecorder(name string) events.EventRecorder {
+func (c *cluster) GetEventRecorder(name string) recorder.EventRecorder {
 	return c.recorderProvider.GetEventRecorder(name)
-}
-
-func (c *cluster) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
-	return c.recorderProvider.GetAnnotatedEventRecorder(name)
 }
 
 func (c *cluster) GetRESTMapper() meta.RESTMapper {

--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
 )
 
 // EventBroadcasterProducer makes an event broadcaster, returning
@@ -164,16 +165,8 @@ func (p *Provider) GetEventRecorderFor(name string) record.EventRecorder {
 // broadcaster. All events will be associated with the given reportingController
 // name. client-go appends "-" and the hostname to derive reportingInstance,
 // which must fit within the events.k8s.io/v1 128-character limit.
-func (p *Provider) GetEventRecorder(name string) events.EventRecorder {
-	return &lazyRecorder{
-		prov: p,
-		name: name,
-	}
-}
-
-// GetAnnotatedEventRecorder returns an annotated event recorder that broadcasts to this provider's
-// broadcaster. All events will be associated with a component of the given name.
-func (p *Provider) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
+// The returned recorder supports both Eventf and AnnotatedEventf.
+func (p *Provider) GetEventRecorder(name string) recorder.EventRecorder {
 	return &lazyRecorder{
 		prov: p,
 		name: name,
@@ -182,6 +175,8 @@ func (p *Provider) GetAnnotatedEventRecorder(name string) events.AnnotatedEventR
 
 // lazyRecorder is a recorder that doesn't actually instantiate any underlying
 // recorder until the first event is emitted.
+var _ recorder.EventRecorder = (*lazyRecorder)(nil)
+
 type lazyRecorder struct {
 	prov *Provider
 	name string

--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -171,21 +171,33 @@ func (p *Provider) GetEventRecorder(name string) events.EventRecorder {
 	}
 }
 
+// GetAnnotatedEventRecorder returns an annotated event recorder that broadcasts to this provider's
+// broadcaster. All events will be associated with a component of the given name.
+func (p *Provider) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
+	return &lazyRecorder{
+		prov: p,
+		name: name,
+	}
+}
+
 // lazyRecorder is a recorder that doesn't actually instantiate any underlying
 // recorder until the first event is emitted.
 type lazyRecorder struct {
 	prov *Provider
 	name string
 
-	recOnce sync.Once
-	rec     events.EventRecorder
+	recOnce                sync.Once
+	eventRecorder          events.EventRecorder
+	annotatedEventRecorder events.AnnotatedEventRecorder
 }
 
 // ensureRecording ensures that a concrete recorder is populated for this recorder.
 func (l *lazyRecorder) ensureRecording() {
 	l.recOnce.Do(func() {
 		_, broadcaster := l.prov.getBroadcaster()
-		l.rec = broadcaster.NewRecorder(l.prov.scheme, l.name)
+		rec := broadcaster.NewRecorder(l.prov.scheme, l.name)
+		l.eventRecorder = rec
+		l.annotatedEventRecorder = rec.(events.AnnotatedEventRecorder)
 	})
 }
 
@@ -194,7 +206,17 @@ func (l *lazyRecorder) Eventf(regarding runtime.Object, related runtime.Object, 
 
 	l.prov.lock.RLock()
 	if !l.prov.stopped {
-		l.rec.Eventf(regarding, related, eventtype, reason, action, note, args...)
+		l.eventRecorder.Eventf(regarding, related, eventtype, reason, action, note, args...)
+	}
+	l.prov.lock.RUnlock()
+}
+
+func (l *lazyRecorder) AnnotatedEventf(regarding runtime.Object, related runtime.Object, annotations map[string]string, eventtype, reason, action, note string, args ...any) {
+	l.ensureRecording()
+
+	l.prov.lock.RLock()
+	if !l.prov.stopped {
+		l.annotatedEventRecorder.AnnotatedEventf(regarding, related, annotations, eventtype, reason, action, note, args...)
 	}
 	l.prov.lock.RUnlock()
 }

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -45,15 +45,17 @@ var _ = Describe("recorder", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Creating the Controller")
-			deprecatedRecorder := cm.GetEventRecorder("test-deprecated-recorder")
+			deprecatedRecorder := cm.GetEventRecorderFor("test-deprecated-recorder") //nolint:staticcheck // testing deprecated API
 			recorder := cm.GetEventRecorder("test-recorder")
+			annotatedRecorder := cm.GetAnnotatedEventRecorder("test-annotated-recorder")
 			instance, err := controller.New("foo-controller", cm, controller.Options{
 				Reconciler: reconcile.Func(
 					func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 						dp, err := clientset.AppsV1().Deployments(request.Namespace).Get(ctx, request.Name, metav1.GetOptions{})
 						Expect(err).NotTo(HaveOccurred())
-						deprecatedRecorder.Eventf(dp, nil, corev1.EventTypeNormal, "deprecated-test-reason", "deprecatedAction", "deprecated-test-msg")
+						deprecatedRecorder.Eventf(dp, corev1.EventTypeNormal, "deprecated-test-reason", "deprecated-test-msg")
 						recorder.Eventf(dp, nil, corev1.EventTypeNormal, "test-reason", "test-action", "test-note")
+						annotatedRecorder.AnnotatedEventf(dp, nil, map[string]string{"key": "value"}, corev1.EventTypeNormal, "test-annotated-reason", "test-annotated-action", "test-annotated-note")
 						return reconcile.Result{}, nil
 					}),
 			})
@@ -129,6 +131,24 @@ var _ = Describe("recorder", func() {
 			Expect(evt.Reason).To(Equal("test-reason"))
 			Expect(evt.Action).To(Equal("test-action"))
 			Expect(evt.Note).To(Equal("test-note"))
+
+			By("Validate annotated event is published as expected")
+			annotatedEvtWatcher, err := clientset.EventsV1().Events("default").Watch(ctx,
+				metav1.ListOptions{FieldSelector: fields.OneTermEqualSelector("reason", "test-annotated-reason").String()})
+			Expect(err).NotTo(HaveOccurred())
+
+			resultEvent = <-annotatedEvtWatcher.ResultChan()
+
+			Expect(resultEvent.Type).To(Equal(watch.Added))
+			annotatedEvt, isEvent := resultEvent.Object.(*eventsv1.Event)
+			Expect(isEvent).To(BeTrue())
+
+			Expect(annotatedEvt.Regarding).To(Equal(*dpRef))
+			Expect(annotatedEvt.Type).To(Equal(corev1.EventTypeNormal))
+			Expect(annotatedEvt.Reason).To(Equal("test-annotated-reason"))
+			Expect(annotatedEvt.Action).To(Equal("test-annotated-action"))
+			Expect(annotatedEvt.Note).To(Equal("test-annotated-note"))
+			Expect(annotatedEvt.Annotations).To(HaveKeyWithValue("key", "value"))
 		})
 	})
 })

--- a/pkg/internal/recorder/recorder_integration_test.go
+++ b/pkg/internal/recorder/recorder_integration_test.go
@@ -47,7 +47,6 @@ var _ = Describe("recorder", func() {
 			By("Creating the Controller")
 			deprecatedRecorder := cm.GetEventRecorderFor("test-deprecated-recorder") //nolint:staticcheck // testing deprecated API
 			recorder := cm.GetEventRecorder("test-recorder")
-			annotatedRecorder := cm.GetAnnotatedEventRecorder("test-annotated-recorder")
 			instance, err := controller.New("foo-controller", cm, controller.Options{
 				Reconciler: reconcile.Func(
 					func(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -55,7 +54,7 @@ var _ = Describe("recorder", func() {
 						Expect(err).NotTo(HaveOccurred())
 						deprecatedRecorder.Eventf(dp, corev1.EventTypeNormal, "deprecated-test-reason", "deprecated-test-msg")
 						recorder.Eventf(dp, nil, corev1.EventTypeNormal, "test-reason", "test-action", "test-note")
-						annotatedRecorder.AnnotatedEventf(dp, nil, map[string]string{"key": "value"}, corev1.EventTypeNormal, "test-annotated-reason", "test-annotated-action", "test-annotated-note")
+						recorder.AnnotatedEventf(dp, nil, map[string]string{"key": "value"}, corev1.EventTypeNormal, "test-annotated-reason", "test-annotated-action", "test-annotated-note")
 						return reconcile.Result{}, nil
 					}),
 			})

--- a/pkg/internal/recorder/recorder_test.go
+++ b/pkg/internal/recorder/recorder_test.go
@@ -62,6 +62,15 @@ var _ = Describe("recorder.Provider", func() {
 			Expect(recorder).NotTo(BeNil())
 		})
 	})
+	Describe("GetAnnotatedEventRecorder", func() {
+		It("should return a recorder instance.", func() {
+			provider, err := recorder.NewProvider(cfg, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster())
+			Expect(err).NotTo(HaveOccurred())
+
+			recorder := provider.GetAnnotatedEventRecorder("test")
+			Expect(recorder).NotTo(BeNil())
+		})
+	})
 })
 
 func makeBroadcaster() func() (record.EventBroadcaster, events.EventBroadcaster, bool) {

--- a/pkg/internal/recorder/recorder_test.go
+++ b/pkg/internal/recorder/recorder_test.go
@@ -54,21 +54,15 @@ var _ = Describe("recorder.Provider", func() {
 		})
 	})
 	Describe("GetEventRecorder", func() {
-		It("should return a recorder instance.", func() {
+		It("should return a recorder instance that supports both Eventf and AnnotatedEventf.", func() {
 			provider, err := recorder.NewProvider(cfg, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster())
 			Expect(err).NotTo(HaveOccurred())
 
-			recorder := provider.GetEventRecorder("test")
-			Expect(recorder).NotTo(BeNil())
-		})
-	})
-	Describe("GetAnnotatedEventRecorder", func() {
-		It("should return a recorder instance.", func() {
-			provider, err := recorder.NewProvider(cfg, httpClient, scheme.Scheme, logr.Discard(), makeBroadcaster())
-			Expect(err).NotTo(HaveOccurred())
-
-			recorder := provider.GetAnnotatedEventRecorder("test")
-			Expect(recorder).NotTo(BeNil())
+			rec := provider.GetEventRecorder("test")
+			Expect(rec).NotTo(BeNil())
+			// Verify it satisfies both interfaces
+			var _ events.EventRecorder = rec
+			var _ events.AnnotatedEventRecorder = rec
 		})
 	})
 })

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -268,6 +268,10 @@ func (cm *controllerManager) GetEventRecorder(name string) events.EventRecorder 
 	return cm.cluster.GetEventRecorder(name)
 }
 
+func (cm *controllerManager) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
+	return cm.cluster.GetAnnotatedEventRecorder(name)
+}
+
 func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {
 	return cm.cluster.GetRESTMapper()
 }

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/events"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
@@ -46,6 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/internal/httpserver"
 	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
@@ -264,12 +264,8 @@ func (cm *controllerManager) GetEventRecorderFor(name string) record.EventRecord
 	return cm.cluster.GetEventRecorderFor(name) //nolint:staticcheck
 }
 
-func (cm *controllerManager) GetEventRecorder(name string) events.EventRecorder {
+func (cm *controllerManager) GetEventRecorder(name string) recorder.EventRecorder {
 	return cm.cluster.GetEventRecorder(name)
-}
-
-func (cm *controllerManager) GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder {
-	return cm.cluster.GetAnnotatedEventRecorder(name)
 }
 
 func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -40,4 +40,7 @@ type Provider interface {
 	// characters, so callers should ensure that len(name) + 1 + len(hostname)
 	// is at most 128.
 	GetEventRecorder(name string) events.EventRecorder
+	// GetAnnotatedEventRecorder returns an AnnotatedEventRecorder that supports
+	// attaching annotations to events.
+	GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder
 }

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -25,6 +25,13 @@ import (
 	"k8s.io/client-go/tools/record"
 )
 
+// EventRecorder combines both events.EventRecorder and events.AnnotatedEventRecorder
+// so that callers only need a single recorder to emit both regular and annotated events.
+type EventRecorder interface {
+	events.EventRecorder
+	events.AnnotatedEventRecorder
+}
+
 // Provider knows how to generate new event recorders with given name.
 type Provider interface {
 	// GetEventRecorderFor returns an EventRecorder for the old events API.
@@ -39,8 +46,6 @@ type Provider interface {
 	// reportingController. reportingInstance must be no more than 128
 	// characters, so callers should ensure that len(name) + 1 + len(hostname)
 	// is at most 128.
-	GetEventRecorder(name string) events.EventRecorder
-	// GetAnnotatedEventRecorder returns an AnnotatedEventRecorder that supports
-	// attaching annotations to events.
-	GetAnnotatedEventRecorder(name string) events.AnnotatedEventRecorder
+	// The returned recorder supports both Eventf and AnnotatedEventf.
+	GetEventRecorder(name string) EventRecorder
 }


### PR DESCRIPTION
Adds support for creating event recorders that can attach custom annotations to events,
mirroring the `AnnotatedEventf` capability recently added to `client-go/tools/events`
(see kubernetes/kubernetes#138103).

This introduces a new `AnnotatedEventRecorderProvider` interface in `pkg/recorder` rather
than adding a method to the existing `Provider` interface, so this is a backwards-compatible
change. Consumers can type-assert the manager/cluster to access the new functionality:

```go
if p, ok := mgr.(recorder.AnnotatedEventRecorderProvider); ok {
    rec := p.GetAnnotatedEventRecorder("my-controller")
    rec.AnnotatedEventf(obj, nil, map[string]string{"key": "value"}, corev1.EventTypeNormal, "Reason", "Action", "Note")
}
```

Changes:
- Added AnnotatedEventRecorderProvider interface in pkg/recorder
- Implemented GetAnnotatedEventRecorder on the internal recorder Provider
- Implemented AnnotatedEventf on lazyRecorder
- Added GetAnnotatedEventRecorder on cluster and controllerManager (concrete types only, no interface changes)
- Added unit and integration tests