### PR TITLE
📖 Document event recorder name length constraint

### DIFF
--- a/pkg/internal/recorder/recorder.go
+++ b/pkg/internal/recorder/recorder.go
@@ -161,7 +161,9 @@ func (p *Provider) GetEventRecorderFor(name string) record.EventRecorder {
 }
 
 // GetEventRecorder returns an event recorder that broadcasts to this provider's
-// broadcaster.  All events will be associated with a component of the given name.
+// broadcaster. All events will be associated with the given reportingController
+// name. client-go appends "-" and the hostname to derive reportingInstance,
+// which must fit within the events.k8s.io/v1 128-character limit.
 func (p *Provider) GetEventRecorder(name string) events.EventRecorder {
 	return &lazyRecorder{
 		prov: p,

--- a/pkg/recorder/recorder.go
+++ b/pkg/recorder/recorder.go
@@ -31,6 +31,13 @@ type Provider interface {
 	//
 	// Deprecated: this uses the old events API and will be removed in a future release. Please use GetEventRecorder instead.
 	GetEventRecorderFor(name string) record.EventRecorder
-	// GetEventRecorder returns a EventRecorder with given name.
+	// GetEventRecorder returns an EventRecorder with given name.
+	//
+	// The name is used as the reportingController of events.k8s.io/v1 Events
+	// and must be a valid Kubernetes qualified name. client-go derives the
+	// reportingInstance by appending "-" and the current hostname to
+	// reportingController. reportingInstance must be no more than 128
+	// characters, so callers should ensure that len(name) + 1 + len(hostname)
+	// is at most 128.
 	GetEventRecorder(name string) events.EventRecorder
 }


### PR DESCRIPTION
## What changed

Documented the effective length constraint for `GetEventRecorder` names when using the `events.k8s.io/v1` recorder.

## Why

`client-go` uses the recorder name as `reportingController` and derives `reportingInstance` by appending `-` plus the current hostname. Kubernetes limits `reportingInstance` to 128 characters, so long recorder names can be rejected by the API server even when the recorder name itself is otherwise valid.

## User impact

Users now have explicit guidance to keep `len(name) + 1 + len(hostname) <= 128` when calling `GetEventRecorder`.

Fixes #3511

## Validation

- `go test ./pkg/recorder ./pkg/internal/recorder ./pkg/cluster ./pkg/manager -run '^$'`\n- `git diff --check`\n\nFull envtest-backed package tests were not runnable locally because `/usr/local/kubebuilder/bin/etcd` is not installed in this environment.