### PR TITLE
:bug: Fix regression in Apply typed error handling

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -38,6 +38,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1100,6 +1101,26 @@ U5wwSivyi7vmegHKmblOzNVKA5qPO8zWzqBC
 
 				Expect(secret.Data).To(BeComparableTo(data))
 				Expect(secret.Data).To(BeComparableTo(secretApplyConfiguration.Data))
+			})
+
+			It("should propagate a typed error", func(ctx SpecContext) {
+				cl, err := client.New(cfg, client.Options{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cl).NotTo(BeNil())
+
+				obj := corev1applyconfigurations.
+					Secret("typed-secret", "default").
+					WithType(corev1.SecretTypeDockercfg).
+					WithStringData(map[string]string{".dockercfg": "{}"})
+
+				err = cl.Apply(ctx, obj, &client.ApplyOptions{FieldManager: "test-manager"})
+				Expect(err).ToNot(HaveOccurred())
+
+				obj = corev1applyconfigurations.
+					Secret(*obj.Name, *obj.Namespace).
+					WithType(corev1.SecretTypeOpaque)
+				err = cl.Apply(ctx, obj, &client.ApplyOptions{FieldManager: "test-manager"})
+				Expect(isImmutableError(err)).To(BeTrue())
 			})
 		})
 	})
@@ -4432,4 +4453,9 @@ func toUnstructured(o client.Object) (*unstructured.Unstructured, error) {
 	}
 	u := &unstructured.Unstructured{}
 	return u, json.Unmarshal(serialized, u)
+}
+
+func isImmutableError(err error) bool {
+	return apierrors.IsInvalid(err) &&
+		strings.Contains(err.Error(), validation.FieldImmutableErrorMsg)
 }

--- a/pkg/client/typed_client.go
+++ b/pkg/client/typed_client.go
@@ -147,13 +147,18 @@ func (c *typedClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration,
 	applyOpts := &ApplyOptions{}
 	applyOpts.ApplyOptions(opts)
 
-	var contentType string
-	body, err := req.
+	resp := req.
 		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.name).
 		VersionedParams(applyOpts.AsPatchOptions(), c.paramCodec).
-		Do(ctx).
+		Do(ctx)
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	var contentType string
+	body, err := resp.
 		ContentType(&contentType).
 		Raw()
 	if err != nil {
@@ -332,14 +337,19 @@ func (c *typedClient) ApplySubResource(ctx context.Context, obj runtime.ApplyCon
 		return fmt.Errorf("failed to create apply request: %w", err)
 	}
 
-	var contentType string
-	respBody, err := req.
+	resp := req.
 		NamespaceIfScoped(o.namespace, o.isNamespaced()).
 		Resource(o.resource()).
 		Name(o.name).
 		SubResource(subResource).
 		VersionedParams(applyOpts.AsPatchOptions(), c.paramCodec).
-		Do(ctx).
+		Do(ctx)
+	if err := resp.Error(); err != nil {
+		return err
+	}
+
+	var contentType string
+	respBody, err := resp.
 		ContentType(&contentType).
 		Raw()
 	if err != nil {


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

When attempting to upgrade K8s dependencies in multiple operators, I noticed what seems to be a regression in the error handling for the Apply method in the controller-runtime client. Sadly, only one of the operators I've been having issues with is open source, but the problem can be observed in the failing CI of https://github.com/statnett/image-scanner-operator/pull/1729. This operator contains compensating logic for the `RequestEntityTooLarge` error (HTTP status 413), which is broken after upgrading K8s deps (including controller-runtime).

In one of our closed-source operators, I observe a similar issue, which is likely to be related. There we have compensating logic if trying to modify an immutable field. The tests are failing for the upgrade PR with the following logged inside the operator:

````json
{"level":"error","ts":"2026-05-04T08:50:50Z","msg":"Reconciler error","controller":"application","controllerGroup":"stas.statnett.no","controllerKind":"Application","Application":{"name":"v1beta2-immutable-field","namespace":"application-operator"},"namespace":"application-operator","name":"v1beta2-immutable-field","reconcileID":"45487740-546a-427e-a4d4-f826bf4042eb","error":"the server rejected our request due to an error in our request (patch deployments.apps v1beta2-immutable-field)","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.0/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.0/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.0/pkg/internal/controller/controller.go:312"}
````

I believe the regression was introduced in https://github.com/kubernetes-sigs/controller-runtime/pull/3475, which represents a good improvement/feature. But I think the error handling was dramatically changed by the PR.