### PR TITLE
:sparkles: Fakeclient: Add scale subresource support for Apply

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1331,10 +1331,6 @@ func (sw *fakeSubResourceClient) statusPatch(body client.Object, patch client.Pa
 }
 
 func (sw *fakeSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.SubResourceApplyOption) error {
-	if sw.subResource != "status" {
-		return errors.New("fakeSubResourceClient currently only supports Apply for status subresource")
-	}
-
 	applyOpts := &client.SubResourceApplyOptions{}
 	applyOpts.ApplyOpts(opts)
 
@@ -1348,22 +1344,58 @@ func (sw *fakeSubResourceClient) Apply(ctx context.Context, obj runtime.ApplyCon
 		return fmt.Errorf("failed to unmarshal apply configuration: %w", err)
 	}
 
-	patchOpts := &client.SubResourcePatchOptions{}
-	patchOpts.Raw = applyOpts.AsPatchOptions()
-
-	if applyOpts.SubResourceBody != nil {
+	switch sw.subResource {
+	case subResourceScale:
+		if applyOpts.SubResourceBody == nil {
+			return apierrors.NewBadRequest("missing SubResourceBody")
+		}
 		subResourceBodySerialized, err := json.Marshal(applyOpts.SubResourceBody)
 		if err != nil {
 			return fmt.Errorf("failed to serialize subresource body: %w", err)
 		}
-		subResourceBody := &unstructured.Unstructured{}
-		if err := json.Unmarshal(subResourceBodySerialized, subResourceBody); err != nil {
+		scale := &autoscalingv1.Scale{}
+		if err := json.Unmarshal(subResourceBodySerialized, scale); err != nil {
 			return fmt.Errorf("failed to unmarshal subresource body: %w", err)
 		}
-		patchOpts.SubResourceBody = subResourceBody
-	}
 
-	return sw.Patch(ctx, u, &fakeApplyPatch{}, patchOpts)
+		sw.client.schemeLock.RLock()
+		target, err := sw.client.scheme.New(u.GroupVersionKind())
+		sw.client.schemeLock.RUnlock()
+		if err != nil {
+			return err
+		}
+		targetObj, isObject := target.(client.Object)
+		if !isObject {
+			return fmt.Errorf("%T is not a client.Object", target)
+		}
+
+		if err := sw.client.Get(ctx, client.ObjectKeyFromObject(u), targetObj); err != nil {
+			return err
+		}
+		if err := applyScale(targetObj, scale); err != nil {
+			return err
+		}
+		return sw.client.update(targetObj, false, &client.UpdateOptions{FieldManager: applyOpts.FieldManager})
+	case "status":
+		patchOpts := &client.SubResourcePatchOptions{}
+		patchOpts.Raw = applyOpts.AsPatchOptions()
+
+		if applyOpts.SubResourceBody != nil {
+			subResourceBodySerialized, err := json.Marshal(applyOpts.SubResourceBody)
+			if err != nil {
+				return fmt.Errorf("failed to serialize subresource body: %w", err)
+			}
+			subResourceBody := &unstructured.Unstructured{}
+			if err := json.Unmarshal(subResourceBodySerialized, subResourceBody); err != nil {
+				return fmt.Errorf("failed to unmarshal subresource body: %w", err)
+			}
+			patchOpts.SubResourceBody = subResourceBody
+		}
+
+		return sw.Patch(ctx, u, &fakeApplyPatch{}, patchOpts)
+	default:
+		return errors.New("fakeSubResourceClient currently only supports Apply for status and scale subresource")
+	}
 }
 
 func allowsUnconditionalUpdate(gvk schema.GroupVersionKind) bool {

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/watch"
 	clientgoapplyconfigurations "k8s.io/client-go/applyconfigurations"
+	autoscalingv1applyconfigurations "k8s.io/client-go/applyconfigurations/autoscaling/v1"
 	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -2625,6 +2626,9 @@ var _ = Describe("Fake client", func() {
 		expectedErr := "unimplemented scale subresource for resource *v1.Pod"
 		Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scale).Error()).To(Equal(expectedErr))
 		Expect(cl.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Apply(ctx, applyConfigurationFor(cl, obj), client.FieldOwner("test"), &client.SubResourceApplyOptions{
+			SubResourceBody: autoscalingv1applyconfigurations.Scale().WithSpec(autoscalingv1applyconfigurations.ScaleSpec().WithReplicas(2)),
+		}).Error()).To(Equal(expectedErr))
 	})
 	It("supports scale subresources on unstructured objects with spec.replicas", func(ctx SpecContext) {
 		obj := &unstructured.Unstructured{Object: map[string]any{
@@ -2745,6 +2749,9 @@ var _ = Describe("Fake client", func() {
 		expectedErr := "deployments.apps \"foo\" not found"
 		Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scale).Error()).To(Equal(expectedErr))
 		Expect(cl.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scale)).Error()).To(Equal(expectedErr))
+		Expect(cl.SubResource(subResourceScale).Apply(ctx, applyConfigurationFor(cl, obj), client.FieldOwner("test"), &client.SubResourceApplyOptions{
+			SubResourceBody: autoscalingv1applyconfigurations.Scale().WithSpec(autoscalingv1applyconfigurations.ScaleSpec().WithReplicas(2)),
+		}).Error()).To(Equal(expectedErr))
 	})
 
 	It("clears typemeta from structured objects on create", func(ctx SpecContext) {
@@ -3560,8 +3567,57 @@ var _ = Describe("Fake client", func() {
 			Expect(cmp.Diff(scaleExpected, scaleActual)).To(BeEmpty())
 		})
 
+		It(fmt.Sprintf("should be able to Apply scale subresources for resource %T", obj), func(ctx SpecContext) {
+			cl := NewClientBuilder().WithObjects(obj).Build()
+
+			scale := autoscalingv1applyconfigurations.Scale().
+				WithSpec(autoscalingv1applyconfigurations.ScaleSpec().WithReplicas(3))
+			Expect(cl.SubResource(subResourceScale).Apply(ctx,
+				applyConfigurationFor(cl, obj),
+				client.FieldOwner("test"),
+				&client.SubResourceApplyOptions{
+					SubResourceBody: scale,
+				},
+			)).To(Succeed())
+
+			objActual := obj.DeepCopyObject().(client.Object)
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(objActual), objActual)).To(Succeed())
+
+			objExpected := obj.DeepCopyObject().(client.Object)
+			switch expected := objExpected.(type) {
+			case *appsv1.Deployment:
+				expected.ResourceVersion = objActual.GetResourceVersion()
+				expected.Spec.Replicas = new(int32(3))
+			case *appsv1.ReplicaSet:
+				expected.ResourceVersion = objActual.GetResourceVersion()
+				expected.Spec.Replicas = new(int32(3))
+			case *corev1.ReplicationController:
+				expected.ResourceVersion = objActual.GetResourceVersion()
+				expected.Spec.Replicas = new(int32(3))
+			case *appsv1.StatefulSet:
+				expected.ResourceVersion = objActual.GetResourceVersion()
+				expected.Spec.Replicas = new(int32(3))
+			}
+			Expect(cmp.Diff(objExpected, objActual)).To(BeEmpty())
+
+			scaleActual := &autoscalingv1.Scale{}
+			Expect(cl.SubResource(subResourceScale).Get(ctx, obj, scaleActual)).NotTo(HaveOccurred())
+			Expect(scaleActual.Spec.Replicas).To(Equal(int32(3)))
+		})
 	}
 })
+
+func applyConfigurationFor(cl client.Client, obj client.Object) runtime.ApplyConfiguration {
+	gvk, err := cl.GroupVersionKindFor(obj)
+	Expect(err).NotTo(HaveOccurred())
+
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(gvk)
+	u.SetName(obj.GetName())
+	u.SetNamespace(obj.GetNamespace())
+
+	return client.ApplyConfigurationFromUnstructured(u)
+}
 
 type Schemaless map[string]any
 


### PR DESCRIPTION
This change adds support for the scale subresource in the fake clients apply.

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->

/assign @sbueringer 
