### PR TITLE
:bug: Fakeclient: Fix PartialObjectMeta handling

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -343,14 +343,15 @@ func (f *ClientBuilder) Build() client.WithWatch {
 
 const trackerAddResourceVersion = "999"
 
-// convertFromUnstructuredIfNecessary will convert runtime.Unstructured for a GVK that is recognized
-// by the schema into the whatever the schema produces with New() for said GVK.
+// convertFromUnstructuredOrPartialObjectMetaIfNecessary will convert runtime.Unstructured or metav1.PartialObjectMetadata
+// for a GVK that is recognized by the schema into the whatever the schema produces with New() for said GVK.
 // This is required because the tracker unconditionally saves on manipulations, but its List() implementation
 // tries to assign whatever it finds into a ListType it gets from schema.New() - Thus we have to ensure
 // we save as the very same type, otherwise subsequent List requests will fail.
-func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
-	u, isUnstructured := o.(runtime.Unstructured)
-	if !isUnstructured {
+func convertFromUnstructuredOrPartialObjectMetaIfNecessary(s *runtime.Scheme, o runtime.Object) (runtime.Object, error) {
+	_, isUnstructured := o.(runtime.Unstructured)
+	_, isPartial := o.(*metav1.PartialObjectMetadata)
+	if !isUnstructured && !isPartial {
 		return o, nil
 	}
 	gvk := o.GetObjectKind().GroupVersionKind()
@@ -362,16 +363,17 @@ func convertFromUnstructuredIfNecessary(s *runtime.Scheme, o runtime.Object) (ru
 	if err != nil {
 		return nil, fmt.Errorf("scheme recognizes %s but failed to produce an object for it: %w", gvk, err)
 	}
-	if _, isTypedUnstructured := typed.(runtime.Unstructured); isTypedUnstructured {
+	switch typed.(type) {
+	case runtime.Unstructured, *metav1.PartialObjectMetadata:
 		return o, nil
 	}
 
-	unstructuredSerialized, err := json.Marshal(u)
+	serialized, err := json.Marshal(o)
 	if err != nil {
-		return nil, fmt.Errorf("failed to serialize %T: %w", unstructuredSerialized, err)
+		return nil, fmt.Errorf("failed to serialize %T: %w", o, err)
 	}
-	if err := json.Unmarshal(unstructuredSerialized, typed); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", u, typed, err)
+	if err := json.Unmarshal(serialized, typed); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal the content of %T into %T: %w", o, typed, err)
 	}
 
 	return typed, nil

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Fake client", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should be able to Get an unregisted type using unstructured", func(ctx SpecContext) {
+		It("should be able to Get an unregistered type using unstructured", func(ctx SpecContext) {
 			By("Creating an object of an unregistered type")
 			item := &unstructured.Unstructured{}
 			item.SetAPIVersion("custom/v2")
@@ -370,6 +370,110 @@ var _ = Describe("Fake client", func() {
 
 			Expect(partialObjMeta.Kind).To(Equal("Secret"))
 			Expect(partialObjMeta.APIVersion).To(Equal("v1"))
+		})
+
+		It("should be able to Get an unregistered type using PartialObjectMetadata", func(ctx SpecContext) {
+			By("Creating an object of an unregistered type")
+			item := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v9", Kind: "Image"},
+			}
+			err := cl.Create(ctx, item)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting and the object")
+			item = &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v9", Kind: "Image"},
+			}
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should be able to List an unregistered type using PartialObjectMetadata with ListKind", func(ctx SpecContext) {
+			list := &metav1.PartialObjectMetadataList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "custom/v10", Kind: "ImageList"},
+			}
+			err := cl.List(ctx, list)
+			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("custom/v10"))
+			Expect(list.Kind).To(Equal("ImageList"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should be able to List an unregistered type using PartialObjectMetadata with Kind", func(ctx SpecContext) {
+			list := &metav1.PartialObjectMetadataList{
+				TypeMeta: metav1.TypeMeta{APIVersion: "custom/v11", Kind: "Image"},
+			}
+			err := cl.List(ctx, list)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(list.GroupVersionKind().GroupVersion().String()).To(Equal("custom/v11"))
+			Expect(list.Kind).To(Equal("Image"))
+		})
+
+		It("should be able to Patch an unregistered type using PartialObjectMetadata", func(ctx SpecContext) {
+			By("Creating an object of an unregistered type")
+			item := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v13", Kind: "Image"},
+			}
+			err := cl.Create(ctx, item)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Updating the object")
+			original := item.DeepCopy()
+			item.Annotations = map[string]string{"foo": "bar"}
+			err = cl.Patch(ctx, item, client.MergeFrom(original))
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the object")
+			item = &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v13", Kind: "Image"},
+			}
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Inspecting the object")
+			Expect(item.Annotations).To(Equal(map[string]string{"foo": "bar"}))
+		})
+
+		It("should be able to Delete an unregistered type using PartialObjectMetadata", func(ctx SpecContext) {
+			By("Creating an object of an unregistered type")
+			item := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v14", Kind: "Image"},
+			}
+			err := cl.Create(ctx, item)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Deleting the object")
+			err = cl.Delete(ctx, item)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Getting the object")
+			item = &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v14", Kind: "Image"},
+			}
+			err = cl.Get(ctx, client.ObjectKeyFromObject(item), item)
+			Expect(apierrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("should be able to Get an unregistered type that was initialized using PartialObjectMetadata", func(ctx SpecContext) {
+			By("Initializing the client with an object of an unregistered type")
+			item := &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v15", Kind: "Image"},
+			}
+			cl := NewClientBuilder().WithScheme(runtime.NewScheme()).WithObjects(item).Build()
+
+			By("Getting the object")
+			item = &metav1.PartialObjectMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-item"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: "custom/v15", Kind: "Image"},
+			}
+			err := cl.Get(ctx, client.ObjectKeyFromObject(item), item)
+			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should support filtering by labels and their values", func(ctx SpecContext) {

--- a/pkg/client/fake/versioned_tracker.go
+++ b/pkg/client/fake/versioned_tracker.go
@@ -73,7 +73,7 @@ func (t versionedTracker) Add(obj runtime.Object) error {
 			accessor.SetResourceVersion(trackerAddResourceVersion)
 		}
 
-		obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+		obj, err = convertFromUnstructuredOrPartialObjectMetaIfNecessary(t.scheme, obj)
 		if err != nil {
 			return err
 		}
@@ -87,6 +87,18 @@ func (t versionedTracker) Add(obj runtime.Object) error {
 				return fmt.Errorf("invalid managedFields on %T: %w", obj, err)
 			}
 		}
+		// The trackers add panics when using PartialObjectMetadata without registering it to
+		// the scheme.
+		if _, isPartial := obj.(*metav1.PartialObjectMetadata); isPartial {
+			gvk, err := apiutil.GVKForObject(obj, t.scheme)
+			if err != nil {
+				return fmt.Errorf("failed to get gvk for %T: %w", obj, err)
+			}
+			if !t.scheme.Recognizes(gvk) {
+				t.scheme.AddKnownTypeWithName(gvk, obj)
+			}
+		}
+
 		if err := t.upstream.Add(obj); err != nil {
 			return err
 		}
@@ -111,7 +123,7 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
 	}
 	accessor.SetResourceVersion("1")
-	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	obj, err = convertFromUnstructuredOrPartialObjectMetaIfNecessary(t.scheme, obj)
 	if err != nil {
 		return err
 	}
@@ -301,7 +313,7 @@ func (t versionedTracker) updateObject(
 		return nil, false, t.Delete(gvr, accessor.GetNamespace(), accessor.GetName(), metav1.DeleteOptions{DryRun: dryRun})
 	}
 
-	obj, err = convertFromUnstructuredIfNecessary(t.scheme, obj)
+	obj, err = convertFromUnstructuredOrPartialObjectMetaIfNecessary(t.scheme, obj)
 	return obj, false, err
 }
 


### PR DESCRIPTION
Prior to this, it would:
* Panic when getting a PartialObjectMeta in the builder
* Panic when listing a type known to the scheme where we added objects as PartialObjectMeta

/assign @sbueringer 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
