### PR TITLE
:bug: fakeclient: fix AddIndex panic when wrapped with an interceptor

### DIFF
--- a/pkg/client/fake/client.go
+++ b/pkg/client/fake/client.go
@@ -1746,12 +1746,13 @@ func applyScale(obj client.Object, scale *autoscalingv1.Scale) error {
 	return nil
 }
 
-// AddIndex adds an index to a fake client. It will panic if used with a client that is not a fake client.
+// AddIndex adds an index to a fake client. It will panic if used with a client that is not a fake client,
+// or a wrapper around one, such as the client returned by ClientBuilder.WithInterceptorFuncs.
 // It will error if there is already an index for given object with the same name as field.
 //
 // It can be used to test code that adds indexes to the cache at runtime.
 func AddIndex(c client.Client, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
-	fakeClient, isFakeClient := c.(*fakeClient)
+	fakeClient, isFakeClient := unwrapFakeClient(c)
 	if !isFakeClient {
 		panic("AddIndex can only be used with a fake client")
 	}
@@ -1778,6 +1779,21 @@ func AddIndex(c client.Client, obj runtime.Object, field string, extractValue cl
 	fakeClient.indexes[gvk][field] = extractValue
 
 	return nil
+}
+
+// unwrapFakeClient returns the *fakeClient backing c, unwrapping any clients that wrap it, such as the
+// interceptor client returned by ClientBuilder.WithInterceptorFuncs.
+func unwrapFakeClient(c client.Client) (*fakeClient, bool) {
+	for {
+		if fc, ok := c.(*fakeClient); ok {
+			return fc, true
+		}
+		unwrapper, ok := c.(interface{ Unwrap() client.WithWatch })
+		if !ok {
+			return nil, false
+		}
+		c = unwrapper.Unwrap()
+	}
 }
 
 func (c *fakeClient) addToSchemeIfUnknownAndUnstructuredOrPartial(obj runtime.Object) error {

--- a/pkg/client/fake/client_test.go
+++ b/pkg/client/fake/client_test.go
@@ -3858,6 +3858,15 @@ var _ = Describe("Fake client builder", func() {
 		Expect(called).To(BeTrue())
 	})
 
+	It("supports AddIndex when the client is wrapped with an interceptor", func(ctx SpecContext) {
+		cli := NewClientBuilder().WithInterceptorFuncs(interceptor.Funcs{}).Build()
+
+		err := AddIndex(cli, &appsv1.Deployment{}, "metadata.name", func(obj client.Object) []string {
+			return []string{obj.GetName()}
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should panic when calling build more than once", func() {
 		cb := NewClientBuilder()
 		anotherCb := cb

--- a/pkg/client/interceptor/intercept.go
+++ b/pkg/client/interceptor/intercept.go
@@ -60,6 +60,13 @@ type interceptor struct {
 
 var _ client.WithWatch = &interceptor{}
 
+// Unwrap returns the client that is wrapped by this interceptor. This is used by consumers that need to
+// access functionality of the wrapped client that is not part of the client.WithWatch interface, such as
+// sigs.k8s.io/controller-runtime/pkg/client/fake.AddIndex.
+func (c interceptor) Unwrap() client.WithWatch {
+	return c.client
+}
+
 func (c interceptor) GroupVersionKindFor(obj runtime.Object) (schema.GroupVersionKind, error) {
 	return c.client.GroupVersionKindFor(obj)
 }


### PR DESCRIPTION
:bug: fake: fix AddIndex panic when client is wrapped with an interceptor

<!-- What does this do, and why do we need it? -->
`fake.AddIndex` type-asserted the passed `client.Client` directly to `*fakeClient`.
When a fake client is built with `ClientBuilder.WithInterceptorFuncs(...)`, `Build()`
wraps the `*fakeClient` in an `interceptor` value, so the assertion always failed and
`AddIndex` panicked with "AddIndex can only be used with a fake client", even though a
real fake client was underneath.

This adds an `Unwrap() client.WithWatch` method to the `interceptor` type and has
`AddIndex` unwrap through it (and any future wrapper exposing the same method) to find
the underlying `*fakeClient`, instead of relying on a single type assertion.

Report: https://github.com/kubernetes-sigs/controller-runtime/issues/3582

---
AI assistance: this change was drafted with Claude Code.

Fixes #3582

```release-note
:bug: fake: fix AddIndex panic when client is wrapped with an interceptor
```