### PR TITLE
🐛 Fix confusing CertDir default that was removed in prior refactor

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -77,8 +77,8 @@ type Options struct {
 	// It will be defaulted to 9443 if unspecified.
 	Port int
 
-	// CertDir is the directory that contains the server key and certificate. Defaults to
-	// <temp-dir>/k8s-webhook-server/serving-certs.
+	// CertDir is the directory that contains the server key and certificate.
+	// This field is required if TLSOpts does not provide a custom GetCertificate.
 	CertDir string
 
 	// CertName is the server certificate name. Defaults to tls.crt.
@@ -140,10 +140,6 @@ func (o *Options) setDefaults() {
 		o.Port = DefaultPort
 	}
 
-	if len(o.CertDir) == 0 {
-		o.CertDir = filepath.Join(os.TempDir(), "k8s-webhook-server", "serving-certs")
-	}
-
 	if len(o.CertName) == 0 {
 		o.CertName = "tls.crt"
 	}
@@ -199,6 +195,9 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 	}
 
 	if cfg.GetCertificate == nil {
+		if s.Options.CertDir == "" {
+			return fmt.Errorf("CertDir must be specified or a custom GetCertificate must be provided via TLSOpts")
+		}
 		certPath := filepath.Join(s.Options.CertDir, s.Options.CertName)
 		keyPath := filepath.Join(s.Options.CertDir, s.Options.KeyName)
 


### PR DESCRIPTION
## What does this do / Why do we need it

The default for CertDir was set to a temp directory path, but the cert provisioners that would create files there were removed in a prior refactor (PR #300). This caused developers running examples to get confusing 'file not found' errors on a path that never existed.

This fix removes the default value and adds a clear error message when CertDir is empty and no custom GetCertificate is provided. The comment is updated to indicate CertDir is required.

## Which issue(s) this PR fixes

Fixes #900

## Notes

This PR was written in part with the assistance of generative AI; I reviewed and verified the changes.