### PR TITLE
📖 Update README to include v0.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Compatible k8s.io/*, client-go and minimum Go versions can be looked up in our [
 
 |          | k8s.io/*, client-go | minimum Go version |
 |----------|:-------------------:|:------------------:|
+| CR v0.25 |        v0.37        |        1.26        |
 | CR v0.24 |        v0.36        |        1.26        |
 | CR v0.23 |        v0.35        |        1.25        |
 | CR v0.22 |        v0.34        |        1.24        |


### PR DESCRIPTION
<!-- please add an icon to the title of this PR (see VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠ (:warning:, major), ✨ (:sparkles:, minor), 🐛 (:bug:, patch), 📖 (:book:, docs), or 🌱 (:seedling:, other) -->
When we updated to v0.37.0, I forgot to put the compatibility matrix with v0.37.0 and CR 0.25.0
<!-- What does this do, and why do we need it? -->
/assign @sbueringer 