### PR TITLE
🐛 Fix goroutine leaks in cache Start() methods

### DIFF
--- a/pkg/cache/defaulting_test.go
+++ b/pkg/cache/defaulting_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package cache
 
 import (
+	"context"
+	"errors"
 	"reflect"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	fuzz "github.com/google/gofuzz"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/fields"
@@ -516,4 +520,127 @@ func TestDefaultConfigConsidersAllFields(t *testing.T) {
 			t.Errorf("Defaulted config doesn't match fuzzed one: %s", diff)
 		}
 	}
+}
+
+// mockCache is a mock implementation of Cache for testing Start() behavior.
+type mockCache struct {
+	startFunc func(ctx context.Context) error
+	Cache
+}
+
+func (m *mockCache) Start(ctx context.Context) error {
+	if m.startFunc != nil {
+		return m.startFunc(ctx)
+	}
+	<-ctx.Done()
+	return nil
+}
+
+func TestMultiNamespaceCacheStart_MultipleErrors(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		g := NewWithT(t)
+
+		errTest := errors.New("test error")
+		namespaceToCache := map[string]Cache{
+			"ns1": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+			"ns2": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+			"ns3": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		}
+
+		c := &multiNamespaceCache{
+			namespaceToCache: namespaceToCache,
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		err := c.Start(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(errTest))
+	})
+}
+
+func TestMultiNamespaceCacheStart_ContextCancel(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		g := NewWithT(t)
+
+		normalCache := &mockCache{
+			startFunc: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		}
+
+		namespaceToCache := map[string]Cache{
+			"ns1": normalCache,
+			"ns2": normalCache,
+		}
+
+		c := &multiNamespaceCache{
+			namespaceToCache: namespaceToCache,
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // Cancel immediately
+
+		err := c.Start(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
+}
+
+func TestDelegatingByGVKCacheStart_MultipleErrors(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		g := NewWithT(t)
+
+		errTest := errors.New("test error")
+		caches := map[schema.GroupVersionKind]Cache{
+			{Group: "apps", Version: "v1", Kind: "Deployment"}:  &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+			{Group: "apps", Version: "v1", Kind: "StatefulSet"}: &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+			{Group: "apps", Version: "v1", Kind: "DaemonSet"}:   &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		}
+
+		c := &delegatingByGVKCache{
+			caches:       caches,
+			defaultCache: &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		}
+
+		ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancel()
+
+		err := c.Start(ctx)
+		g.Expect(err).To(HaveOccurred())
+		g.Expect(err).To(MatchError(errTest))
+	})
+}
+
+func TestDelegatingByGVKCacheStart_ContextCancel(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		g := NewWithT(t)
+
+		normalCache := &mockCache{
+			startFunc: func(ctx context.Context) error {
+				<-ctx.Done()
+				return nil
+			},
+		}
+
+		caches := map[schema.GroupVersionKind]Cache{
+			{Group: "apps", Version: "v1", Kind: "Deployment"}: normalCache,
+		}
+
+		c := &delegatingByGVKCache{
+			caches:       caches,
+			defaultCache: normalCache,
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // Cancel immediately
+
+		err := c.Start(ctx)
+		g.Expect(err).NotTo(HaveOccurred())
+	})
 }

--- a/pkg/cache/delegating_by_gvk_cache.go
+++ b/pkg/cache/delegating_by_gvk_cache.go
@@ -77,8 +77,10 @@ func (dbt *delegatingByGVKCache) Start(ctx context.Context) error {
 	allCaches := slices.Collect(maps.Values(dbt.caches))
 	allCaches = append(allCaches, dbt.defaultCache)
 
+	// Use a buffered channel to prevent goroutine leaks when multiple caches
+	// return errors simultaneously.
+	errs := make(chan error, len(allCaches))
 	wg := &sync.WaitGroup{}
-	errs := make(chan error)
 	for idx := range allCaches {
 		cache := allCaches[idx]
 		wg.Go(func() {
@@ -88,12 +90,36 @@ func (dbt *delegatingByGVKCache) Start(ctx context.Context) error {
 		})
 	}
 
-	select {
-	case err := <-errs:
-		return err
-	case <-ctx.Done():
+	// Wait for all goroutines to complete in a separate goroutine
+	done := make(chan struct{})
+	go func() {
 		wg.Wait()
-		return nil
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// All caches completed, check if any returned an error
+		select {
+		case err := <-errs:
+			return err
+		default:
+			return nil
+		}
+	case <-ctx.Done():
+		// Context cancelled, wait for goroutines to finish
+		<-done
+		// Return any error that was captured
+		select {
+		case err := <-errs:
+			return err
+		default:
+			return nil
+		}
+	case err := <-errs:
+		// First error returned, wait for other goroutines to finish
+		<-done
+		return err
 	}
 }
 

--- a/pkg/cache/delegating_by_gvk_cache.go
+++ b/pkg/cache/delegating_by_gvk_cache.go
@@ -21,8 +21,8 @@ import (
 	"maps"
 	"slices"
 	"strings"
-	"sync"
 
+	"golang.org/x/sync/errgroup"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -77,24 +77,15 @@ func (dbt *delegatingByGVKCache) Start(ctx context.Context) error {
 	allCaches := slices.Collect(maps.Values(dbt.caches))
 	allCaches = append(allCaches, dbt.defaultCache)
 
-	wg := &sync.WaitGroup{}
-	errs := make(chan error)
+	group, childCtx := errgroup.WithContext(ctx)
 	for idx := range allCaches {
 		cache := allCaches[idx]
-		wg.Go(func() {
-			if err := cache.Start(ctx); err != nil {
-				errs <- err
-			}
+		group.Go(func() error {
+			return cache.Start(childCtx)
 		})
 	}
 
-	select {
-	case err := <-errs:
-		return err
-	case <-ctx.Done():
-		wg.Wait()
-		return nil
-	}
+	return ignoreContextCanceled(group.Wait())
 }
 
 func (dbt *delegatingByGVKCache) WaitForCacheSync(ctx context.Context) bool {

--- a/pkg/cache/goroutine_leak_test.go
+++ b/pkg/cache/goroutine_leak_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/goleak"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// mockCache is a mock implementation of Cache for testing
+type mockCache struct {
+	startFunc func(ctx context.Context) error
+}
+
+func (m *mockCache) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	return nil
+}
+func (m *mockCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+func (m *mockCache) GetInformer(ctx context.Context, obj client.Object, opts ...InformerGetOption) (Informer, error) {
+	return nil, nil
+}
+func (m *mockCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind, opts ...InformerGetOption) (Informer, error) {
+	return nil, nil
+}
+func (m *mockCache) RemoveInformer(ctx context.Context, obj client.Object) error {
+	return nil
+}
+func (m *mockCache) Start(ctx context.Context) error {
+	if m.startFunc != nil {
+		return m.startFunc(ctx)
+	}
+	<-ctx.Done()
+	return nil
+}
+func (m *mockCache) WaitForCacheSync(ctx context.Context) bool {
+	return true
+}
+func (m *mockCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	return nil
+}
+
+// TestMultiNamespaceCacheStart_GoroutineLeak_MultipleErrors tests that goroutines
+// don't leak when multiple caches return errors simultaneously
+func TestMultiNamespaceCacheStart_GoroutineLeak_MultipleErrors(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Create a multiNamespaceCache with multiple caches that all return errors
+	errTest := errors.New("test error")
+	namespaceToCache := map[string]Cache{
+		"ns1": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		"ns2": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		"ns3": &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+	}
+
+	c := &multiNamespaceCache{
+		namespaceToCache: namespaceToCache,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	// Start should return an error
+	err := c.Start(ctx)
+	if err == nil {
+		t.Fatal("expected error from Start(), got nil")
+	}
+
+	// Give time for goroutines to leak if they will
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestMultiNamespaceCacheStart_GoroutineLeak_ContextCancelWithError tests that
+// goroutines don't leak when context is cancelled while a cache returns an error
+func TestMultiNamespaceCacheStart_GoroutineLeak_ContextCancelWithError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	// Create caches where one returns error slowly, others wait for context
+	var wg sync.WaitGroup
+	slowCacheStarted := make(chan struct{})
+
+	slowCache := &mockCache{
+		startFunc: func(ctx context.Context) error {
+			close(slowCacheStarted)
+			// Wait a bit then return error
+			time.Sleep(30 * time.Millisecond)
+			return errors.New("slow error")
+		},
+	}
+
+	normalCache := &mockCache{
+		startFunc: func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	namespaceToCache := map[string]Cache{
+		"ns1": slowCache,
+		"ns2": normalCache,
+		"ns3": normalCache,
+	}
+
+	c := &multiNamespaceCache{
+		namespaceToCache: namespaceToCache,
+	}
+
+	// Use a short timeout to trigger context cancellation
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	wg.Go(func() {
+		_ = c.Start(ctx)
+	})
+
+	// Wait for slow cache to start
+	<-slowCacheStarted
+
+	// Wait for Start to return
+	wg.Wait()
+
+	// Give time for goroutines to leak if they will
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestDelegatingByGVKCacheStart_GoroutineLeak_MultipleErrors tests that goroutines
+// don't leak when multiple caches return errors simultaneously
+func TestDelegatingByGVKCacheStart_GoroutineLeak_MultipleErrors(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	errTest := errors.New("test error")
+	caches := map[schema.GroupVersionKind]Cache{
+		{Group: "apps", Version: "v1", Kind: "Deployment"}:  &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"}: &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+		{Group: "apps", Version: "v1", Kind: "DaemonSet"}:   &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+	}
+
+	c := &delegatingByGVKCache{
+		caches:       caches,
+		defaultCache: &mockCache{startFunc: func(ctx context.Context) error { return errTest }},
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	err := c.Start(ctx)
+	if err == nil {
+		t.Fatal("expected error from Start(), got nil")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestDelegatingByGVKCacheStart_GoroutineLeak_ContextCancelWithError tests the
+// specific case where wg.Wait() can deadlock
+func TestDelegatingByGVKCacheStart_GoroutineLeak_ContextCancelWithError(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	slowCacheStarted := make(chan struct{})
+	slowCache := &mockCache{
+		startFunc: func(ctx context.Context) error {
+			close(slowCacheStarted)
+			time.Sleep(30 * time.Millisecond)
+			return errors.New("slow error")
+		},
+	}
+
+	normalCache := &mockCache{
+		startFunc: func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	caches := map[schema.GroupVersionKind]Cache{
+		{Group: "apps", Version: "v1", Kind: "Deployment"}:  slowCache,
+		{Group: "apps", Version: "v1", Kind: "StatefulSet"}: normalCache,
+	}
+
+	c := &delegatingByGVKCache{
+		caches:       caches,
+		defaultCache: normalCache,
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_ = c.Start(ctx)
+		close(done)
+	}()
+
+	<-slowCacheStarted
+
+	// Wait for Start to return with timeout
+	select {
+	case <-done:
+		// Good, Start returned
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Start() deadlocked - wg.Wait() is blocking on leaked goroutines")
+	}
+
+	time.Sleep(50 * time.Millisecond)
+}

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -160,29 +161,63 @@ func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema
 }
 
 func (c *multiNamespaceCache) Start(ctx context.Context) error {
-	errs := make(chan error)
+	// Use a buffered channel to prevent goroutine leaks when multiple caches
+	// return errors simultaneously or when context is cancelled.
+	numCaches := len(c.namespaceToCache)
+	if c.clusterCache != nil {
+		numCaches++
+	}
+	errs := make(chan error, numCaches)
+
+	var wg sync.WaitGroup
+
 	// start global cache
 	if c.clusterCache != nil {
-		go func() {
-			err := c.clusterCache.Start(ctx)
-			if err != nil {
+		wg.Go(func() {
+			if err := c.clusterCache.Start(ctx); err != nil {
 				errs <- fmt.Errorf("failed to start cluster-scoped cache: %w", err)
 			}
-		}()
+		})
 	}
 
 	// start namespaced caches
 	for ns, cache := range c.namespaceToCache {
-		go func(ns string, cache Cache) {
+		wg.Go(func() {
 			if err := cache.Start(ctx); err != nil {
 				errs <- fmt.Errorf("failed to start cache for namespace %s: %w", ns, err)
 			}
-		}(ns, cache)
+		})
 	}
+
+	// Wait for all goroutines to complete in a separate goroutine
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
 	select {
+	case <-done:
+		// All caches completed, check if any returned an error
+		select {
+		case err := <-errs:
+			return err
+		default:
+			return nil
+		}
 	case <-ctx.Done():
-		return nil
+		// Context cancelled, wait for goroutines to finish
+		<-done
+		// Return any error that was captured
+		select {
+		case err := <-errs:
+			return err
+		default:
+			return nil
+		}
 	case err := <-errs:
+		// First error returned, wait for other goroutines to finish
+		<-done
 		return err
 	}
 }

--- a/pkg/cache/multi_namespace_cache.go
+++ b/pkg/cache/multi_namespace_cache.go
@@ -18,10 +18,12 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -160,31 +162,34 @@ func (c *multiNamespaceCache) GetInformerForKind(ctx context.Context, gvk schema
 }
 
 func (c *multiNamespaceCache) Start(ctx context.Context) error {
-	errs := make(chan error)
-	// start global cache
+	group, childCtx := errgroup.WithContext(ctx)
+
 	if c.clusterCache != nil {
-		go func() {
-			err := c.clusterCache.Start(ctx)
-			if err != nil {
-				errs <- fmt.Errorf("failed to start cluster-scoped cache: %w", err)
-			}
-		}()
+		clusterCache := c.clusterCache
+		group.Go(func() error {
+			return clusterCache.Start(childCtx)
+		})
 	}
 
-	// start namespaced caches
 	for ns, cache := range c.namespaceToCache {
-		go func(ns string, cache Cache) {
-			if err := cache.Start(ctx); err != nil {
-				errs <- fmt.Errorf("failed to start cache for namespace %s: %w", ns, err)
+		group.Go(func() error {
+			if err := cache.Start(childCtx); err != nil {
+				return fmt.Errorf("failed to start cache for namespace %s: %w", ns, err)
 			}
-		}(ns, cache)
+			return nil
+		})
 	}
-	select {
-	case <-ctx.Done():
+
+	return ignoreContextCanceled(group.Wait())
+}
+
+// ignoreContextCanceled returns nil if the error is a context.Canceled error,
+// otherwise returns the error unchanged.
+func ignoreContextCanceled(err error) error {
+	if errors.Is(err, context.Canceled) {
 		return nil
-	case err := <-errs:
-		return err
 	}
+	return err
 }
 
 func (c *multiNamespaceCache) WaitForCacheSync(ctx context.Context) bool {


### PR DESCRIPTION
## What does this PR do?

This PR fixes goroutine leaks in `multiNamespaceCache.Start()` and `delegatingByGVKCache.Start()` methods in the `pkg/cache` package.

## Why do we need it?

### Problem

Both `Start()` methods used unbuffered error channels (`errs := make(chan error)`) to collect errors from goroutines. This caused goroutine leaks in two scenarios:

1. **Multiple caches return errors simultaneously**: The `select` statement only receives the first error and returns, leaving other goroutines blocked forever on `errs <- err` with no receiver.

2. **Context cancelled while goroutines try to send errors**: When `ctx.Done()` triggers first, the function returns immediately. Any subsequent error sends from goroutines will block forever.

### Example

```go
// Original problematic code
errs := make(chan error)  // unbuffered
for _, cache := range caches {
    go func() {
        if err := cache.Start(ctx); err != nil {
            errs <- err  // blocks forever if no receiver!
        }
    }()
}
select {
case err := <-errs:
    return err  // only receives ONE error, others leak
case <-ctx.Done():
    return nil  // returns immediately, senders leak
}
```

### Fix

- Use buffered channels sized to the number of caches
- Use `sync.WaitGroup` to track all goroutines
- Wait for all goroutines to complete before returning

```go
// Fixed code
errs := make(chan error, len(caches))  // buffered
var wg sync.WaitGroup
for _, cache := range caches {
    wg.Go(func() {
        if err := cache.Start(ctx); err != nil {
            errs <- err  // never blocks
        }
    })
}
done := make(chan struct{})
go func() { wg.Wait(); close(done) }()
// ... wait for all goroutines to complete
```