### PR TITLE
🐛 Fix PriorityQueue deadlock on shutdown

### DIFF
--- a/pkg/controller/priorityqueue/priorityqueue.go
+++ b/pkg/controller/priorityqueue/priorityqueue.go
@@ -397,7 +397,16 @@ func (w *priorityqueue[T]) handleReadyItems() {
 				w.waiters--
 				delete(w.items, item.Key)
 				toDelete = append(toDelete, item)
-				w.get <- *item
+				// w.get is unbuffered, so this send blocks until a GetWithPriority
+				// consumer receives. A consumer that is parked in GetWithPriority can
+				// instead return via <-w.done once ShutDown closes it, leaving no one
+				// to receive here. Also watch w.done so the send does not block forever
+				// and deadlock the queue (the whole queue stalls because w.lock is held).
+				select {
+				case w.get <- *item:
+				case <-w.done:
+					return false
+				}
 
 				return w.waiters > 0
 			})

--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -1007,3 +1007,50 @@ func TestWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *test
 		g.Expect(metrics.retries["test"]).To(Equal(2))
 	})
 }
+
+// TestPriorityQueueDoesNotDeadlockOnShutdownWhileHandingOutItems reproduces
+// https://github.com/kubernetes-sigs/controller-runtime/issues/3538: if
+// handleReadyItems is handing an item to a consumer over the unbuffered w.get
+// channel while ShutDown runs, the parked GetWithPriority consumer can return
+// through <-w.done instead of receiving from w.get. handleReadyItems is then
+// stuck on the send while still holding w.lock, so every later GetWithPriority
+// (and handleAddBuffer) blocks and the whole queue deadlocks. This is a timing
+// race, so we run several rounds of the reporter's add/get loop and fail via a
+// bounded wait if any round leaves workers blocked. After the fix the send is
+// cancelled on shutdown and all workers return.
+func TestPriorityQueueDoesNotDeadlockOnShutdownWhileHandingOutItems(t *testing.T) {
+	t.Parallel()
+
+	for round := 0; round < 50; round++ {
+		q := New[string]("test")
+
+		var wg sync.WaitGroup
+		for i := 0; i < 20; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					q.AddWithOpts(AddOpts{Priority: ptr.To(rand.IntN(100))}, strconv.Itoa(rand.IntN(1000)))
+					if _, _, shutdown := q.GetWithPriority(); shutdown {
+						return
+					}
+				}
+			}()
+		}
+
+		time.Sleep(time.Millisecond)
+		q.ShutDown()
+
+		returned := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(returned)
+		}()
+
+		select {
+		case <-returned:
+		case <-time.After(10 * time.Second):
+			t.Fatalf("workers did not return within 10s after ShutDown in round %d: queue deadlocked", round)
+		}
+	}
+}

--- a/pkg/controller/priorityqueue/priorityqueue_test.go
+++ b/pkg/controller/priorityqueue/priorityqueue_test.go
@@ -1021,21 +1021,19 @@ func TestWhenAddingMultipleItemsWithRatelimitTrueTheyDontAffectEachOther(t *test
 func TestPriorityQueueDoesNotDeadlockOnShutdownWhileHandingOutItems(t *testing.T) {
 	t.Parallel()
 
-	for round := 0; round < 50; round++ {
+	for round := range 50 {
 		q := New[string]("test")
 
 		var wg sync.WaitGroup
-		for i := 0; i < 20; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		for range 20 {
+			wg.Go(func() {
 				for {
-					q.AddWithOpts(AddOpts{Priority: ptr.To(rand.IntN(100))}, strconv.Itoa(rand.IntN(1000)))
+					q.AddWithOpts(AddOpts{Priority: new(rand.IntN(100))}, strconv.Itoa(rand.IntN(1000)))
 					if _, _, shutdown := q.GetWithPriority(); shutdown {
 						return
 					}
 				}
-			}()
+			})
 		}
 
 		time.Sleep(time.Millisecond)


### PR DESCRIPTION
Calls to `GetWithPriority` can hang forever after `ShutDown`, and the whole PriorityQueue deadlocks. This fixes #3538.

The problem is in `handleReadyItems`: it hands a ready item to a waiting consumer with an unbuffered send on `w.get` while holding `w.lock`. If `ShutDown` closes `w.done` first, the consumer that was parked in `GetWithPriority` returns through `<-w.done` instead of receiving, so nobody is left to take the item. The send then blocks forever with `w.lock` still held, and every later `GetWithPriority` and `handleAddBuffer` stalls on that lock. I wrapped the send in a select that also watches `w.done`, so it gets cancelled on shutdown and the lock is released. This matches what the reporter suggested and confirmed fixes it.

I also added a regression test that runs the reporter's add/get loop across several rounds and fails with a bounded wait if any worker stays blocked after `ShutDown`. It reliably deadlocks on the current code (usually within the first handful of rounds) and passes with the fix, including under `-race`.
