### PR TITLE
🐛 Fix envtest process stop on Windows

### DIFF
--- a/pkg/internal/testing/process/signal_windows.go
+++ b/pkg/internal/testing/process/signal_windows.go
@@ -1,4 +1,4 @@
-//go:build !aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris && !windows && !zos
+//go:build windows
 
 /*
 Copyright 2026 The Kubernetes Authors.
@@ -23,6 +23,6 @@ import (
 	"syscall"
 )
 
-func signalProcess(process *os.Process, sig syscall.Signal) error {
-	return process.Signal(sig)
+func signalProcess(process *os.Process, _ syscall.Signal) error {
+	return process.Kill()
 }


### PR DESCRIPTION
Fixes #3518

This adds a Windows-specific `signalProcess` implementation for envtest process teardown.

On Windows, `os.Process.Signal` does not support `SIGTERM` / `SIGKILL`, so `Environment.Stop()` fails when stopping the local `kube-apiserver` and `etcd` processes.

The Windows implementation uses `process.Kill()` instead.

This does not provide full Windows process-tree semantics like Unix process-group signaling. A Windows Job Object would be needed for that. However, in the current envtest setup, `kube-apiserver` and `etcd` are started directly via `exec.Command`. Killing those direct child processes fixes the current teardown failure.

Tested with an envtest admission webhook suite on Windows.