### PR TITLE
:sparkles: Pass Managers Logger to Leader Elector via Context

### DIFF
--- a/pkg/manager/internal.go
+++ b/pkg/manager/internal.go
@@ -462,6 +462,10 @@ func (cm *controllerManager) Start(ctx context.Context) (err error) {
 		// Create a context that inherits all keys from the parent context
 		// but can be cancelled independently for leader election management
 		baseCtx := context.WithoutCancel(ctx)
+
+		// Inject the logger into the context for client-go contextual logging
+		baseCtx = logr.NewContext(baseCtx, cm.logger.WithName("leaderelection"))
+
 		leaderCtx, cancel := context.WithCancel(baseCtx)
 		cm.leaderElectionCancel = cancel
 		if leaderElector != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Passes the manager logger with name `leaderelection` via context to `leaderElector.Run()`, ensuring contextual logging in `client-go` uses the configured manager logger instead of falling back to the global logger.

**Which issue(s) this PR fixes**:
Fixes #2656

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
