### PR TITLE
:sparkles: Allow overriding REST client latency histogram buckets

### DIFF
--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -36,6 +36,25 @@ const (
 	verbLabel = "verb"
 )
 
+// defaultRESTClientDurationBuckets matches Kubernetes core controller REST client metrics.
+// They start at 5ms; override via RESTClientMetricsOptions.DurationBuckets if a scrape
+// pipeline still consumes classic buckets and needs sub-5ms resolution.
+var defaultRESTClientDurationBuckets = []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0}
+
+func restClientDurationHistogram(name, help string, labels []string, buckets []float64) *prometheus.HistogramVec {
+	if len(buckets) == 0 {
+		buckets = defaultRESTClientDurationBuckets
+	}
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name:                            name,
+		Help:                            help,
+		Buckets:                         buckets,
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  100,
+		NativeHistogramMinResetDuration: 1 * time.Hour,
+	}, labels)
+}
+
 var (
 	// client metrics.
 
@@ -47,28 +66,18 @@ var (
 		[]string{"code", "method", hostLabel},
 	)
 
-	requestLatency = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:                            "rest_client_request_duration_seconds",
-			Help:                            "Request latency in seconds. Broken down by verb and host.",
-			Buckets:                         []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-		},
+	requestLatency = restClientDurationHistogram(
+		"rest_client_request_duration_seconds",
+		"Request latency in seconds. Broken down by verb and host.",
 		[]string{verbLabel, hostLabel},
+		nil,
 	)
 
-	resolverLatency = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:                            "rest_client_dns_resolution_duration_seconds",
-			Help:                            "DNS resolver latency in seconds. Broken down by host.",
-			Buckets:                         []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-		},
+	resolverLatency = restClientDurationHistogram(
+		"rest_client_dns_resolution_duration_seconds",
+		"DNS resolver latency in seconds. Broken down by host.",
 		[]string{hostLabel},
+		nil,
 	)
 
 	requestSize = prometheus.NewHistogramVec(
@@ -97,16 +106,11 @@ var (
 		[]string{verbLabel, hostLabel},
 	)
 
-	rateLimiterLatency = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name:                            "rest_client_rate_limiter_duration_seconds",
-			Help:                            "Client side rate limiter latency in seconds. Broken down by verb, and host.",
-			Buckets:                         []float64{0.005, 0.025, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0, 15.0, 30.0, 60.0},
-			NativeHistogramBucketFactor:     1.1,
-			NativeHistogramMaxBucketNumber:  100,
-			NativeHistogramMinResetDuration: 1 * time.Hour,
-		},
+	rateLimiterLatency = restClientDurationHistogram(
+		"rest_client_rate_limiter_duration_seconds",
+		"Client side rate limiter latency in seconds. Broken down by verb, and host.",
 		[]string{verbLabel, hostLabel},
+		nil,
 	)
 
 	requestRetry = prometheus.NewCounterVec(
@@ -164,18 +168,78 @@ func registerClientMetrics() {
 
 	// register the metrics with client-go
 	clientmetrics.Register(clientmetrics.RegisterOpts{
-		RequestResult:      &resultAdapter{metric: requestResult},
-		RequestLatency:     &latencyAdapter{metric: requestLatency, enabled: &requestLatencyEnabled},
-		ResolverLatency:    &resolverLatencyAdapter{metric: resolverLatency, enabled: &resolverLatencyEnabled},
-		RequestSize:        &sizeAdapter{metric: requestSize, enabled: &requestSizeEnabled},
-		ResponseSize:       &sizeAdapter{metric: responseSize, enabled: &responseSizeEnabled},
-		RateLimiterLatency: &latencyAdapter{metric: rateLimiterLatency, enabled: &rateLimiterLatencyEnabled},
-		RequestRetry:       &retryAdapter{metric: requestRetry, enabled: &requestRetryEnabled},
+		RequestResult: &resultAdapter{metric: requestResult},
+		RequestLatency: &latencyAdapter{
+			metric:  func() *prometheus.HistogramVec { return requestLatency },
+			enabled: &requestLatencyEnabled,
+		},
+		ResolverLatency: &resolverLatencyAdapter{
+			metric:  func() *prometheus.HistogramVec { return resolverLatency },
+			enabled: &resolverLatencyEnabled,
+		},
+		RequestSize:  &sizeAdapter{metric: requestSize, enabled: &requestSizeEnabled},
+		ResponseSize: &sizeAdapter{metric: responseSize, enabled: &responseSizeEnabled},
+		RateLimiterLatency: &latencyAdapter{
+			metric:  func() *prometheus.HistogramVec { return rateLimiterLatency },
+			enabled: &rateLimiterLatencyEnabled,
+		},
+		RequestRetry: &retryAdapter{metric: requestRetry, enabled: &requestRetryEnabled},
 	})
 }
 
-// RegisterRESTClientMetrics enables the client metrics.
+// RESTClientMetricsOptions configures RegisterRESTClientMetricsWithOptions.
+type RESTClientMetricsOptions struct {
+	// DurationBuckets overrides the classic Prometheus histogram buckets used by
+	// rest_client_request_duration_seconds, rest_client_dns_resolution_duration_seconds,
+	// and rest_client_rate_limiter_duration_seconds.
+	//
+	// If nil or empty, the Kubernetes-default buckets are kept (starting at 5ms).
+	// Native histogram settings are not changed.
+	//
+	// Options are applied on the first RegisterRESTClientMetrics /
+	// RegisterRESTClientMetricsWithOptions call. Later calls ignore a different
+	// DurationBuckets value so already-registered collectors are not replaced.
+	DurationBuckets []float64
+}
+
+var applyDurationBucketsOnce sync.Once
+
+func applyDurationBuckets(buckets []float64) {
+	applyDurationBucketsOnce.Do(func() {
+		if len(buckets) == 0 {
+			return
+		}
+		requestLatency = restClientDurationHistogram(
+			"rest_client_request_duration_seconds",
+			"Request latency in seconds. Broken down by verb and host.",
+			[]string{verbLabel, hostLabel},
+			buckets,
+		)
+		resolverLatency = restClientDurationHistogram(
+			"rest_client_dns_resolution_duration_seconds",
+			"DNS resolver latency in seconds. Broken down by host.",
+			[]string{hostLabel},
+			buckets,
+		)
+		rateLimiterLatency = restClientDurationHistogram(
+			"rest_client_rate_limiter_duration_seconds",
+			"Client side rate limiter latency in seconds. Broken down by verb, and host.",
+			[]string{verbLabel, hostLabel},
+			buckets,
+		)
+	})
+}
+
+// RegisterRESTClientMetrics enables the given client metrics using default buckets
+// that match Kubernetes core controllers.
 func RegisterRESTClientMetrics(metrics ...RESTClientMetric) {
+	RegisterRESTClientMetricsWithOptions(RESTClientMetricsOptions{}, metrics...)
+}
+
+// RegisterRESTClientMetricsWithOptions enables the given client metrics.
+// See RESTClientMetricsOptions for knobs such as custom duration buckets.
+func RegisterRESTClientMetricsWithOptions(opts RESTClientMetricsOptions, metrics ...RESTClientMetric) {
+	applyDurationBuckets(opts.DurationBuckets)
 	for _, m := range metrics {
 		switch m {
 		case MetricRequestLatency:
@@ -231,7 +295,7 @@ func (r *resultAdapter) Increment(_ context.Context, code, method, host string) 
 }
 
 type latencyAdapter struct {
-	metric  *prometheus.HistogramVec
+	metric  func() *prometheus.HistogramVec
 	enabled *atomic.Bool
 }
 
@@ -239,11 +303,11 @@ func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, dura
 	if !l.enabled.Load() {
 		return
 	}
-	l.metric.WithLabelValues(verb, u.Host).Observe(duration.Seconds())
+	l.metric().WithLabelValues(verb, u.Host).Observe(duration.Seconds())
 }
 
 type resolverLatencyAdapter struct {
-	metric  *prometheus.HistogramVec
+	metric  func() *prometheus.HistogramVec
 	enabled *atomic.Bool
 }
 
@@ -251,7 +315,7 @@ func (r *resolverLatencyAdapter) Observe(_ context.Context, host string, duratio
 	if !r.enabled.Load() {
 		return
 	}
-	r.metric.WithLabelValues(host).Observe(duration.Seconds())
+	r.metric().WithLabelValues(host).Observe(duration.Seconds())
 }
 
 type sizeAdapter struct {

--- a/pkg/metrics/client_go_adapter.go
+++ b/pkg/metrics/client_go_adapter.go
@@ -55,32 +55,35 @@ func restClientDurationHistogram(name, help string, labels []string, buckets []f
 	}, labels)
 }
 
-var (
-	// client metrics.
-
-	requestResult = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "rest_client_requests_total",
-			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
-		},
-		[]string{"code", "method", hostLabel},
-	)
-
-	requestLatency = restClientDurationHistogram(
+func newRequestLatency(buckets []float64) *prometheus.HistogramVec {
+	return restClientDurationHistogram(
 		"rest_client_request_duration_seconds",
 		"Request latency in seconds. Broken down by verb and host.",
 		[]string{verbLabel, hostLabel},
-		nil,
+		buckets,
 	)
+}
 
-	resolverLatency = restClientDurationHistogram(
+func newResolverLatency(buckets []float64) *prometheus.HistogramVec {
+	return restClientDurationHistogram(
 		"rest_client_dns_resolution_duration_seconds",
 		"DNS resolver latency in seconds. Broken down by host.",
 		[]string{hostLabel},
-		nil,
+		buckets,
 	)
+}
 
-	requestSize = prometheus.NewHistogramVec(
+func newRateLimiterLatency(buckets []float64) *prometheus.HistogramVec {
+	return restClientDurationHistogram(
+		"rest_client_rate_limiter_duration_seconds",
+		"Client side rate limiter latency in seconds. Broken down by verb, and host.",
+		[]string{verbLabel, hostLabel},
+		buckets,
+	)
+}
+
+func newRequestSize() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "rest_client_request_size_bytes",
 			Help: "Request size in bytes. Broken down by verb and host.",
@@ -92,8 +95,10 @@ var (
 		},
 		[]string{verbLabel, hostLabel},
 	)
+}
 
-	responseSize = prometheus.NewHistogramVec(
+func newResponseSize() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "rest_client_response_size_bytes",
 			Help: "Response size in bytes. Broken down by verb and host.",
@@ -105,21 +110,36 @@ var (
 		},
 		[]string{verbLabel, hostLabel},
 	)
+}
 
-	rateLimiterLatency = restClientDurationHistogram(
-		"rest_client_rate_limiter_duration_seconds",
-		"Client side rate limiter latency in seconds. Broken down by verb, and host.",
-		[]string{verbLabel, hostLabel},
-		nil,
-	)
-
-	requestRetry = prometheus.NewCounterVec(
+func newRequestRetry() *prometheus.CounterVec {
+	return prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "rest_client_request_retries_total",
 			Help: "Number of request retries, partitioned by status code, verb, and host.",
 		},
 		[]string{"code", verbLabel, hostLabel},
 	)
+}
+
+var (
+	// requestResult is registered by default. The other client metrics are
+	// opt-in: adapters start with a nil collector and RegisterRESTClientMetrics*
+	// stores the HistogramVec / CounterVec.
+	requestResult = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "rest_client_requests_total",
+			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
+		},
+		[]string{"code", "method", hostLabel},
+	)
+
+	requestLatency     = &latencyAdapter{}
+	resolverLatency    = &resolverLatencyAdapter{}
+	requestSize        = &sizeAdapter{}
+	responseSize       = &sizeAdapter{}
+	rateLimiterLatency = &latencyAdapter{}
+	requestRetry       = &retryAdapter{}
 )
 
 // RESTClientMetric identifies an opt-in client-go REST client metric.
@@ -141,22 +161,6 @@ const (
 	MetricRequestRetry
 )
 
-// Per-metric gates.
-var (
-	requestLatencyEnabled     atomic.Bool
-	resolverLatencyEnabled    atomic.Bool
-	requestSizeEnabled        atomic.Bool
-	responseSizeEnabled       atomic.Bool
-	rateLimiterLatencyEnabled atomic.Bool
-	requestRetryEnabled       atomic.Bool
-	requestLatencyOnce        sync.Once
-	resolverLatencyOnce       sync.Once
-	requestSizeOnce           sync.Once
-	responseSizeOnce          sync.Once
-	rateLimiterLatencyOnce    sync.Once
-	requestRetryOnce          sync.Once
-)
-
 func init() {
 	registerClientMetrics()
 }
@@ -168,22 +172,13 @@ func registerClientMetrics() {
 
 	// register the metrics with client-go
 	clientmetrics.Register(clientmetrics.RegisterOpts{
-		RequestResult: &resultAdapter{metric: requestResult},
-		RequestLatency: &latencyAdapter{
-			metric:  func() *prometheus.HistogramVec { return requestLatency },
-			enabled: &requestLatencyEnabled,
-		},
-		ResolverLatency: &resolverLatencyAdapter{
-			metric:  func() *prometheus.HistogramVec { return resolverLatency },
-			enabled: &resolverLatencyEnabled,
-		},
-		RequestSize:  &sizeAdapter{metric: requestSize, enabled: &requestSizeEnabled},
-		ResponseSize: &sizeAdapter{metric: responseSize, enabled: &responseSizeEnabled},
-		RateLimiterLatency: &latencyAdapter{
-			metric:  func() *prometheus.HistogramVec { return rateLimiterLatency },
-			enabled: &rateLimiterLatencyEnabled,
-		},
-		RequestRetry: &retryAdapter{metric: requestRetry, enabled: &requestRetryEnabled},
+		RequestResult:      &resultAdapter{metric: requestResult},
+		RequestLatency:     requestLatency,
+		ResolverLatency:    resolverLatency,
+		RequestSize:        requestSize,
+		ResponseSize:       responseSize,
+		RateLimiterLatency: rateLimiterLatency,
+		RequestRetry:       requestRetry,
 	})
 }
 
@@ -196,38 +191,10 @@ type RESTClientMetricsOptions struct {
 	// If nil or empty, the Kubernetes-default buckets are kept (starting at 5ms).
 	// Native histogram settings are not changed.
 	//
-	// Options are applied on the first RegisterRESTClientMetrics /
-	// RegisterRESTClientMetricsWithOptions call. Later calls ignore a different
-	// DurationBuckets value so already-registered collectors are not replaced.
+	// DurationBuckets is read when each duration metric is first registered.
+	// Later calls for the same metric are ignored so already-registered collectors
+	// are not replaced.
 	DurationBuckets []float64
-}
-
-var applyDurationBucketsOnce sync.Once
-
-func applyDurationBuckets(buckets []float64) {
-	applyDurationBucketsOnce.Do(func() {
-		if len(buckets) == 0 {
-			return
-		}
-		requestLatency = restClientDurationHistogram(
-			"rest_client_request_duration_seconds",
-			"Request latency in seconds. Broken down by verb and host.",
-			[]string{verbLabel, hostLabel},
-			buckets,
-		)
-		resolverLatency = restClientDurationHistogram(
-			"rest_client_dns_resolution_duration_seconds",
-			"DNS resolver latency in seconds. Broken down by host.",
-			[]string{hostLabel},
-			buckets,
-		)
-		rateLimiterLatency = restClientDurationHistogram(
-			"rest_client_rate_limiter_duration_seconds",
-			"Client side rate limiter latency in seconds. Broken down by verb, and host.",
-			[]string{verbLabel, hostLabel},
-			buckets,
-		)
-	})
 }
 
 // RegisterRESTClientMetrics enables the given client metrics using default buckets
@@ -239,39 +206,26 @@ func RegisterRESTClientMetrics(metrics ...RESTClientMetric) {
 // RegisterRESTClientMetricsWithOptions enables the given client metrics.
 // See RESTClientMetricsOptions for knobs such as custom duration buckets.
 func RegisterRESTClientMetricsWithOptions(opts RESTClientMetricsOptions, metrics ...RESTClientMetric) {
-	applyDurationBuckets(opts.DurationBuckets)
 	for _, m := range metrics {
 		switch m {
 		case MetricRequestLatency:
-			requestLatencyOnce.Do(func() {
-				requestLatencyEnabled.Store(true)
-				Registry.MustRegister(requestLatency)
+			requestLatency.enable(func() *prometheus.HistogramVec {
+				return newRequestLatency(opts.DurationBuckets)
 			})
 		case MetricDNSResolutionLatency:
-			resolverLatencyOnce.Do(func() {
-				resolverLatencyEnabled.Store(true)
-				Registry.MustRegister(resolverLatency)
+			resolverLatency.enable(func() *prometheus.HistogramVec {
+				return newResolverLatency(opts.DurationBuckets)
 			})
 		case MetricRequestSize:
-			requestSizeOnce.Do(func() {
-				requestSizeEnabled.Store(true)
-				Registry.MustRegister(requestSize)
-			})
+			requestSize.enable(newRequestSize)
 		case MetricResponseSize:
-			responseSizeOnce.Do(func() {
-				responseSizeEnabled.Store(true)
-				Registry.MustRegister(responseSize)
-			})
+			responseSize.enable(newResponseSize)
 		case MetricRateLimiterLatency:
-			rateLimiterLatencyOnce.Do(func() {
-				rateLimiterLatencyEnabled.Store(true)
-				Registry.MustRegister(rateLimiterLatency)
+			rateLimiterLatency.enable(func() *prometheus.HistogramVec {
+				return newRateLimiterLatency(opts.DurationBuckets)
 			})
 		case MetricRequestRetry:
-			requestRetryOnce.Do(func() {
-				requestRetryEnabled.Store(true)
-				Registry.MustRegister(requestRetry)
-			})
+			requestRetry.enable(newRequestRetry)
 		default:
 			// unknown metric, ignore
 		}
@@ -295,49 +249,85 @@ func (r *resultAdapter) Increment(_ context.Context, code, method, host string) 
 }
 
 type latencyAdapter struct {
-	metric  func() *prometheus.HistogramVec
-	enabled *atomic.Bool
+	once   sync.Once
+	metric atomic.Pointer[prometheus.HistogramVec]
+}
+
+func (l *latencyAdapter) enable(newMetric func() *prometheus.HistogramVec) {
+	l.once.Do(func() {
+		h := newMetric()
+		l.metric.Store(h)
+		Registry.MustRegister(h)
+	})
 }
 
 func (l *latencyAdapter) Observe(_ context.Context, verb string, u url.URL, duration time.Duration) {
-	if !l.enabled.Load() {
+	h := l.metric.Load()
+	if h == nil {
 		return
 	}
-	l.metric().WithLabelValues(verb, u.Host).Observe(duration.Seconds())
+	h.WithLabelValues(verb, u.Host).Observe(duration.Seconds())
 }
 
 type resolverLatencyAdapter struct {
-	metric  func() *prometheus.HistogramVec
-	enabled *atomic.Bool
+	once   sync.Once
+	metric atomic.Pointer[prometheus.HistogramVec]
+}
+
+func (r *resolverLatencyAdapter) enable(newMetric func() *prometheus.HistogramVec) {
+	r.once.Do(func() {
+		h := newMetric()
+		r.metric.Store(h)
+		Registry.MustRegister(h)
+	})
 }
 
 func (r *resolverLatencyAdapter) Observe(_ context.Context, host string, duration time.Duration) {
-	if !r.enabled.Load() {
+	h := r.metric.Load()
+	if h == nil {
 		return
 	}
-	r.metric().WithLabelValues(host).Observe(duration.Seconds())
+	h.WithLabelValues(host).Observe(duration.Seconds())
 }
 
 type sizeAdapter struct {
-	metric  *prometheus.HistogramVec
-	enabled *atomic.Bool
+	once   sync.Once
+	metric atomic.Pointer[prometheus.HistogramVec]
+}
+
+func (r *sizeAdapter) enable(newMetric func() *prometheus.HistogramVec) {
+	r.once.Do(func() {
+		h := newMetric()
+		r.metric.Store(h)
+		Registry.MustRegister(h)
+	})
 }
 
 func (r *sizeAdapter) Observe(_ context.Context, verb string, host string, size float64) {
-	if !r.enabled.Load() {
+	h := r.metric.Load()
+	if h == nil {
 		return
 	}
-	r.metric.WithLabelValues(verb, host).Observe(size)
+	h.WithLabelValues(verb, host).Observe(size)
 }
 
 type retryAdapter struct {
-	metric  *prometheus.CounterVec
-	enabled *atomic.Bool
+	once   sync.Once
+	metric atomic.Pointer[prometheus.CounterVec]
+}
+
+func (r *retryAdapter) enable(newMetric func() *prometheus.CounterVec) {
+	r.once.Do(func() {
+		c := newMetric()
+		r.metric.Store(c)
+		Registry.MustRegister(c)
+	})
 }
 
 func (r *retryAdapter) IncrementRetry(_ context.Context, code, verb, host string) {
-	if !r.enabled.Load() {
+	c := r.metric.Load()
+	if c == nil {
 		return
 	}
-	r.metric.WithLabelValues(code, verb, host).Inc()
+	c.WithLabelValues(code, verb, host).Inc()
 }

--- a/pkg/metrics/client_go_adapter_test.go
+++ b/pkg/metrics/client_go_adapter_test.go
@@ -24,6 +24,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	clientmetrics "k8s.io/client-go/tools/metrics"
 )
 
@@ -86,5 +88,113 @@ var _ = Describe("RESTClientMetrics", func() {
 		for _, name := range optInMetricNames {
 			Expect(names).To(HaveKey(name), "metric %s should be found after calling RegisterRESTClientMetrics", name)
 		}
+
+		Expect(histogramBounds(namesToFamily("rest_client_request_duration_seconds"))).To(Equal(defaultRESTClientDurationBuckets))
+		Expect(histogramBounds(namesToFamily("rest_client_rate_limiter_duration_seconds"))).To(Equal(defaultRESTClientDurationBuckets))
+		Expect(histogramBounds(namesToFamily("rest_client_dns_resolution_duration_seconds"))).To(Equal(defaultRESTClientDurationBuckets))
 	})
 })
+
+func namesToFamily(name string) *dto.MetricFamily {
+	mfs, err := Registry.Gather()
+	Expect(err).NotTo(HaveOccurred())
+	for _, mf := range mfs {
+		if mf.GetName() == name {
+			return mf
+		}
+	}
+	Fail("metric family " + name + " not found")
+	return nil
+}
+
+func histogramBounds(mf *dto.MetricFamily) []float64 {
+	Expect(mf.GetMetric()).NotTo(BeEmpty())
+	buckets := mf.GetMetric()[0].GetHistogram().GetBucket()
+	bounds := make([]float64, 0, len(buckets))
+	for _, b := range buckets {
+		bounds = append(bounds, b.GetUpperBound())
+	}
+	return bounds
+}
+
+func TestRESTClientDurationHistogramBuckets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("default buckets start at 5ms", func(t *testing.T) {
+		t.Parallel()
+		h := restClientDurationHistogram(
+			"test_rest_client_request_duration_seconds",
+			"test",
+			[]string{verbLabel, hostLabel},
+			nil,
+		)
+		bounds := gatherHistogramBounds(t, h, "GET", "example.com", 0.001)
+		if len(bounds) != len(defaultRESTClientDurationBuckets) {
+			t.Fatalf("got %d buckets, want %d: %v", len(bounds), len(defaultRESTClientDurationBuckets), bounds)
+		}
+		for i := range defaultRESTClientDurationBuckets {
+			if bounds[i] != defaultRESTClientDurationBuckets[i] {
+				t.Fatalf("bucket[%d]=%v, want %v", i, bounds[i], defaultRESTClientDurationBuckets[i])
+			}
+		}
+	})
+
+	t.Run("custom buckets capture sub-5ms observations", func(t *testing.T) {
+		t.Parallel()
+		custom := []float64{0.001, 0.0025, 0.005, 0.025, 0.1}
+		h := restClientDurationHistogram(
+			"test_rest_client_request_duration_seconds_custom",
+			"test",
+			[]string{verbLabel, hostLabel},
+			custom,
+		)
+		reg := prometheus.NewPedanticRegistry()
+		if err := reg.Register(h); err != nil {
+			t.Fatal(err)
+		}
+		h.WithLabelValues("PATCH", "example.com").Observe(0.001)
+
+		mfs, err := reg.Gather()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(mfs) != 1 || len(mfs[0].GetMetric()) != 1 {
+			t.Fatalf("expected one metric family with one series, got %#v", mfs)
+		}
+		buckets := mfs[0].GetMetric()[0].GetHistogram().GetBucket()
+		if len(buckets) != len(custom) {
+			t.Fatalf("got %d buckets, want %d", len(buckets), len(custom))
+		}
+		for i, want := range custom {
+			if buckets[i].GetUpperBound() != want {
+				t.Fatalf("bucket[%d] le=%v, want %v", i, buckets[i].GetUpperBound(), want)
+			}
+		}
+		// 1ms observation should land in the 0.001s bucket, not collapse into 5ms.
+		if buckets[0].GetCumulativeCount() != 1 {
+			t.Fatalf("le=0.001 count=%d, want 1", buckets[0].GetCumulativeCount())
+		}
+	})
+}
+
+func gatherHistogramBounds(t *testing.T, h *prometheus.HistogramVec, verb, host string, observe float64) []float64 {
+	t.Helper()
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(h); err != nil {
+		t.Fatal(err)
+	}
+	h.WithLabelValues(verb, host).Observe(observe)
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mfs) != 1 || len(mfs[0].GetMetric()) != 1 {
+		t.Fatalf("expected one metric family with one series, got %#v", mfs)
+	}
+	buckets := mfs[0].GetMetric()[0].GetHistogram().GetBucket()
+	bounds := make([]float64, 0, len(buckets))
+	for _, b := range buckets {
+		bounds = append(bounds, b.GetUpperBound())
+	}
+	return bounds
+}

--- a/pkg/metrics/client_go_adapter_test.go
+++ b/pkg/metrics/client_go_adapter_test.go
@@ -19,6 +19,7 @@ package metrics
 import (
 	"context"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -117,6 +118,79 @@ func histogramBounds(mf *dto.MetricFamily) []float64 {
 	return bounds
 }
 
+func TestLatencyAdapterObserveNoopsWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	var a latencyAdapter
+	a.Observe(context.Background(), "GET", url.URL{Host: "example.com"}, time.Millisecond)
+}
+
+func TestLatencyAdapterObservesAfterStore(t *testing.T) {
+	t.Parallel()
+
+	custom := []float64{0.001, 0.0025, 0.005, 0.025, 0.1}
+	h := restClientDurationHistogram(
+		"test_latency_adapter_observe",
+		"test",
+		[]string{verbLabel, hostLabel},
+		custom,
+	)
+
+	var a latencyAdapter
+	a.metric.Store(h)
+	a.Observe(context.Background(), "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
+
+	reg := prometheus.NewPedanticRegistry()
+	if err := reg.Register(h); err != nil {
+		t.Fatal(err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mfs) != 1 || len(mfs[0].GetMetric()) != 1 {
+		t.Fatalf("expected one metric family with one series, got %#v", mfs)
+	}
+	buckets := mfs[0].GetMetric()[0].GetHistogram().GetBucket()
+	if len(buckets) != len(custom) {
+		t.Fatalf("got %d buckets, want %d", len(buckets), len(custom))
+	}
+	// 1ms observation should land in the 0.001s bucket, not collapse into 5ms.
+	if buckets[0].GetCumulativeCount() != 1 {
+		t.Fatalf("le=0.001 count=%d, want 1", buckets[0].GetCumulativeCount())
+	}
+}
+
+func TestLatencyAdapterConcurrentObserveAndStore(t *testing.T) {
+	t.Parallel()
+
+	var a latencyAdapter
+	h := restClientDurationHistogram(
+		"test_latency_adapter_race",
+		"test",
+		[]string{verbLabel, hostLabel},
+		[]float64{0.001, 0.005, 0.025},
+	)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 1000; j++ {
+				a.Observe(context.Background(), "GET", url.URL{Host: "example.com"}, time.Millisecond)
+			}
+		}()
+	}
+
+	close(start)
+	a.metric.Store(h)
+	a.Observe(context.Background(), "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
+	wg.Wait()
+}
+
 func TestRESTClientDurationHistogramBuckets(t *testing.T) {
 	t.Parallel()
 
@@ -173,6 +247,18 @@ func TestRESTClientDurationHistogramBuckets(t *testing.T) {
 		// 1ms observation should land in the 0.001s bucket, not collapse into 5ms.
 		if buckets[0].GetCumulativeCount() != 1 {
 			t.Fatalf("le=0.001 count=%d, want 1", buckets[0].GetCumulativeCount())
+		}
+	})
+
+	t.Run("request latency constructor uses the same name and default buckets", func(t *testing.T) {
+		t.Parallel()
+		h := newRequestLatency(nil)
+		if got := h.WithLabelValues("GET", "example.com"); got == nil {
+			t.Fatal("expected a labeled histogram")
+		}
+		bounds := gatherHistogramBounds(t, h, "GET", "example.com", 0.001)
+		if len(bounds) != len(defaultRESTClientDurationBuckets) {
+			t.Fatalf("got %d buckets, want %d: %v", len(bounds), len(defaultRESTClientDurationBuckets), bounds)
 		}
 	})
 }

--- a/pkg/metrics/client_go_adapter_test.go
+++ b/pkg/metrics/client_go_adapter_test.go
@@ -122,7 +122,7 @@ func TestLatencyAdapterObserveNoopsWhenUnset(t *testing.T) {
 	t.Parallel()
 
 	var a latencyAdapter
-	a.Observe(context.Background(), "GET", url.URL{Host: "example.com"}, time.Millisecond)
+	a.Observe(t.Context(), "GET", url.URL{Host: "example.com"}, time.Millisecond)
 }
 
 func TestLatencyAdapterObservesAfterStore(t *testing.T) {
@@ -138,7 +138,7 @@ func TestLatencyAdapterObservesAfterStore(t *testing.T) {
 
 	var a latencyAdapter
 	a.metric.Store(h)
-	a.Observe(context.Background(), "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
+	a.Observe(t.Context(), "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
 
 	reg := prometheus.NewPedanticRegistry()
 	if err := reg.Register(h); err != nil {
@@ -172,22 +172,21 @@ func TestLatencyAdapterConcurrentObserveAndStore(t *testing.T) {
 		[]float64{0.001, 0.005, 0.025},
 	)
 
+	ctx := t.Context()
 	start := make(chan struct{})
 	var wg sync.WaitGroup
-	for i := 0; i < 8; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 8 {
+		wg.Go(func() {
 			<-start
-			for j := 0; j < 1000; j++ {
-				a.Observe(context.Background(), "GET", url.URL{Host: "example.com"}, time.Millisecond)
+			for range 1000 {
+				a.Observe(ctx, "GET", url.URL{Host: "example.com"}, time.Millisecond)
 			}
-		}()
+		})
 	}
 
 	close(start)
 	a.metric.Store(h)
-	a.Observe(context.Background(), "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
+	a.Observe(ctx, "PATCH", url.URL{Host: "example.com"}, time.Millisecond)
 	wg.Wait()
 }
 


### PR DESCRIPTION
<!-- ✨ minor / compatible feature -->

## What

Make classic histogram buckets for the opt-in REST client duration metrics overridable at registration time.

`RegisterRESTClientMetrics` is unchanged and still uses the Kubernetes-default buckets (starting at 5ms). Callers that scrape only classic buckets and need sub-5ms resolution can do:

```go
metrics.RegisterRESTClientMetricsWithOptions(metrics.RESTClientMetricsOptions{
    DurationBuckets: []float64{0.001, 0.0025, 0.005, 0.025, 0.1, 0.25, 0.5, 1, 2, 4, 8, 15, 30, 60},
}, metrics.MetricRequestLatency, metrics.MetricRateLimiterLatency)
```

This applies to:

- `rest_client_request_duration_seconds`
- `rest_client_dns_resolution_duration_seconds`
- `rest_client_rate_limiter_duration_seconds`

Native histogram settings (`NativeHistogramBucketFactor` etc.) are not changed. Size histograms are not changed. The first `RegisterRESTClientMetrics*` call wins so already-registered collectors are not replaced.

## Why

Follow-up to #3510 / #3559. Fast controller hot-path PATCH/PUT latencies often sit in the 1–15ms range; with the default 5ms / 25ms buckets, p50/p90 on classic histograms is mostly quantization artifact. Changing the defaults would diverge from Kubernetes core, so this is opt-in only.

## How to verify

```bash
go test ./pkg/metrics/ -count=1
```

This PR was written in part with the assistance of generative AI.

Fixes #3559