### PR TITLE
📖 webhook: clarify CertDir default

### DIFF
--- a/pkg/webhook/server.go
+++ b/pkg/webhook/server.go
@@ -77,8 +77,14 @@ type Options struct {
 	// It will be defaulted to 9443 if unspecified.
 	Port int
 
-	// CertDir is the directory that contains the server key and certificate. Defaults to
-	// <temp-dir>/k8s-webhook-server/serving-certs.
+	// CertDir is the directory that contains the server key and certificate.
+	// The server expects the files to be named CertName and KeyName (see
+	// below). If unset, CertDir defaults to
+	// <temp-dir>/k8s-webhook-server/serving-certs, where <temp-dir> comes
+	// from os.TempDir() (usually /tmp on Linux, but TMPDIR-dependent).
+	// Most operators should configure this explicitly (for example, to the
+	// cert directory mounted in by a Kubernetes Secret) rather than relying
+	// on the default.
 	CertDir string
 
 	// CertName is the server certificate name. Defaults to tls.crt.


### PR DESCRIPTION
Clarifies the godoc for `webhook.Options.CertDir`: it now documents that the key and certificate files are expected to be named `CertName`/`KeyName`, that the default location derives from `os.TempDir()` (so it is `TMPDIR`-dependent, not always `/tmp`), and that operators should usually set it explicitly rather than rely on the default.

Docs-only change, no behavior change.

Replaces #3500, which I accidentally closed with a bad force-push; the reopen button was disabled, so opening fresh as suggested there.
