### PR TITLE
:book: Fix "ratelimting" typo in GetConfig doc comments

### DIFF
--- a/alias.go
+++ b/alias.go
@@ -107,7 +107,7 @@ var (
 	// If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 	// in cluster and use the cluster provided kubeconfig.
 	//
-	// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+	// The returned `*rest.Config` has client-side rate limiting disabled as we can rely on API priority and
 	// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 	//
 	// Will log an error and exit if there is an error creating the rest.Config.
@@ -117,7 +117,7 @@ var (
 	// If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 	// in cluster and use the cluster provided kubeconfig.
 	//
-	// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+	// The returned `*rest.Config` has client-side rate limiting disabled as we can rely on API priority and
 	// fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 	//
 	// Config precedence

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -61,7 +61,7 @@ func RegisterFlags(fs *flag.FlagSet) {
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
 //
-// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// The returned `*rest.Config` has client-side rate limiting disabled as we can rely on API priority and
 // fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 //
 // Config precedence:
@@ -81,7 +81,7 @@ func GetConfig() (*rest.Config, error) {
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
 //
-// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// The returned `*rest.Config` has client-side rate limiting disabled as we can rely on API priority and
 // fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 //
 // Config precedence:
@@ -169,7 +169,7 @@ func loadConfigWithContext(apiServerURL string, loader clientcmd.ClientConfigLoa
 // If --kubeconfig is set, will use the kubeconfig file at that location.  Otherwise will assume running
 // in cluster and use the cluster provided kubeconfig.
 //
-// The returned `*rest.Config` has client-side ratelimting disabled as we can rely on API priority and
+// The returned `*rest.Config` has client-side rate limiting disabled as we can rely on API priority and
 // fairness. Set its QPS to a value equal or bigger than 0 to re-enable it.
 //
 // Will log an error and exit if there is an error creating the rest.Config.


### PR DESCRIPTION
Corrects the misspelling of "rate limiting" (written as "ratelimting") in the doc comments for `GetConfig`, `GetConfigOrDie`, and `GetConfigWithContext`, as well as their re-exported aliases in `alias.go`.

Documentation-only change; no functional impact.

**Which issue(s) this PR fixes:**
None — trivial typo fix.