### PR TITLE
🌱 Declare contents: read permissions for pr-verify action

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The single `verify.yml` workflow uses `pull_request_target` and only reads `github.event.pull_request.title` from the event payload, then runs `./hack/verify-pr-title.sh`. No git push, comments, or release operations — `contents: read` is the right floor for the GITHUB_TOKEN, and because the workflow runs on `pull_request_target` (default-branch context, otherwise inherits broad token scope) the explicit cap is a real tightening.

Mirrors the same change just approved + merged in [kubernetes-sigs/cluster-api-provider-vsphere#4005](https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/pull/4005) per @sbueringer's suggestion.