### PR TITLE
📖predicate: clarify predicates don't reduce cache memory

### DIFF
--- a/pkg/predicate/predicate.go
+++ b/pkg/predicate/predicate.go
@@ -30,6 +30,9 @@ import (
 var log = logf.RuntimeLog.WithName("predicate").WithName("eventFilters")
 
 // Predicate filters events before enqueuing the keys.
+//
+// NOTE: This does not affect what the cache stores. That is configured via
+// cache.Options, which are global to all users of the cache.
 type Predicate = TypedPredicate[client.Object]
 
 // TypedPredicate filters events before enqueuing the keys.


### PR DESCRIPTION
Clarifies in the `Predicate` godoc that predicates only filter which events are enqueued for reconciliation — they do **not** reduce what the informer cache stores. Every watched object is still held in memory regardless of whether a predicate rejects its events.

Adds a short pointer to the mechanisms that actually bound cache memory for a Kind: a label/field selector (`cache.Options` / `cache.ByObject`), a `cache.ByObject` Transform, or `client.Options.Cache.DisableFor`.

This is a source of confusion (and OOMKills) for controllers watching Kinds with many or large objects, e.g. Secrets in a namespace that also holds large, unrelated objects.

Fixes #3552