### PR TITLE
🐛 Fix restmapper cache invalidation when version is not provided

### DIFF
--- a/pkg/client/apiutil/restmapper.go
+++ b/pkg/client/apiutil/restmapper.go
@@ -275,12 +275,6 @@ func (m *mapper) addGroupVersionResourcesToCacheAndReloadLocked(gvr map[schema.G
 // findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked tries to find the passed apiGroup.
 // If the server supports aggregated discovery, it will always perform that.
 func (m *mapper) findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked(groupName string) (_ *metav1.APIGroup, didAggregatedDiscovery bool, _ error) {
-	// Looking in the cache first
-	group, ok := m.apiGroups[groupName]
-	if ok {
-		return group, false, nil
-	}
-
 	// Update the cache if nothing was found.
 	apiGroups, maybeResources, _, err := m.client.GroupsAndMaybeResources()
 	if err != nil {

--- a/pkg/client/apiutil/restmapper.go
+++ b/pkg/client/apiutil/restmapper.go
@@ -275,13 +275,6 @@ func (m *mapper) addGroupVersionResourcesToCacheAndReloadLocked(gvr map[schema.G
 // findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked tries to find the passed apiGroup.
 // If the server supports aggregated discovery, it will always perform that.
 func (m *mapper) findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked(groupName string) (_ *metav1.APIGroup, didAggregatedDiscovery bool, _ error) {
-	// Looking in the cache first
-	group, ok := m.apiGroups[groupName]
-	if ok {
-		return group, false, nil
-	}
-
-	// Update the cache if nothing was found.
 	apiGroups, maybeResources, _, err := m.client.GroupsAndMaybeResources()
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to get server groups: %w", err)
@@ -294,12 +287,32 @@ func (m *mapper) findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked(groupName s
 	for i := range apiGroups.Groups {
 		group := &apiGroups.Groups[i]
 		m.apiGroups[group.Name] = group
+
+		// Remove stale versions from the cache: any version cached for this group
+		// that is no longer advertised by the server should be evicted.
+		if knownGroup, ok := m.knownGroups[group.Name]; ok {
+			serverVersions := make(map[string]bool, len(group.Versions))
+			for _, v := range group.Versions {
+				serverVersions[v.Version] = true
+			}
+			for version := range knownGroup.VersionedResources {
+				if !serverVersions[version] {
+					delete(knownGroup.VersionedResources, version)
+				}
+			}
+			filtered := []metav1.GroupVersionForDiscovery{}
+			for _, v := range knownGroup.Group.Versions {
+				if serverVersions[v.Version] {
+					filtered = append(filtered, v)
+				}
+			}
+			knownGroup.Group.Versions = filtered
+		}
 	}
 	if len(maybeResources) > 0 {
 		didAggregatedDiscovery = true
 		m.addGroupVersionResourcesToCacheAndReloadLocked(maybeResources)
 	}
-
 	// Looking in the cache again.
 	// Don't return an error here if the API group is not present.
 	// The reloaded RESTMapper will take care of returning a NoMatchError.

--- a/pkg/client/apiutil/restmapper_test.go
+++ b/pkg/client/apiutil/restmapper_test.go
@@ -56,7 +56,6 @@ func newCountingRoundTripper(rt http.RoundTripper) *countingRoundTripper {
 // RoundTrip implements http.RoundTripper.RoundTrip that additionally counts requests.
 func (crt *countingRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	crt.requestCount++
-
 	return crt.roundTripper.RoundTrip(r)
 }
 
@@ -598,25 +597,40 @@ func TestLazyRestMapperProvider(t *testing.T) {
 				c, err := client.New(restCfg, client.Options{Scheme: s})
 				g.Expect(err).NotTo(gmg.HaveOccurred())
 
-				// Register another CRD in runtime - "riders.crew.example.com".
-				createNewCRD(t.Context(), g, c, "crew.example.com", "Rider", "riders")
+				// Register another CRD in runtime - "riders.crew.example.com" with differents versions (v1alpha1 and v1alpha2)
+				newCRD := newCRD(t.Context(), g, c, "crew.example.com", "Rider", "riders")
+				newCRD.Spec.Versions[0].Name = "v1alpha1"
+				newCRD.Spec.Versions[1].Name = "v1alpha2"
+				g.Expect(c.Create(t.Context(), newCRD)).To(gmg.Succeed())
 
 				// Wait a bit until the CRD is registered.
-				g.Eventually(func() error {
-					_, err := lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
-					return err
-				}).Should(gmg.Succeed())
+				discHTTP, err := rest.HTTPClientFor(restCfg)
+				g.Expect(err).NotTo(gmg.HaveOccurred())
+				discClient, err := discovery.NewDiscoveryClientForConfigAndClient(restCfg, discHTTP)
+				g.Eventually(func(g gmg.Gomega) {
+					_, err = discClient.ServerResourcesForGroupVersion("crew.example.com/v1alpha1")
+					g.Expect(err).NotTo(gmg.HaveOccurred())
+				}).Should(gmg.Succeed(), "v1alpha1 should be available")
 
+				// Verify that when requesting the new kind without a version, it doesn't error
 				// Since we don't specify what version we expect, restmapper will fetch them all and search there.
 				// To fetch a list of available versions
 				//  #1: GET https://host/api
 				//  #2: GET https://host/apis
-				// Then, for each currently registered version:
-				// 	#3: GET https://host/apis/crew.example.com/v1
-				//	#4: GET https://host/apis/crew.example.com/v2
+				// Then, if aggregatedDiscovery is disabled, each currently registered version:
+				// 	#3: GET https://host/apis/crew.example.com/v1alpha1
+				//	#4: GET https://host/apis/crew.example.com/v1alpha2
+				// 	#5: GET https://host/apis/crew.example.com/v1
+				//	#6: GET https://host/apis/crew.example.com/v2
+				crt.Reset()
 				mapping, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: "crew.example.com", Kind: "rider"})
 				g.Expect(err).NotTo(gmg.HaveOccurred())
 				g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal("rider"))
+				expectedAPIRequestCount = 6
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
 			})
 
 			t.Run("LazyRESTMapper should invalidate the group cache if a version is not found", func(t *testing.T) {
@@ -719,13 +733,18 @@ func TestLazyRestMapperProvider(t *testing.T) {
 				g.Expect(crt.GetRequestCount()).To(gmg.Equal(0))
 
 				// We request Limo, which is not in the mapper because it doesn't exist.
-				// This will trigger a reload of the lazy mapper cache.
-				// Reloading the cache will read v2 again and since it's not available anymore, it should invalidate the cache.
-				// 	#1: GET https://host/apis/inventory.example.com/v1alpha1
-				// 	#2: GET https://host/apis/inventory.example.com/v1
+				// This will trigger a reload of the lazy mapper cache. It will first fetch a list of available versions
+				//  #1: GET https://host/api
+				//  #2: GET https://host/apis
+				// Then, if aggregatedDiscovery is disabled, since v1alpha1 is not available anymore, it will only fetch v1 version
+				// 	#3: GET https://host/apis/inventory.example.com/v1
 				_, err = lazyRestMapper.RESTMapping(schema.GroupKind{Group: group, Kind: "Limo"})
 				g.Expect(err).To(beNoMatchError())
-				g.Expect(crt.GetRequestCount()).To(gmg.Equal(2))
+				expectedAPIRequestCount = 3
+				if aggregatedDiscovery {
+					expectedAPIRequestCount = 2
+				}
+				g.Expect(crt.GetRequestCount()).To(gmg.Equal(expectedAPIRequestCount))
 				crt.Reset()
 
 				// Now we request v1alpha1 again and it should return an error since the cache was invalidated.
@@ -769,14 +788,6 @@ func TestLazyRestMapperProvider(t *testing.T) {
 			})
 		})
 	}
-}
-
-// createNewCRD creates a new CRD with the given group, kind, and plural and returns it.
-func createNewCRD(ctx context.Context, g gmg.Gomega, c client.Client, group, kind, plural string) *apiextensionsv1.CustomResourceDefinition {
-	newCRD := newCRD(ctx, g, c, group, kind, plural)
-	g.Expect(c.Create(ctx, newCRD)).To(gmg.Succeed())
-
-	return newCRD
 }
 
 // newCRD returns a new CRD with the given group, kind, and plural.

--- a/pkg/client/apiutil/restmapper_wb_test.go
+++ b/pkg/client/apiutil/restmapper_wb_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	gmg "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
@@ -211,4 +213,145 @@ type fakeAggregatedDiscoveryClient struct {
 func (f *fakeAggregatedDiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
 	groupList, err := f.DiscoveryInterface.ServerGroups()
 	return groupList, nil, nil, err
+}
+
+// Test the cache invalidation when mapping is requested without specifying a version
+func TestLazyRestMapper_AggregatedDiscovery_CacheInvalidation(t *testing.T) {
+	tests := []struct {
+		name                string
+		initialAPIGroup     *metav1.APIGroup
+		initialResourceList map[schema.GroupVersion]*metav1.APIResourceList
+		updatedAPIGroup     *metav1.APIGroup
+		updatedResourceList map[schema.GroupVersion]*metav1.APIResourceList
+		expectedKind        schema.GroupKind
+	}{
+		{
+			name: "new resource added to an existing group version",
+			initialAPIGroup: &metav1.APIGroup{
+				Name: "testGroup",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "testGroup/v1", Version: "v1"},
+				},
+			},
+			initialResourceList: map[schema.GroupVersion]*metav1.APIResourceList{
+				{Group: "testGroup", Version: "v1"}: {
+					GroupVersion: "testGroup/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "firstResources", Kind: "FirstResources", Version: "v1"},
+					},
+				},
+			},
+			updatedAPIGroup: &metav1.APIGroup{
+				Name: "testGroup",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "testGroup/v1", Version: "v1"},
+				},
+			},
+			updatedResourceList: map[schema.GroupVersion]*metav1.APIResourceList{
+				{Group: "testGroup", Version: "v1"}: {
+					GroupVersion: "testGroup/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "firstResources", Kind: "FirstResources", Version: "v1"},
+						{Name: "secondResources", Kind: "SecondResources", Version: "v1"},
+					},
+				},
+			},
+			expectedKind:   schema.GroupKind{Group: "testGroup", Kind: "SecondResources"},
+		},
+		{
+			name: "new version added to existing group",
+			initialAPIGroup: &metav1.APIGroup{
+				Name: "testGroup",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "testGroup/v1", Version: "v1"},
+				},
+			},
+			initialResourceList: map[schema.GroupVersion]*metav1.APIResourceList{
+				{Group: "testGroup", Version: "v1"}: {
+					GroupVersion: "testGroup/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "v1OnlyResources", Kind: "V1OnlyResource", Version: "v1"},
+					},
+				},
+			},
+			updatedAPIGroup: &metav1.APIGroup{
+				Name: "testGroup",
+				Versions: []metav1.GroupVersionForDiscovery{
+					{GroupVersion: "testGroup/v1", Version: "v1"},
+					{GroupVersion: "testGroup/v2", Version: "v2"},
+				},
+			},
+			updatedResourceList: map[schema.GroupVersion]*metav1.APIResourceList{
+				{Group: "testGroup", Version: "v1"}: {
+					GroupVersion: "testGroup/v1",
+					APIResources: []metav1.APIResource{
+						{Name: "v1OnlyResources", Kind: "V1OnlyResource", Version: "v1"},
+					},
+				},
+				{Group: "testGroup", Version: "v2"}: {
+					GroupVersion: "testGroup/v2",
+					APIResources: []metav1.APIResource{
+						{Name: "v2OnlyResources", Kind: "V2OnlyResource", Version: "v2"},
+					},
+				},
+			},
+			expectedKind:   schema.GroupKind{Group: "testGroup", Kind: "V2OnlyResource"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := gmg.NewWithT(t)
+			m := &mapper{
+				mapper: restmapper.NewDiscoveryRESTMapper([]*restmapper.APIGroupResources{}),
+				client: &mockAggregatedDiscoveryClient{
+					initialGroupList:    &metav1.APIGroupList{Groups: []metav1.APIGroup{*tt.initialAPIGroup}},
+					initialResourceList: tt.initialResourceList,
+					updatedGroupList:    &metav1.APIGroupList{Groups: []metav1.APIGroup{*tt.updatedAPIGroup}},
+					updatedResourceList: tt.updatedResourceList,
+				},
+				apiGroups:   map[string]*metav1.APIGroup{},
+				knownGroups: map[string]*restmapper.APIGroupResources{},
+			}
+
+			// First call the mapper should return an error since the resource is not yet served
+			_, err := m.RESTMapping(tt.expectedKind)
+			g.Expect(err).To(gmg.HaveOccurred(), "expected error while CRD is not yet installed")
+			g.Expect(meta.IsNoMatchError(err)).To(gmg.BeTrue(), "expected NoMatchError, got: %v", err)
+
+			// Second call should be successful
+			mapping, err := m.RESTMapping(tt.expectedKind)
+			g.Expect(err).NotTo(gmg.HaveOccurred(), "expected CRD to be found once it is installed")
+			g.Expect(mapping.GroupVersionKind.Kind).To(gmg.Equal(tt.expectedKind.Kind))
+		})
+	}
+}
+
+type mockAggregatedDiscoveryClient struct {
+	discovery.DiscoveryInterface
+	initialized         bool
+	initialGroupList    *metav1.APIGroupList
+	initialResourceList map[schema.GroupVersion]*metav1.APIResourceList
+	updatedGroupList    *metav1.APIGroupList
+	updatedResourceList map[schema.GroupVersion]*metav1.APIResourceList
+	currentResourceList map[schema.GroupVersion]*metav1.APIResourceList
+}
+
+func (c *mockAggregatedDiscoveryClient) GroupsAndMaybeResources() (*metav1.APIGroupList, map[schema.GroupVersion]*metav1.APIResourceList, map[schema.GroupVersion]error, error) {
+	if !c.initialized {
+		c.initialized = true
+		c.currentResourceList = c.initialResourceList
+		return c.initialGroupList, c.initialResourceList, nil, nil
+	}
+	c.currentResourceList = c.updatedResourceList
+	return c.updatedGroupList, c.updatedResourceList, nil, nil
+}
+
+func (c *mockAggregatedDiscoveryClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	for gv, resources := range c.currentResourceList {
+		if gv.String() == groupVersion {
+			return resources, nil
+		}
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Group: groupVersion, Resource: ""}, "")
 }


### PR DESCRIPTION
restmapper's `findAPIGroupByNameAndMaybeAggregatedDiscoveryLocked` method can't rely on the apiGroups cache, otherwise new versions of a group will never be discovered when the client does not provide a group version while requesting a RESTMapping.

Fixes: https://github.com/kubernetes-sigs/controller-runtime/issues/3542