### PR TITLE
🐛 manager: suppress expected leader-election-lost error on graceful shutdown

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -51,14 +51,19 @@ import (
 
 const (
 	// Values taken from: https://github.com/kubernetes/component-base/blob/master/config/v1alpha1/defaults.go
-	defaultLeaseDuration          = 15 * time.Second
-	defaultRenewDeadline          = 10 * time.Second
-	defaultRetryPeriod            = 2 * time.Second
+	defaultLeaseDuration = 15 * time.Second
+	defaultRenewDeadline = 10 * time.Second
+	defaultRetryPeriod   = 2 * time.Second
+
 	defaultGracefulShutdownPeriod = 30 * time.Second
 
 	defaultReadinessEndpoint = "/readyz"
 	defaultLivenessEndpoint  = "/healthz"
 )
+
+// errLeaderElectionLost is returned by OnStoppedLeading when leader election is lost.
+// It is used to suppress this expected error during graceful shutdown.
+var errLeaderElectionLost = errors.New("leader election lost")
 
 var _ Runnable = &controllerManager{}
 
@@ -529,7 +534,7 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 			})
 			select {
 			case err := <-cm.errChan:
-				if !errors.Is(err, context.Canceled) {
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, errLeaderElectionLost) {
 					cm.logger.Error(err, "error received after stop sequence was engaged")
 				}
 			case <-stopComplete:
@@ -634,7 +639,7 @@ func (cm *controllerManager) initLeaderElector() (*leaderelection.LeaderElector,
 				// Most implementations of leader election log.Fatal() here.
 				// Since Start is wrapped in log.Fatal when called, we can just return
 				// an error here which will cause the program to exit.
-				cm.errChan <- errors.New("leader election lost")
+				cm.errChan <- errLeaderElectionLost
 			},
 		},
 		ReleaseOnCancel: cm.leaderElectionReleaseOnCancel,

--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -533,6 +533,13 @@ func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) e
 				cm.internalCancel()
 			})
 			select {
+			// errLeaderElectionLost is safe to suppress here. This drain goroutine
+			// is only started from engageStopProcedure, which is called via defer
+			// in Start() — meaning Start() has already exited its select loop and
+			// returned any mid-run errLeaderElectionLost to the caller before this
+			// goroutine ever reads from errChan. Any errLeaderElectionLost seen
+			// here is therefore always the result of our own cm.internalCancel()
+			// call above, not a genuine unexpected loss.
 			case err := <-cm.errChan:
 				if !errors.Is(err, context.Canceled) && !errors.Is(err, errLeaderElectionLost) {
 					cm.logger.Error(err, "error received after stop sequence was engaged")

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -45,6 +45,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/cache/informertest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -2074,39 +2075,30 @@ var _ = Describe("manger.Manager", func() {
 		Expect(<-runnableExecutionOrderChan).To(Equal(leaderElectionRunnableName))
 	})
 
-	It("should not log an error when leader election is lost during graceful shutdown", func() {
-		// This is the scenario from https://github.com/kubernetes-sigs/controller-runtime/issues/3535:
-		// Stopping the manager releases the leader lock, which triggers OnStoppedLeading.
-		// That callback sends errLeaderElectionLost onto errChan. The drain goroutine in
-		// engageStopProcedure must not log this as an unexpected error.
-		ctx, cancel := context.WithCancel(context.Background())
+	It("should not return leader election lost during graceful shutdown", func(ctx SpecContext) {
+		runCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
 		m, err := New(cfg, Options{
 			LeaderElection:          true,
 			LeaderElectionID:        "leader-election-lost-on-stop-test",
 			LeaderElectionNamespace: "default",
-			GracefulShutdownTimeout: func() *time.Duration { d := 5 * time.Second; return &d }(),
+			GracefulShutdownTimeout: ptr.To(5 * time.Second),
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		doneCh := make(chan error, 1)
 		go func() {
-			doneCh <- m.Start(ctx)
+			doneCh <- m.Start(runCtx)
 		}()
 
-		// Wait until elected.
-		select {
-		case <-m.Elected():
-		case <-time.After(10 * time.Second):
-			Fail("timed out waiting for manager to be elected")
-		}
+		Eventually(m.Elected()).Should(BeClosed())
 
-		// Cancel the context — this is the normal shutdown path.
 		cancel()
 
-		// Start() must return cleanly (nil or context.Canceled), not "leader election lost".
-		Eventually(doneCh, "10s").Should(Receive(Or(BeNil(), MatchError(context.Canceled))))
+		Eventually(doneCh).Should(
+			Receive(Or(BeNil(), MatchError(context.Canceled))),
+		)
 	})
 })
 

--- a/pkg/manager/manager_test.go
+++ b/pkg/manager/manager_test.go
@@ -2073,6 +2073,41 @@ var _ = Describe("manger.Manager", func() {
 		<-m.Elected()
 		Expect(<-runnableExecutionOrderChan).To(Equal(leaderElectionRunnableName))
 	})
+
+	It("should not log an error when leader election is lost during graceful shutdown", func() {
+		// This is the scenario from https://github.com/kubernetes-sigs/controller-runtime/issues/3535:
+		// Stopping the manager releases the leader lock, which triggers OnStoppedLeading.
+		// That callback sends errLeaderElectionLost onto errChan. The drain goroutine in
+		// engageStopProcedure must not log this as an unexpected error.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		m, err := New(cfg, Options{
+			LeaderElection:          true,
+			LeaderElectionID:        "leader-election-lost-on-stop-test",
+			LeaderElectionNamespace: "default",
+			GracefulShutdownTimeout: func() *time.Duration { d := 5 * time.Second; return &d }(),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		doneCh := make(chan error, 1)
+		go func() {
+			doneCh <- m.Start(ctx)
+		}()
+
+		// Wait until elected.
+		select {
+		case <-m.Elected():
+		case <-time.After(10 * time.Second):
+			Fail("timed out waiting for manager to be elected")
+		}
+
+		// Cancel the context — this is the normal shutdown path.
+		cancel()
+
+		// Start() must return cleanly (nil or context.Canceled), not "leader election lost".
+		Eventually(doneCh, "10s").Should(Receive(Or(BeNil(), MatchError(context.Canceled))))
+	})
 })
 
 type runnableError struct{}


### PR DESCRIPTION

Fixes #3535
 
## What the Issue Was
 
On graceful shutdown with `LeaderElection` enabled, cancelling the
leader election context triggers `OnStoppedLeading`, which pushes
`errLeaderElectionLost` onto `errChan`. The drain goroutine in
`engageStopProcedure` only filtered `context.Canceled`, so this
expected error was logged as unexpected:
 
```
level=ERROR msg="error received after stop sequence was engaged" err="leader election lost"
```
 
When combined with `t.Output()` in tests, this also causes panics or
data races as the manager writes to the test log after the test exits.
 
## Solution
 
- Added a package-level `errLeaderElectionLost` sentinel for reliable
  `errors.Is` matching.
- Used the sentinel in `OnStoppedLeading` instead of an anonymous
  `errors.New`.
- Added the sentinel to the `engageStopProcedure` drain filter
  alongside `context.Canceled`.
Genuine mid-run leader election loss (before stop is engaged) still
propagates to `Start`'s caller unchanged.
 
## Changes
 
- `pkg/manager/internal.go`: sentinel + filter fix.
- `pkg/manager/manager_test.go`: regression test for graceful shutdown.
## Testing
 
```
$ go test sigs.k8s.io/controller-runtime/pkg/manager -v \
  -run "should not log an error when leader election is lost during graceful shutdown"
--- PASS
PASS
```