### PR TITLE
✨ Add admission response status code metrics for webhooks

### DIFF
--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -162,8 +162,8 @@ func (wh *Webhook) writeAdmissionResponse(ctx context.Context, w io.Writer, ar v
 		}
 	} else {
 		res := ar.Response
-		code := int32(0)
-		if res.Result != nil {
+		code := int32(http.StatusOK)
+		if res.Result != nil && res.Result.Code != 0 {
 			code = res.Result.Code
 		}
 		admissionmetrics.ObserveAdmissionResponse(ctx, res.Allowed, code)

--- a/pkg/webhook/admission/http.go
+++ b/pkg/webhook/admission/http.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admission
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -29,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+
+	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
 )
 
 var admissionScheme = runtime.NewScheme()
@@ -62,6 +65,7 @@ func init() {
 var _ http.Handler = &Webhook{}
 
 func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	metricCtx := r.Context()
 	ctx := r.Context()
 	if wh.WithContextFunc != nil {
 		ctx = wh.WithContextFunc(ctx, r)
@@ -70,7 +74,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if r.Body == nil || r.Body == http.NoBody {
 		err := errors.New("request body is empty")
 		wh.getLogger(nil).Error(err, "bad request")
-		wh.writeResponse(w, Errored(http.StatusBadRequest, err))
+		wh.writeResponse(metricCtx, w, Errored(http.StatusBadRequest, err))
 		return
 	}
 
@@ -79,13 +83,13 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(limitedReader)
 	if err != nil {
 		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request")
-		wh.writeResponse(w, Errored(http.StatusBadRequest, err))
+		wh.writeResponse(metricCtx, w, Errored(http.StatusBadRequest, err))
 		return
 	}
 	if limitedReader.N <= 0 {
 		err := fmt.Errorf("request entity is too large; limit is %d bytes", maxRequestSize)
 		wh.getLogger(nil).Error(err, "unable to read the body from the incoming request; limit reached")
-		wh.writeResponse(w, Errored(http.StatusRequestEntityTooLarge, err))
+		wh.writeResponse(metricCtx, w, Errored(http.StatusRequestEntityTooLarge, err))
 		return
 	}
 
@@ -93,7 +97,7 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if contentType := r.Header.Get("Content-Type"); contentType != "application/json" {
 		err = fmt.Errorf("contentType=%s, expected application/json", contentType)
 		wh.getLogger(nil).Error(err, "unable to process a request with unknown content type")
-		wh.writeResponse(w, Errored(http.StatusBadRequest, err))
+		wh.writeResponse(metricCtx, w, Errored(http.StatusBadRequest, err))
 		return
 	}
 
@@ -111,22 +115,22 @@ func (wh *Webhook) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	_, actualAdmRevGVK, err := admissionCodecs.UniversalDeserializer().Decode(body, nil, &ar)
 	if err != nil {
 		wh.getLogger(nil).Error(err, "unable to decode the request")
-		wh.writeResponse(w, Errored(http.StatusBadRequest, err))
+		wh.writeResponse(metricCtx, w, Errored(http.StatusBadRequest, err))
 		return
 	}
 	wh.getLogger(&req).V(5).Info("received request")
 
-	wh.writeResponseTyped(w, wh.Handle(ctx, req), actualAdmRevGVK)
+	wh.writeResponseTyped(metricCtx, w, wh.Handle(ctx, req), actualAdmRevGVK)
 }
 
 // writeResponse writes response to w generically, i.e. without encoding GVK information.
-func (wh *Webhook) writeResponse(w io.Writer, response Response) {
-	wh.writeAdmissionResponse(w, v1.AdmissionReview{Response: &response.AdmissionResponse})
+func (wh *Webhook) writeResponse(ctx context.Context, w io.Writer, response Response) {
+	wh.writeAdmissionResponse(ctx, w, v1.AdmissionReview{Response: &response.AdmissionResponse})
 }
 
 // writeResponseTyped writes response to w with GVK set to admRevGVK, which is necessary
 // if multiple AdmissionReview versions are permitted by the webhook.
-func (wh *Webhook) writeResponseTyped(w io.Writer, response Response, admRevGVK *schema.GroupVersionKind) {
+func (wh *Webhook) writeResponseTyped(ctx context.Context, w io.Writer, response Response, admRevGVK *schema.GroupVersionKind) {
 	ar := v1.AdmissionReview{
 		Response: &response.AdmissionResponse,
 	}
@@ -138,11 +142,11 @@ func (wh *Webhook) writeResponseTyped(w io.Writer, response Response, admRevGVK 
 	} else {
 		ar.SetGroupVersionKind(*admRevGVK)
 	}
-	wh.writeAdmissionResponse(w, ar)
+	wh.writeAdmissionResponse(ctx, w, ar)
 }
 
 // writeAdmissionResponse writes ar to w.
-func (wh *Webhook) writeAdmissionResponse(w io.Writer, ar v1.AdmissionReview) {
+func (wh *Webhook) writeAdmissionResponse(ctx context.Context, w io.Writer, ar v1.AdmissionReview) {
 	if err := json.NewEncoder(w).Encode(ar); err != nil {
 		wh.getLogger(nil).Error(err, "unable to encode and write the response")
 		// Since the `ar v1.AdmissionReview` is a clear and legal object,
@@ -153,9 +157,16 @@ func (wh *Webhook) writeAdmissionResponse(w io.Writer, ar v1.AdmissionReview) {
 		serverError := Errored(http.StatusInternalServerError, err)
 		if err = json.NewEncoder(w).Encode(v1.AdmissionReview{Response: &serverError.AdmissionResponse}); err != nil {
 			wh.getLogger(nil).Error(err, "still unable to encode and write the InternalServerError response")
+		} else {
+			admissionmetrics.ObserveAdmissionResponse(ctx, serverError.Allowed, serverError.Result.Code)
 		}
 	} else {
 		res := ar.Response
+		code := int32(0)
+		if res.Result != nil {
+			code = res.Result.Code
+		}
+		admissionmetrics.ObserveAdmissionResponse(ctx, res.Allowed, code)
 		if log := wh.getLogger(nil); log.V(5).Enabled() {
 			if res.Result != nil {
 				log = log.WithValues("code", res.Result.Code, "reason", res.Result.Reason, "message", res.Result.Message)

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -285,6 +285,25 @@ var _ = Describe("Admission Webhooks", func() {
 				metricsPath, "false", "200",
 			))).To(Equal(float64(1)))
 		})
+
+		It("should report an allowed response without a result as 200", func() {
+			const metricsPath = "/admission-response-allowed-default-code-test"
+			webhook := &Webhook{
+				Handler: HandlerFunc(func(context.Context, Request) Response {
+					return Response{AdmissionResponse: admissionv1.AdmissionResponse{Allowed: true}}
+				}),
+			}
+			instrumentedWebhook, err := StandaloneWebhook(webhook, StandaloneOptions{MetricsPath: metricsPath})
+			Expect(err).NotTo(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodPost, metricsPath, bytes.NewBufferString(`{"request":{}}`))
+			req.Header.Set("Content-Type", "application/json")
+			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), req)
+
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "true", "200",
+			))).To(Equal(float64(1)))
+		})
 	})
 })
 

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -34,6 +34,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
+	internalmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics"
 )
 
 var _ = Describe("Admission Webhooks", func() {
@@ -267,6 +268,21 @@ var _ = Describe("Admission Webhooks", func() {
 			))).To(Equal(float64(1)))
 			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
 				metricsPath, "false", "400",
+			))).To(Equal(float64(1)))
+		})
+
+		It("should report an unset admission response status code as 200", func() {
+			const metricsPath = "/admission-response-default-code-test"
+			instrumentedWebhook := internalmetrics.InstrumentedHook(metricsPath, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				webhook.writeAdmissionResponse(r.Context(), w, admissionv1.AdmissionReview{
+					Response: &admissionv1.AdmissionResponse{Allowed: false},
+				})
+			}))
+
+			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, metricsPath, nil))
+
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "false", "200",
 			))).To(Equal(float64(1)))
 		})
 	})

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -258,7 +258,9 @@ var _ = Describe("Admission Webhooks", func() {
 
 			req := httptest.NewRequest(http.MethodPost, metricsPath, bytes.NewBufferString(`{"request":{}}`))
 			req.Header.Set("Content-Type", "application/json")
-			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), req)
+			respRecorder := httptest.NewRecorder()
+			instrumentedWebhook.ServeHTTP(respRecorder, req)
+			Expect(respRecorder.Code).To(Equal(http.StatusOK))
 
 			badReq := httptest.NewRequest(http.MethodPost, metricsPath, nil)
 			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), badReq)

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
 )
@@ -233,11 +234,26 @@ var _ = Describe("Admission Webhooks", func() {
 			const metricsPath = "/admission-response-metrics-test"
 			webhook := &Webhook{
 				Handler: HandlerFunc(func(context.Context, Request) Response {
-					return Denied("denied")
+					return Response{AdmissionResponse: admissionv1.AdmissionResponse{
+						Allowed: false,
+						Result: &metav1.Status{
+							Code:    http.StatusTooManyRequests,
+							Message: "rate limited",
+						},
+					}}
 				}),
 			}
 			instrumentedWebhook, err := StandaloneWebhook(webhook, StandaloneOptions{MetricsPath: metricsPath})
 			Expect(err).NotTo(HaveOccurred())
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "true", "200",
+			))).To(BeZero())
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "false", "403",
+			))).To(BeZero())
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "false", "500",
+			))).To(BeZero())
 
 			req := httptest.NewRequest(http.MethodPost, metricsPath, bytes.NewBufferString(`{"request":{}}`))
 			req.Header.Set("Content-Type", "application/json")
@@ -247,7 +263,7 @@ var _ = Describe("Admission Webhooks", func() {
 			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), badReq)
 
 			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
-				metricsPath, "false", "403",
+				metricsPath, "false", "429",
 			))).To(Equal(float64(1)))
 			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
 				metricsPath, "false", "400",

--- a/pkg/webhook/admission/http_test.go
+++ b/pkg/webhook/admission/http_test.go
@@ -28,8 +28,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	admissionv1 "k8s.io/api/admission/v1"
+
+	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
 )
 
 var _ = Describe("Admission Webhooks", func() {
@@ -224,6 +227,31 @@ var _ = Describe("Admission Webhooks", func() {
 				webhook.ServeHTTP(bw, req)
 				return respRecorder.Body.Len()
 			}, time.Second*3).Should(Equal(0))
+		})
+
+		It("should report admission response status codes", func() {
+			const metricsPath = "/admission-response-metrics-test"
+			webhook := &Webhook{
+				Handler: HandlerFunc(func(context.Context, Request) Response {
+					return Denied("denied")
+				}),
+			}
+			instrumentedWebhook, err := StandaloneWebhook(webhook, StandaloneOptions{MetricsPath: metricsPath})
+			Expect(err).NotTo(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodPost, metricsPath, bytes.NewBufferString(`{"request":{}}`))
+			req.Header.Set("Content-Type", "application/json")
+			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), req)
+
+			badReq := httptest.NewRequest(http.MethodPost, metricsPath, nil)
+			instrumentedWebhook.ServeHTTP(httptest.NewRecorder(), badReq)
+
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "false", "403",
+			))).To(Equal(float64(1)))
+			Expect(testutil.ToFloat64(admissionmetrics.AdmissionResponseTotal.WithLabelValues(
+				metricsPath, "false", "400",
+			))).To(Equal(float64(1)))
 		})
 	})
 })

--- a/pkg/webhook/admission/metrics/metrics.go
+++ b/pkg/webhook/admission/metrics/metrics.go
@@ -58,6 +58,7 @@ func InitializeAdmissionResponseTotal(path string) {
 		{"true", "200"},
 		{"false", "400"},
 		{"false", "403"},
+		{"false", "429"},
 		{"false", "500"},
 	} {
 		AdmissionResponseTotal.WithLabelValues(path, labels[0], labels[1]).Add(0)

--- a/pkg/webhook/admission/metrics/metrics.go
+++ b/pkg/webhook/admission/metrics/metrics.go
@@ -51,6 +51,19 @@ func init() {
 	WebhookPanics.WithLabelValues().Add(0)
 }
 
+// InitializeAdmissionResponseTotal initializes the most common admission
+// response label combinations for the given webhook path.
+func InitializeAdmissionResponseTotal(path string) {
+	for _, labels := range [][2]string{
+		{"true", "200"},
+		{"false", "400"},
+		{"false", "403"},
+		{"false", "500"},
+	} {
+		AdmissionResponseTotal.WithLabelValues(path, labels[0], labels[1]).Add(0)
+	}
+}
+
 // ObserveAdmissionResponse records an admission response if the webhook is
 // instrumented.
 func ObserveAdmissionResponse(ctx context.Context, allowed bool, code int32) {

--- a/pkg/webhook/admission/metrics/metrics.go
+++ b/pkg/webhook/admission/metrics/metrics.go
@@ -17,8 +17,12 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
+	"strconv"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	internalmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics"
 )
 
 var (
@@ -28,12 +32,36 @@ var (
 		Name: "controller_runtime_webhook_panics_total",
 		Help: "Total number of webhook panics",
 	}, []string{})
+
+	// AdmissionResponseTotal is a prometheus counter metric which holds the
+	// total number of admission responses by webhook, allowed status, and
+	// admission response status code.
+	AdmissionResponseTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "controller_runtime_webhook_admission_responses_total",
+		Help: "Total number of admission responses by status code and allowed status.",
+	}, []string{"webhook", "allowed", "admission_code"})
 )
 
 func init() {
 	metrics.Registry.MustRegister(
 		WebhookPanics,
+		AdmissionResponseTotal,
 	)
 	// Init metric.
 	WebhookPanics.WithLabelValues().Add(0)
+}
+
+// ObserveAdmissionResponse records an admission response if the webhook is
+// instrumented.
+func ObserveAdmissionResponse(ctx context.Context, allowed bool, code int32) {
+	path, ok := internalmetrics.WebhookPathFromContext(ctx)
+	if !ok {
+		return
+	}
+
+	AdmissionResponseTotal.WithLabelValues(
+		path,
+		strconv.FormatBool(allowed),
+		strconv.FormatInt(int64(code), 10),
+	).Inc()
 }

--- a/pkg/webhook/admission/webhook.go
+++ b/pkg/webhook/admission/webhook.go
@@ -244,6 +244,7 @@ func StandaloneWebhook(hook *Webhook, opts StandaloneOptions) (http.Handler, err
 	if opts.MetricsPath == "" {
 		return hook, nil
 	}
+	admissionmetrics.InitializeAdmissionResponseTotal(opts.MetricsPath)
 	return metrics.InstrumentedHook(opts.MetricsPath, hook), nil
 }
 

--- a/pkg/webhook/internal/metrics/metrics.go
+++ b/pkg/webhook/internal/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -25,6 +26,8 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+type webhookPathKey struct{}
 
 var (
 	// RequestLatency is a prometheus metric which is a histogram of the latency
@@ -80,11 +83,23 @@ func InstrumentedHook(path string, hookRaw http.Handler) http.Handler {
 	cnt.WithLabelValues("200")
 	cnt.WithLabelValues("500")
 
+	hook := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := context.WithValue(r.Context(), webhookPathKey{}, path)
+		hookRaw.ServeHTTP(w, r.WithContext(ctx))
+	})
+
 	return promhttp.InstrumentHandlerDuration(
 		lat,
 		promhttp.InstrumentHandlerCounter(
 			cnt,
-			promhttp.InstrumentHandlerInFlight(gge, hookRaw),
+			promhttp.InstrumentHandlerInFlight(gge, hook),
 		),
 	)
+}
+
+// WebhookPathFromContext returns the path used to register the webhook, if the
+// webhook is instrumented.
+func WebhookPathFromContext(ctx context.Context) (string, bool) {
+	path, ok := ctx.Value(webhookPathKey{}).(string)
+	return path, ok
 }

--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/internal/httpserver"
+	admissionmetrics "sigs.k8s.io/controller-runtime/pkg/webhook/admission/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics"
 )
 
@@ -177,6 +178,9 @@ func (s *DefaultServer) Register(path string, hook http.Handler) {
 		panic(fmt.Errorf("can't register duplicate path: %v", path))
 	}
 	s.webhooks[path] = hook
+	if _, ok := hook.(*Admission); ok {
+		admissionmetrics.InitializeAdmissionResponseTotal(path)
+	}
 	s.webhookMux.Handle(path, metrics.InstrumentedHook(path, hook))
 
 	regLog := log.WithValues("path", path)

--- a/pkg/webhook/server_metrics_test.go
+++ b/pkg/webhook/server_metrics_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhook
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+func TestRegisterInitializesAdmissionResponseMetrics(t *testing.T) {
+	const path = "/server-admission-response-metrics-test"
+	NewServer(Options{}).Register(path, &Admission{})
+
+	metricFamilies, err := metrics.Registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	want := map[string]bool{
+		"true/200":  false,
+		"false/400": false,
+		"false/403": false,
+		"false/500": false,
+	}
+	for _, family := range metricFamilies {
+		if family.GetName() != "controller_runtime_webhook_admission_responses_total" {
+			continue
+		}
+		for _, metric := range family.Metric {
+			labels := map[string]string{}
+			for _, label := range metric.Label {
+				labels[label.GetName()] = label.GetValue()
+			}
+			if labels["webhook"] != path {
+				continue
+			}
+
+			key := labels["allowed"] + "/" + labels["admission_code"]
+			if _, ok := want[key]; !ok {
+				t.Errorf("unexpected initialized label combination %q", key)
+				continue
+			}
+			if value := metric.GetCounter().GetValue(); value != 0 {
+				t.Errorf("expected initialized metric %q to be zero, got %v", key, value)
+			}
+			want[key] = true
+		}
+	}
+
+	for labels, found := range want {
+		if !found {
+			t.Errorf("expected initialized metric labels %q", labels)
+		}
+	}
+}

--- a/pkg/webhook/server_metrics_test.go
+++ b/pkg/webhook/server_metrics_test.go
@@ -35,6 +35,7 @@ func TestRegisterInitializesAdmissionResponseMetrics(t *testing.T) {
 		"true/200":  false,
 		"false/400": false,
 		"false/403": false,
+		"false/429": false,
 		"false/500": false,
 	}
 	for _, family := range metricFamilies {


### PR DESCRIPTION
## What does this do, and why do we need it?

This PR adds an admission-response-level metric:

```text
controller_runtime_webhook_admission_responses_total{webhook,allowed,admission_code}
```

This PR intentionally does not change the HTTP response status for valid AdmissionReview responses. Kubernetes admission webhooks are expected to return HTTP 200 with an AdmissionReview body, including when an admission decision is denied.

The existing `controller_runtime_webhook_requests_total{code=...}` metric continues to represent the HTTP transport status code observed by promhttp. The new metric separately exposes `AdmissionResponse.status.code`, making admission decisions and errors such as 400, 403, 429, and 500 observable without changing the existing HTTP request metric semantics.

The common response series are initialized when an Admission webhook is registered directly with the webhook server or configured through `StandaloneWebhook`. Responses with an unset status code follow the existing `Response.Complete` behavior and are recorded as 200.

## Validation

- `go test ./pkg/webhook/...`
- `go vet ./pkg/webhook/...`

Addresses the metrics aspect of #2972.
