### PR TITLE
🐛 fake: set deletionTimestamp on object passed to Delete

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1198,6 +1198,9 @@ func (c *fakeClient) deleteObjectLocked(gvr schema.GroupVersionResource, accesso
 			if len(oldAccessor.GetFinalizers()) > 0 {
 				now := metav1.Now()
 				oldAccessor.SetDeletionTimestamp(&now)
+				// Reflect onto the caller's object so Delete matches Create/Update/Get
+				// and apiserver responses when finalizers delay removal.
+				accessor.SetDeletionTimestamp(&now)
 				// Call update directly with mutability parameter set to true to allow
 				// changes to deletionTimestamp
 				return c.tracker.update(gvr, old, accessor.GetNamespace(), false, true, metav1.UpdateOptions{})

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -796,6 +796,21 @@ var _ = Describe("Fake client", func() {
 			Expect(apierrors.IsNotFound(err)).To(BeTrue())
 		})
 
+		It("should set deletionTimestamp on the object passed to Delete when finalizers are present", func(ctx SpecContext) {
+			obj := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cm",
+					Namespace:  "delete-updates-caller-object",
+					Finalizers: []string{"finalizers.sigs.k8s.io/test"},
+				},
+			}
+			Expect(cl.Create(ctx, obj)).To(Succeed())
+			Expect(obj.DeletionTimestamp).To(BeNil())
+
+			Expect(cl.Delete(ctx, obj)).To(Succeed())
+			Expect(obj.DeletionTimestamp).NotTo(BeNil())
+		})
+
 		It("should handle finalizers on Update", func(ctx SpecContext) {
 			namespacedName := types.NamespacedName{
 				Name:      "test-cm",
@@ -1211,15 +1226,11 @@ var _ = Describe("Fake client", func() {
 			By("Deleting the object")
 			err = cl.Delete(ctx, newObj)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(newObj.DeletionTimestamp).NotTo(BeNil())
 
 			By("Removing the finalizer")
-			obj := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:       namespacedName.Name,
-					Namespace:  namespacedName.Namespace,
-					Finalizers: []string{},
-				},
-			}
+			obj := newObj.DeepCopy()
+			obj.Finalizers = []string{}
 			err = cl.Patch(ctx, obj, client.MergeFrom(newObj))
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Summary
- When fake `Client.Delete` soft-deletes an object because finalizers remain, copy `deletionTimestamp` onto the caller's object (same pattern as Create/Update/Get).
- Add a unit test covering that behavior.
- Adjust the existing finalizers-on-Patch test so `MergeFrom` preserves the timestamp now present on the deleted object.

This addresses the **fake client** half of kubernetes-sigs/controller-runtime#3059. The issue was later broadened to also cover the real typed client (`.Error()` vs `.Into(obj)`); that part is **out of scope** here and can land as a follow-up (see previously stalled #3098).

## Test plan
- [x] `go test ./pkg/client/fake/`