### PR TITLE
:sparkles: Fakeclient: Add WithGlobalResourceVersionCounter

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -24,6 +24,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	/*
@@ -130,6 +131,7 @@ type ClientBuilder struct {
 	interceptorFuncs      *interceptor.Funcs
 	typeConverters        []managedfields.TypeConverter
 	returnManagedFields   bool
+	globalRVCounter       bool
 	isBuilt               bool
 
 	// indexes maps each GroupVersionKind (GVK) to the indexes registered for that GVK.
@@ -176,6 +178,15 @@ func (f *ClientBuilder) WithRuntimeObjects(initRuntimeObjs ...runtime.Object) *C
 // tracker.
 func (f *ClientBuilder) WithObjectTracker(ot testing.ObjectTracker) *ClientBuilder {
 	f.objectTracker = ot
+	return f
+}
+
+// WithGlobalResourceVersionCounter makes the client use a global counter for resourceVersions
+// rather than tracking them per object, mimicking what the apiserver does.
+//
+// Disabled by default.
+func (f *ClientBuilder) WithGlobalResourceVersionCounter() *ClientBuilder {
+	f.globalRVCounter = true
 	return f
 }
 
@@ -306,6 +317,9 @@ func (f *ClientBuilder) Build() client.WithWatch {
 		scheme:                        f.scheme,
 		withStatusSubresource:         withStatusSubResource,
 		usesFieldManagedObjectTracker: usesFieldManagedObjectTracker,
+	}
+	if f.globalRVCounter {
+		tracker.resourceVersionCounter = &atomic.Uint64{}
 	}
 
 	for _, obj := range f.initObject {
@@ -948,7 +962,11 @@ func (c *fakeClient) patch(obj client.Object, patch client.Patch, opts ...client
 		if isApplyCreate {
 			// Overwrite it unconditionally, this matches the apiserver behavior
 			// which allows to set it on create, but will then ignore it.
-			obj.SetResourceVersion("1")
+			if c.tracker.resourceVersionCounter != nil {
+				obj.SetResourceVersion(c.tracker.nextResourceVersion())
+			} else {
+				obj.SetResourceVersion("1")
+			}
 		} else {
 			// SSA deletionTimestamp updates are silently ignored
 			obj.SetDeletionTimestamp(oldAccessor.GetDeletionTimestamp())

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -1636,6 +1636,49 @@ var _ = Describe("Fake client", func() {
 		Expect(retrieved).To(Equal(reference))
 	})
 
+	It("should use a per-object ResourceVersion counter by default", func(ctx SpecContext) {
+		cl := NewClientBuilder().
+			WithObjects(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: "ns1"}}).
+			Build()
+
+		By("Getting the deployment that was added to the tracker")
+		obj := &appsv1.Deployment{}
+		Expect(cl.Get(ctx, types.NamespacedName{Name: "test-deployment", Namespace: "ns1"}, obj)).To(Succeed())
+		Expect(obj.ResourceVersion).To(Equal(trackerAddResourceVersion))
+
+		By("Creating a configMap")
+		newCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns2"}}
+		Expect(cl.Create(ctx, newCM)).To(Succeed())
+		Expect(newCM.ResourceVersion).To(Equal("1"))
+
+		By("Updating the deployment")
+		obj.Labels = map[string]string{"test-label": "label-value"}
+		Expect(cl.Update(ctx, obj)).To(Succeed())
+		Expect(obj.ResourceVersion).To(Equal("1000"))
+	})
+
+	It("should use a single global ResourceVersion counter when WithGlobalResourceVersionCounter is used", func(ctx SpecContext) {
+		cl := NewClientBuilder().
+			WithGlobalResourceVersionCounter().
+			WithObjects(&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "test-deployment", Namespace: "ns1"}}).
+			Build()
+
+		By("Getting the deployment that was added to the tracker")
+		obj := &appsv1.Deployment{}
+		Expect(cl.Get(ctx, types.NamespacedName{Name: "test-deployment", Namespace: "ns1"}, obj)).To(Succeed())
+		Expect(obj.ResourceVersion).To(Equal("1"))
+
+		By("Creating a configMap")
+		newCM := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "test-cm", Namespace: "ns2"}}
+		Expect(cl.Create(ctx, newCM)).To(Succeed())
+		Expect(newCM.ResourceVersion).To(Equal("2"))
+
+		By("Updating the deployment")
+		obj.Labels = map[string]string{"test-label": "label-value"}
+		Expect(cl.Update(ctx, obj)).To(Succeed())
+		Expect(obj.ResourceVersion).To(Equal("3"))
+	})
+
 	It("should be able to build with given tracker and get resource", func(ctx SpecContext) {
 		clientSet := fake.NewClientset(dep)
 		cl := NewClientBuilder().WithRuntimeObjects(dep2).WithObjectTracker(clientSet.Tracker()).Build()

--- a/pkg/client/fake/versioned_tracker.go
+++ b/pkg/client/fake/versioned_tracker.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"strconv"
+	"sync/atomic"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -44,6 +45,12 @@ type versionedTracker struct {
 	scheme                        *runtime.Scheme
 	withStatusSubresource         sets.Set[schema.GroupVersionKind]
 	usesFieldManagedObjectTracker bool
+
+	resourceVersionCounter *atomic.Uint64
+}
+
+func (t versionedTracker) nextResourceVersion() string {
+	return strconv.FormatUint(t.resourceVersionCounter.Add(1), 10)
 }
 
 func (t versionedTracker) Add(obj runtime.Object) error {
@@ -66,11 +73,15 @@ func (t versionedTracker) Add(obj runtime.Object) error {
 			return fmt.Errorf("refusing to create obj %s with metadata.deletionTimestamp but no finalizers", accessor.GetName())
 		}
 		if accessor.GetResourceVersion() == "" {
-			// We use a "magic" value of 999 here because this field
-			// is parsed as uint and and 0 is already used in Update.
-			// As we can't go lower, go very high instead so this can
-			// be recognized
-			accessor.SetResourceVersion(trackerAddResourceVersion)
+			if t.resourceVersionCounter != nil {
+				accessor.SetResourceVersion(t.nextResourceVersion())
+			} else {
+				// We use a "magic" value of 999 here because this field
+				// is parsed as uint and and 0 is already used in Update.
+				// As we can't go lower, go very high instead so this can
+				// be recognized
+				accessor.SetResourceVersion(trackerAddResourceVersion)
+			}
 		}
 
 		obj, err = convertFromUnstructuredOrPartialObjectMetaIfNecessary(t.scheme, obj)
@@ -122,7 +133,11 @@ func (t versionedTracker) Create(gvr schema.GroupVersionResource, obj runtime.Ob
 	if accessor.GetResourceVersion() != "" {
 		return apierrors.NewBadRequest("resourceVersion can not be set for Create requests")
 	}
-	accessor.SetResourceVersion("1")
+	if t.resourceVersionCounter != nil {
+		accessor.SetResourceVersion(t.nextResourceVersion())
+	} else {
+		accessor.SetResourceVersion("1")
+	}
 	obj, err = convertFromUnstructuredOrPartialObjectMetaIfNecessary(t.scheme, obj)
 	if err != nil {
 		return err
@@ -298,12 +313,16 @@ func (t versionedTracker) updateObject(
 	if oldAccessor.GetResourceVersion() == "" {
 		oldAccessor.SetResourceVersion("0")
 	}
-	intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
-	if err != nil {
-		return nil, false, fmt.Errorf("can not convert resourceVersion %q to int: %w", oldAccessor.GetResourceVersion(), err)
+	if t.resourceVersionCounter != nil {
+		accessor.SetResourceVersion(t.nextResourceVersion())
+	} else {
+		intResourceVersion, err := strconv.ParseUint(oldAccessor.GetResourceVersion(), 10, 64)
+		if err != nil {
+			return nil, false, fmt.Errorf("can not convert resourceVersion %q to int: %w", oldAccessor.GetResourceVersion(), err)
+		}
+		intResourceVersion++
+		accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
 	}
-	intResourceVersion++
-	accessor.SetResourceVersion(strconv.FormatUint(intResourceVersion, 10))
 
 	if !deleting && !deletionTimestampEqual(accessor, oldAccessor) {
 		return nil, false, fmt.Errorf("error: Unable to edit %s: metadata.deletionTimestamp field is immutable", accessor.GetName())


### PR DESCRIPTION
WithGlobalResourceVersionCounter maintains a cross-object RV counter similar to what the APIServer does as opposed to maintain it per object. The default of maintaining it per object remains unchanged.

/assign @sbueringer 

<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->

<!-- What does this do, and why do we need it? -->
