### PR TITLE
✨ Add TypedInformer source

### DIFF
--- a/pkg/internal/source/event_handler.go
+++ b/pkg/internal/source/event_handler.go
@@ -35,7 +35,7 @@ var log = logf.RuntimeLog.WithName("source").WithName("EventHandler")
 var _ cache.ResourceEventHandler = &EventHandler[client.Object, any]{}
 
 // NewEventHandler creates a new EventHandler.
-func NewEventHandler[object client.Object, request comparable](
+func NewEventHandler[object any, request comparable](
 	ctx context.Context,
 	queue workqueue.TypedRateLimitingInterface[request],
 	handler handler.TypedEventHandler[object, request],
@@ -49,7 +49,7 @@ func NewEventHandler[object client.Object, request comparable](
 }
 
 // EventHandler adapts a handler.EventHandler interface to a cache.ResourceEventHandler interface.
-type EventHandler[object client.Object, request comparable] struct {
+type EventHandler[object any, request comparable] struct {
 	// ctx stores the context that created the event handler
 	// that is used to propagate cancellation signals to each handler function.
 	ctx context.Context

--- a/pkg/source/source.go
+++ b/pkg/source/source.go
@@ -264,19 +264,23 @@ func (cs *channel[object, request]) syncLoop(ctx context.Context) {
 	}
 }
 
-// Informer is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create).
-type Informer struct {
+// TypedInformer is used to provide a source of events originating inside the cluster from Watches using generic
+// event handlers and predicates.
+type TypedInformer[object any, request comparable] struct {
 	// Informer is the controller-runtime Informer
 	Informer   cache.Informer
-	Handler    handler.EventHandler
-	Predicates []predicate.Predicate
+	Handler    handler.TypedEventHandler[object, request]
+	Predicates []predicate.TypedPredicate[object]
 }
+
+// Informer is used to provide a source of events originating inside the cluster from Watches (e.g. Pod Create).
+type Informer = TypedInformer[client.Object, reconcile.Request]
 
 var _ Source = &Informer{}
 
 // Start is internal and should be called only by the Controller to register an EventHandler with the Informer
 // to enqueue reconcile.Requests.
-func (is *Informer) Start(ctx context.Context, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) error {
+func (is *TypedInformer[object, request]) Start(ctx context.Context, queue workqueue.TypedRateLimitingInterface[request]) error {
 	// Informer should have been specified by the user.
 	if is.Informer == nil {
 		return fmt.Errorf("must specify Informer.Informer")
@@ -294,7 +298,7 @@ func (is *Informer) Start(ctx context.Context, queue workqueue.TypedRateLimiting
 	return nil
 }
 
-func (is *Informer) String() string {
+func (is *TypedInformer[object, request]) String() string {
 	return fmt.Sprintf("informer source: %p", is.Informer)
 }
 


### PR DESCRIPTION
This PR mimics the existing pattern of having a typed version of each source. This small change would help users avoid having to write their own version of `TypedInformer`.

For an example of a use-case, see: https://github.com/kubernetes-sigs/aws-load-balancer-controller/pull/4678/changes#diff-aeaa3ed265c13311667100ad572f071fc3928d07227e8320322116bfee2a0e90