### PR TITLE
🌱chore: Update golangci-lint to v2.12.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,6 +34,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # tag=v9.2.0
         with:
-          version: v2.11.3
+          version: v2.12.1
           args: --output.text.print-linter-name=true --output.text.colors=true --timeout 10m
           working-directory: ${{matrix.working-directory}}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,9 @@ linters:
             msg: Use ginkgos SpecContext or go testings t.Context instead
           - pattern: context.TODO
             msg: Use ginkgos SpecContext or go testings t.Context instead
+    goconst:
+      ignore-tests: true
+      min-occurrences: 5
     govet:
       disable:
         - fieldalignment

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1503,7 +1503,7 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 				dep, err := clientset.AppsV1().Deployments(dep.Namespace).Create(ctx, dep, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				dep.APIVersion = appsv1.SchemeGroupVersion.String()
-				dep.Kind = "Deployment" //nolint:goconst
+				dep.Kind = "Deployment"
 				depUnstructured, err := toUnstructured(dep)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1368,7 +1368,7 @@ func (sw *fakeSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyCon
 
 func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {
 	switch gvk.Group {
-	case "apps":
+	case "apps": //nolint:goconst
 		switch gvk.Kind {
 		case "ControllerRevision", "DaemonSet", "Deployment", "ReplicaSet", "StatefulSet":
 			return true

--- a/pkg/handler/enqueue.go
+++ b/pkg/handler/enqueue.go
@@ -108,7 +108,7 @@ func (e *TypedEnqueueRequestForObject[T]) Generic(ctx context.Context, evt event
 }
 
 func isNil(arg any) bool {
-	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Pointer ||
 		v.Kind() == reflect.Interface ||
 		v.Kind() == reflect.Slice ||
 		v.Kind() == reflect.Map ||

--- a/pkg/internal/controller/metrics/metrics.go
+++ b/pkg/internal/controller/metrics/metrics.go
@@ -32,7 +32,7 @@ var (
 	ReconcileTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "controller_runtime_reconcile_total",
 		Help: "Total number of reconciliations per controller",
-	}, []string{"controller", "result"})
+	}, []string{"controller", "result"}) //nolint:goconst
 
 	// ReconcileErrors is a prometheus counter metrics which holds the total
 	// number of errors from the Reconciler.

--- a/pkg/internal/metrics/workqueue.go
+++ b/pkg/internal/metrics/workqueue.go
@@ -48,7 +48,7 @@ var (
 		Subsystem: WorkQueueSubsystem,
 		Name:      DepthKey,
 		Help:      "Current depth of workqueue by workqueue and priority",
-	}, []string{"name", "controller", "priority"})
+	}, []string{"name", "controller", "priority"}) //nolint:goconst
 
 	adds = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Subsystem: WorkQueueSubsystem,

--- a/pkg/internal/source/kind.go
+++ b/pkg/internal/source/kind.go
@@ -148,7 +148,7 @@ func (ks *Kind[object, request]) WaitForSync(ctx context.Context) error {
 }
 
 func isNil(arg any) bool {
-	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Pointer ||
 		v.Kind() == reflect.Interface ||
 		v.Kind() == reflect.Slice ||
 		v.Kind() == reflect.Map ||

--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -417,7 +417,7 @@ func LabelSelectorPredicate(s metav1.LabelSelector) (Predicate, error) {
 }
 
 func isNil(arg any) bool {
-	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Ptr ||
+	if v := reflect.ValueOf(arg); !v.IsValid() || ((v.Kind() == reflect.Pointer ||
 		v.Kind() == reflect.Interface ||
 		v.Kind() == reflect.Slice ||
 		v.Kind() == reflect.Map ||

--- a/pkg/webhook/admission/defaulter_custom.go
+++ b/pkg/webhook/admission/defaulter_custom.go
@@ -70,7 +70,7 @@ func WithDefaulter[T runtime.Object](scheme *runtime.Scheme, defaulter Defaulter
 			new: func() T {
 				var zero T
 				typ := reflect.TypeOf(zero)
-				if typ.Kind() == reflect.Ptr {
+				if typ.Kind() == reflect.Pointer {
 					return reflect.New(typ.Elem()).Interface().(T)
 				}
 				return zero

--- a/pkg/webhook/admission/validator_custom.go
+++ b/pkg/webhook/admission/validator_custom.go
@@ -64,7 +64,7 @@ func WithValidator[T runtime.Object](scheme *runtime.Scheme, validator Validator
 			new: func() T {
 				var zero T
 				typ := reflect.TypeOf(zero)
-				if typ.Kind() == reflect.Ptr {
+				if typ.Kind() == reflect.Pointer {
 					return reflect.New(typ.Elem()).Interface().(T)
 				}
 				return zero


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

 ## Summary                                                                                                                                                                
  - Update golangci-lint action from v2.11.3 to v2.12.1                                                                                                                     
  - Add `goconst` linter configuration (`ignore-tests: true`, `min-occurrences: 5`) : https://github.com/golangci/golangci-lint/pull/6480                                                                         
  - Replace deprecated `reflect.Ptr` with `reflect.Pointer` across 4 files                                                                                                  
  - Address new `goconst` findings by removing unnecessary `//nolint:goconst` comments